### PR TITLE
docgen: parse properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "sherif": "^0.11.0",
     "simple-git-hooks": "^2.11.1",
     "size-limit": "^11.1.4",
-    "ts-morph": "^23.0.0",
+    "ts-morph": "^24.0.0",
     "tsx": "^4.17.0",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: ^11.1.4
         version: 11.1.4(patch_hash=imbqp73nbgdxtxyjg4sp7amlam)
       ts-morph:
-        specifier: ^23.0.0
-        version: 23.0.0
+        specifier: ^24.0.0
+        version: 24.0.0
       tsx:
         specifier: ^4.17.0
         version: 4.17.0
@@ -1696,8 +1696,8 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@ts-morph/common@0.24.0':
-    resolution: {integrity: sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==}
+  '@ts-morph/common@0.25.0':
+    resolution: {integrity: sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==}
 
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
@@ -2342,8 +2342,8 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  code-block-writer@13.0.2:
-    resolution: {integrity: sha512-XfXzAGiStXSmCIwrkdfvc7FS5Dtj8yelCtyOf2p2skCAfvLd6zu0rGzuS9NSCO3bq1JKpFZ7tbKdKlcd5occQA==}
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -2813,6 +2813,14 @@ packages:
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
+  fdir@6.4.2:
+    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -4686,6 +4694,10 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyglobby@0.2.9:
+    resolution: {integrity: sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@0.8.4:
     resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
     engines: {node: '>=14.0.0'}
@@ -4735,8 +4747,8 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  ts-morph@23.0.0:
-    resolution: {integrity: sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==}
+  ts-morph@24.0.0:
+    resolution: {integrity: sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==}
 
   tsconfck@3.1.1:
     resolution: {integrity: sha512-00eoI6WY57SvZEVjm13stEVE90VkEdJAFGgpFLTsZbJyW/LwFQ7uQxJHWpZ2hzSWgCPKc9AnBnNP+0X7o3hAmQ==}
@@ -6744,12 +6756,11 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@ts-morph/common@0.24.0':
+  '@ts-morph/common@0.25.0':
     dependencies:
-      fast-glob: 3.3.2
       minimatch: 9.0.5
-      mkdirp: 3.0.1
       path-browserify: 1.0.1
+      tinyglobby: 0.2.9
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -7565,7 +7576,7 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  code-block-writer@13.0.2: {}
+  code-block-writer@13.0.3: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -8139,6 +8150,10 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+
+  fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   figures@6.1.0:
     dependencies:
@@ -10415,6 +10430,11 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyglobby@0.2.9:
+    dependencies:
+      fdir: 6.4.2(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinypool@0.8.4: {}
 
   tinyspy@2.2.1: {}
@@ -10447,10 +10467,10 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-morph@23.0.0:
+  ts-morph@24.0.0:
     dependencies:
-      '@ts-morph/common': 0.24.0
-      code-block-writer: 13.0.2
+      '@ts-morph/common': 0.25.0
+      code-block-writer: 13.0.3
 
   tsconfck@3.1.1(typescript@5.5.4):
     optionalDependencies:

--- a/scripts/docgen/build.ts
+++ b/scripts/docgen/build.ts
@@ -113,7 +113,12 @@ for (const namespace of namespaces) {
       items.push({ text: `.${displayName}`, link })
       functions.push({ apiItem: member, description, link })
 
-      const content = renderApiFunction({ data, dataLookup, overloads })
+      const content = renderApiFunction({
+        apiItem: apiPackage,
+        data,
+        dataLookup,
+        overloads,
+      })
       fs.writeFileSync(`${dir}/${displayName}.md`, content)
     } else if (member.kind === model.ApiItemKind.Class) {
       if (displayName.endsWith('Error'))

--- a/scripts/docgen/utils/tsmorph.ts
+++ b/scripts/docgen/utils/tsmorph.ts
@@ -1,0 +1,7 @@
+import { Project, ScriptTarget } from 'ts-morph'
+
+export const project = new Project({
+  compilerOptions: {
+    target: ScriptTarget.ESNext,
+  },
+})

--- a/src/internal/Address/assert.ts
+++ b/src/internal/Address/assert.ts
@@ -52,7 +52,7 @@ export function Address_assert(
 }
 
 export declare namespace Address_assert {
-  interface Options {
+  type Options = {
     /**
      * Enables strict mode. Whether or not to compare the address against its checksum.
      *

--- a/src/internal/Address/from.ts
+++ b/src/internal/Address/from.ts
@@ -47,7 +47,7 @@ export function Address_from(
 }
 
 export declare namespace Address_from {
-  interface Options {
+  type Options = {
     /**
      * Whether to checksum the address.
      *

--- a/src/internal/Address/fromPublicKey.ts
+++ b/src/internal/Address/fromPublicKey.ts
@@ -34,7 +34,7 @@ export function Address_fromPublicKey(
 }
 
 export declare namespace Address_fromPublicKey {
-  interface Options {
+  type Options = {
     /**
      * Whether to checksum the address.
      *

--- a/src/internal/Address/validate.ts
+++ b/src/internal/Address/validate.ts
@@ -38,7 +38,7 @@ export function Address_validate(
 }
 
 export declare namespace Address_validate {
-  interface Options {
+  type Options = {
     /**
      * Enables strict mode. Whether or not to compare the address against its checksum.
      *

--- a/src/internal/AesGcm/getKey.ts
+++ b/src/internal/AesGcm/getKey.ts
@@ -48,7 +48,7 @@ export async function AesGcm_getKey(
 }
 
 export declare namespace AesGcm_getKey {
-  interface Options {
+  type Options = {
     /** The number of iterations to use. @default 900_000 */
     iterations?: number | undefined
     /** Password to derive key from. */

--- a/src/internal/Authorization/from.ts
+++ b/src/internal/Authorization/from.ts
@@ -64,9 +64,9 @@ export function Authorization_from<
 }
 
 export declare namespace Authorization_from {
-  interface Options<
+  type Options<
     signature extends Signature | undefined = Signature | undefined,
-  > {
+  > = {
     /** The {@link ox#Signature.Signature} to attach to the Authorization. */
     signature?: signature | Signature | undefined
   }

--- a/src/internal/ContractAddress/fromCreate.ts
+++ b/src/internal/ContractAddress/fromCreate.ts
@@ -37,7 +37,7 @@ export function ContractAddress_fromCreate(
 }
 
 export declare namespace ContractAddress_fromCreate {
-  interface Options {
+  type Options = {
     /** The address the contract was deployed from. */
     from: Address
     /** The nonce of the transaction which deployed the contract. */

--- a/src/internal/HdKey/fromSeed.ts
+++ b/src/internal/HdKey/fromSeed.ts
@@ -47,7 +47,7 @@ export function HdKey_fromSeed(
 }
 
 export declare namespace HdKey_fromSeed {
-  interface Options {
+  type Options = {
     /** The versions to use for the HD Key. */
     versions?: Versions | undefined
   }

--- a/src/internal/HdKey/path.ts
+++ b/src/internal/HdKey/path.ts
@@ -20,7 +20,7 @@ export function HdKey_path(options: HdKey_path.Options = {}): string {
 }
 
 export declare namespace HdKey_path {
-  interface Options {
+  type Options = {
     /**
      * The account.
      * @default 0

--- a/src/internal/Mnemonic/random.ts
+++ b/src/internal/Mnemonic/random.ts
@@ -25,7 +25,7 @@ export function Mnemonic_random(
 }
 
 export declare namespace Mnemonic_random {
-  interface Options {
+  type Options = {
     /**
      * The strength of the mnemonic to generate, in bits.
      * @default 128

--- a/src/internal/Mnemonic/toHdKey.ts
+++ b/src/internal/Mnemonic/toHdKey.ts
@@ -40,7 +40,7 @@ export function Mnemonic_toHdKey(
 }
 
 export declare namespace Mnemonic_toHdKey {
-  interface Options {
+  type Options = {
     /** An optional passphrase for additional protection to the seed. */
     passphrase?: string | undefined
   }

--- a/src/internal/P256/getPublicKey.ts
+++ b/src/internal/P256/getPublicKey.ts
@@ -33,7 +33,7 @@ export function P256_getPublicKey(
 }
 
 export declare namespace P256_getPublicKey {
-  interface Options {
+  type Options = {
     /**
      * Private key to compute the public key from.
      */

--- a/src/internal/P256/randomPrivateKey.ts
+++ b/src/internal/P256/randomPrivateKey.ts
@@ -28,7 +28,7 @@ export function P256_randomPrivateKey<as extends 'Hex' | 'Bytes' = 'Hex'>(
 }
 
 export declare namespace P256_randomPrivateKey {
-  interface Options<as extends 'Hex' | 'Bytes' = 'Hex'> {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
     /**
      * Format of the returned private key.
      * @default 'Hex'

--- a/src/internal/P256/recoverPublicKey.ts
+++ b/src/internal/P256/recoverPublicKey.ts
@@ -42,7 +42,7 @@ export function P256_recoverPublicKey(
 }
 
 export declare namespace P256_recoverPublicKey {
-  interface Options {
+  type Options = {
     /** Payload that was signed. */
     payload: Hex | Bytes
     /** Signature of the payload. */

--- a/src/internal/P256/sign.ts
+++ b/src/internal/P256/sign.ts
@@ -37,7 +37,7 @@ export function P256_sign(options: P256_sign.Options): Signature {
 }
 
 export declare namespace P256_sign {
-  interface Options {
+  type Options = {
     /** If set to `true`, the payload will be hashed (sha256) before being signed. */
     hash?: boolean | undefined
     /** Payload to sign. */

--- a/src/internal/P256/verify.ts
+++ b/src/internal/P256/verify.ts
@@ -40,7 +40,7 @@ export function P256_verify(options: P256_verify.Options): boolean {
 }
 
 export declare namespace P256_verify {
-  interface Options {
+  type Options = {
     /** If set to `true`, the payload will be hashed (sha256) before being verified. */
     hash?: boolean | undefined
     /** Payload that was signed. */

--- a/src/internal/PublicKey/assert.ts
+++ b/src/internal/PublicKey/assert.ts
@@ -65,7 +65,7 @@ export function PublicKey_assert(
 }
 
 export declare namespace PublicKey_assert {
-  interface Options {
+  type Options = {
     /** Whether or not the public key should be compressed. */
     compressed?: boolean
   }

--- a/src/internal/PublicKey/validate.ts
+++ b/src/internal/PublicKey/validate.ts
@@ -32,7 +32,7 @@ export function PublicKey_validate(
 }
 
 export declare namespace PublicKey_validate {
-  interface Options {
+  type Options = {
     /** Whether or not the public key should be compressed. */
     compressed?: boolean
   }

--- a/src/internal/Secp256k1/getPublicKey.ts
+++ b/src/internal/Secp256k1/getPublicKey.ts
@@ -31,7 +31,7 @@ export function Secp256k1_getPublicKey(
 }
 
 export declare namespace Secp256k1_getPublicKey {
-  interface Options {
+  type Options = {
     /**
      * Private key to compute the public key from.
      */

--- a/src/internal/Secp256k1/randomPrivateKey.ts
+++ b/src/internal/Secp256k1/randomPrivateKey.ts
@@ -28,7 +28,7 @@ export function Secp256k1_randomPrivateKey<as extends 'Hex' | 'Bytes' = 'Hex'>(
 }
 
 export declare namespace Secp256k1_randomPrivateKey {
-  interface Options<as extends 'Hex' | 'Bytes' = 'Hex'> {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
     /**
      * Format of the returned private key.
      * @default 'Hex'

--- a/src/internal/Secp256k1/recoverAddress.ts
+++ b/src/internal/Secp256k1/recoverAddress.ts
@@ -31,7 +31,7 @@ export function Secp256k1_recoverAddress(
 }
 
 export declare namespace Secp256k1_recoverAddress {
-  interface Options {
+  type Options = {
     /** Payload that was signed. */
     payload: Hex | Bytes
     /** Signature of the payload. */

--- a/src/internal/Secp256k1/recoverPublicKey.ts
+++ b/src/internal/Secp256k1/recoverPublicKey.ts
@@ -40,7 +40,7 @@ export function Secp256k1_recoverPublicKey(
 }
 
 export declare namespace Secp256k1_recoverPublicKey {
-  interface Options {
+  type Options = {
     /** Payload that was signed. */
     payload: Hex | Bytes
     /** Signature of the payload. */

--- a/src/internal/Secp256k1/sign.ts
+++ b/src/internal/Secp256k1/sign.ts
@@ -37,7 +37,7 @@ export function Secp256k1_sign(options: Secp256k1_sign.Options): Signature {
 }
 
 export declare namespace Secp256k1_sign {
-  interface Options {
+  type Options = {
     /** If set to `true`, the payload will be hashed (sha256) before being signed. */
     hash?: boolean | undefined
     /** Payload to sign. */


### PR DESCRIPTION
Uses `ts-morph` to expand parameter properties. Think we can make more robust, but it works for now – can revisit later.