### PR TITLE
Ensure address is checksummed when creating SIWE messages

### DIFF
--- a/.changeset/fuzzy-boats-explode.md
+++ b/.changeset/fuzzy-boats-explode.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Ensured addresses are checksummed when creating SIWE messages

--- a/src/core/Siwe.ts
+++ b/src/core/Siwe.ts
@@ -206,7 +206,7 @@ export function createMessage(value: Message): string {
   }
 
   // Construct message
-  const address = Address.from(value.address)
+  const address = Address.from(value.address, { checksum: true })
   const origin = (() => {
     if (scheme) return `${scheme}://${domain}`
     return domain

--- a/src/core/_test/Siwe.test.ts
+++ b/src/core/_test/Siwe.test.ts
@@ -243,6 +243,30 @@ describe('createMessage', () => {
     vi.useRealTimers()
   })
 
+  test('behavior: non-checksummed address', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(Date.UTC(2023, 1, 1)))
+
+    expect(
+      Siwe.createMessage({
+        ...message,
+        address: '0xa0cf798816d4b9b9866b5330eea46a18382f251e',
+      }),
+    ).toMatchInlineSnapshot(`
+        "example.com wants you to sign in with your Ethereum account:
+        0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
+
+
+        URI: https://example.com/path
+        Version: 1
+        Chain ID: 1
+        Nonce: foobarbaz
+        Issued At: 2023-02-01T00:00:00.000Z"
+      `)
+
+    vi.useRealTimers()
+  })
+
   test('behavior: invalid address', () => {
     expect(() =>
       Siwe.createMessage({ ...message, address: '0xfoobarbaz' }),


### PR DESCRIPTION
This PR makes `Siwe.createMessage` more friendly to use by ensuring the provided address is checksummed. Since this is required by the EIP it feels like a reasonable behavior. 

