### PR TITLE
feat: add ECDH support for secure key agreement

### DIFF
--- a/.changesets/bright-mountains-dance.md
+++ b/.changesets/bright-mountains-dance.md
@@ -1,0 +1,9 @@
+---
+'ox': minor
+---
+
+Added [ECDH (Elliptic Curve Diffie-Hellman)](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh) shared secrets to `P256`, `Secp256k1`, and `WebCryptoP256` modules. This enables secure key agreement between parties using elliptic curve cryptography for both secp256k1 and secp256r1 (P256) curves, with support for both `@noble/curves` (for `P256` and `Secp256k1`) implementation and Web Crypto APIs (`WebCryptoP256`).
+
+- `P256.getSharedSecret`
+- `Secp256k1.getSharedSecret`
+- `WebCryptoP256.getSharedSecret`

--- a/src/core/WebCryptoP256.ts
+++ b/src/core/WebCryptoP256.ts
@@ -1,7 +1,7 @@
 import { p256 } from '@noble/curves/p256'
 import * as Bytes from './Bytes.js'
 import type * as Errors from './Errors.js'
-import type * as Hex from './Hex.js'
+import * as Hex from './Hex.js'
 import * as PublicKey from './PublicKey.js'
 import type * as Signature from './Signature.js'
 import type { Compute } from './internal/types.js'
@@ -66,6 +66,144 @@ export declare namespace createKeyPair {
   }>
 
   type ErrorType = PublicKey.from.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Generates an ECDH P256 key pair for key agreement that includes:
+ *
+ * - a `privateKey` of type [`CryptoKey`](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey)
+ * - a `publicKey` of type {@link ox#PublicKey.PublicKey}
+ *
+ * @example
+ * ```ts twoslash
+ * import { WebCryptoP256 } from 'ox'
+ *
+ * const { publicKey, privateKey } = await WebCryptoP256.createKeyPairECDH()
+ * // @log: {
+ * // @log:   privateKey: CryptoKey {},
+ * // @log:   publicKey: {
+ * // @log:     x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+ * // @log:     y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+ * // @log:     prefix: 4,
+ * // @log:   },
+ * // @log: }
+ * ```
+ *
+ * @param options - Options for creating the key pair.
+ * @returns The key pair.
+ */
+export async function createKeyPairECDH(
+  options: createKeyPairECDH.Options = {},
+): Promise<createKeyPairECDH.ReturnType> {
+  const { extractable = false } = options
+  const keypair = await globalThis.crypto.subtle.generateKey(
+    {
+      name: 'ECDH',
+      namedCurve: 'P-256',
+    },
+    extractable,
+    ['deriveKey', 'deriveBits'],
+  )
+  const publicKey_raw = await globalThis.crypto.subtle.exportKey(
+    'raw',
+    keypair.publicKey,
+  )
+  const publicKey = PublicKey.from(new Uint8Array(publicKey_raw))
+  return {
+    privateKey: keypair.privateKey,
+    publicKey,
+  }
+}
+
+export declare namespace createKeyPairECDH {
+  type Options = {
+    /** A boolean value indicating whether it will be possible to export the private key using `globalThis.crypto.subtle.exportKey()`. */
+    extractable?: boolean | undefined
+  }
+
+  type ReturnType = Compute<{
+    privateKey: CryptoKey
+    publicKey: PublicKey.PublicKey
+  }>
+
+  type ErrorType = PublicKey.from.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Computes a shared secret using ECDH (Elliptic Curve Diffie-Hellman) between a private key and a public key using Web Crypto APIs.
+ *
+ * @example
+ * ```ts twoslash
+ * import { WebCryptoP256 } from 'ox'
+ *
+ * const { privateKey: privateKeyA } = await WebCryptoP256.createKeyPairECDH()
+ * const { publicKey: publicKeyB } = await WebCryptoP256.createKeyPairECDH()
+ *
+ * const sharedSecret = await WebCryptoP256.getSharedSecret({
+ *   privateKey: privateKeyA,
+ *   publicKey: publicKeyB
+ * })
+ * ```
+ *
+ * @param options - The options to compute the shared secret.
+ * @returns The computed shared secret.
+ */
+export async function getSharedSecret<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: getSharedSecret.Options<as>,
+): Promise<getSharedSecret.ReturnType<as>> {
+  const { as = 'Hex', privateKey, publicKey } = options
+
+  if (privateKey.algorithm.name === 'ECDSA') {
+    throw new Error('privateKey is not compatible with ECDH. please use `createKeyPairECDH` to create an ECDH key.')
+  }
+
+  const publicKeyCrypto = await globalThis.crypto.subtle.importKey(
+    'raw',
+    PublicKey.toBytes(publicKey),
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    [],
+  )
+
+  const sharedSecretBuffer = await globalThis.crypto.subtle.deriveBits(
+    {
+      name: 'ECDH',
+      public: publicKeyCrypto,
+    },
+    privateKey,
+    256, // 32 bytes * 8 bits/byte
+  )
+
+  const sharedSecret = new Uint8Array(sharedSecretBuffer)
+  if (as === 'Hex') return Hex.fromBytes(sharedSecret) as never
+  return sharedSecret as never
+}
+
+export declare namespace getSharedSecret {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned shared secret.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /**
+     * Private key to use for the shared secret computation (must be a CryptoKey for ECDH).
+     */
+    privateKey: CryptoKey
+    /**
+     * Public key to use for the shared secret computation.
+     */
+    publicKey: PublicKey.PublicKey<boolean>
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | PublicKey.toBytes.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /**

--- a/src/core/WebCryptoP256.ts
+++ b/src/core/WebCryptoP256.ts
@@ -154,7 +154,9 @@ export async function getSharedSecret<as extends 'Hex' | 'Bytes' = 'Hex'>(
   const { as = 'Hex', privateKey, publicKey } = options
 
   if (privateKey.algorithm.name === 'ECDSA') {
-    throw new Error('privateKey is not compatible with ECDH. please use `createKeyPairECDH` to create an ECDH key.')
+    throw new Error(
+      'privateKey is not compatible with ECDH. please use `createKeyPairECDH` to create an ECDH key.',
+    )
   }
 
   const publicKeyCrypto = await globalThis.crypto.subtle.importKey(

--- a/src/core/_test/WebCryptoP256.test.ts
+++ b/src/core/_test/WebCryptoP256.test.ts
@@ -155,7 +155,7 @@ describe('getSharedSecret', () => {
         publicKey: publicKeyB,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: privateKey is not compatible with ECDH. please use \`createKeyPairECDH\` to create an ECDH key.]`,
+      '[Error: privateKey is not compatible with ECDH. please use `createKeyPairECDH` to create an ECDH key.]',
     )
   })
 

--- a/src/core/_test/WebCryptoP256.test.ts
+++ b/src/core/_test/WebCryptoP256.test.ts
@@ -1,4 +1,4 @@
-import { WebCryptoP256 } from 'ox'
+import { Hex, PublicKey, WebCryptoP256 } from 'ox'
 import { describe, expect, test } from 'vitest'
 
 const { privateKey, publicKey } = await WebCryptoP256.createKeyPair()
@@ -10,6 +10,165 @@ describe('createKeyPair', () => {
     expect(key.publicKey.prefix).toBeDefined()
     expect(key.publicKey.x).toBeDefined()
     expect(key.publicKey.y).toBeDefined()
+  })
+})
+
+describe('createKeyPairECDH', () => {
+  test('default', async () => {
+    const key = await WebCryptoP256.createKeyPairECDH()
+    expect(key.privateKey).toBeDefined()
+    expect(key.privateKey.algorithm.name).toBe('ECDH')
+    expect((key.privateKey.algorithm as EcKeyAlgorithm).namedCurve).toBe(
+      'P-256',
+    )
+    expect(key.privateKey.usages).toContain('deriveBits')
+    expect(key.publicKey.prefix).toBeDefined()
+    expect(key.publicKey.x).toBeDefined()
+    expect(key.publicKey.y).toBeDefined()
+  })
+
+  test('options: extractable', async () => {
+    const keyExtractable = await WebCryptoP256.createKeyPairECDH({
+      extractable: true,
+    })
+    const keyNonExtractable = await WebCryptoP256.createKeyPairECDH({
+      extractable: false,
+    })
+
+    expect(keyExtractable.privateKey.extractable).toBe(true)
+    expect(keyNonExtractable.privateKey.extractable).toBe(false)
+  })
+})
+
+describe('getSharedSecret', () => {
+  test('default', async () => {
+    const { privateKey: privateKeyA, publicKey: publicKeyA } =
+      await WebCryptoP256.createKeyPairECDH()
+    const { privateKey: privateKeyB, publicKey: publicKeyB } =
+      await WebCryptoP256.createKeyPairECDH()
+
+    const sharedSecretA = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    const sharedSecretB = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyB,
+      publicKey: publicKeyA,
+    })
+
+    expect(sharedSecretA).toEqual(sharedSecretB)
+  })
+
+  test('behavior: same key pairs produce same secret', async () => {
+    const { privateKey: privateKeyA } = await WebCryptoP256.createKeyPairECDH()
+    const { publicKey: publicKeyB } = await WebCryptoP256.createKeyPairECDH()
+
+    const sharedSecret1 = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    const sharedSecret2 = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    // Should be deterministic - same inputs produce same output
+    expect(sharedSecret1).toEqual(sharedSecret2)
+  })
+
+  test('behavior: different key pairs produce different secrets', async () => {
+    const { privateKey: privateKeyA } = await WebCryptoP256.createKeyPairECDH()
+    const { publicKey: publicKeyB } = await WebCryptoP256.createKeyPairECDH()
+    const { publicKey: publicKeyC } = await WebCryptoP256.createKeyPairECDH()
+
+    const sharedSecretAB = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    const sharedSecretAC = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyC,
+    })
+
+    // Different key pairs should produce different shared secrets
+    expect(sharedSecretAB).not.toEqual(sharedSecretAC)
+  })
+
+  test('options: as', async () => {
+    const { privateKey: privateKeyA } = await WebCryptoP256.createKeyPairECDH()
+    const { publicKey: publicKeyB } = await WebCryptoP256.createKeyPairECDH()
+
+    // Test Hex output (default)
+    const sharedSecretHex = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    // Test Bytes output
+    const sharedSecretBytes = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+      as: 'Bytes',
+    })
+
+    // Verify formats
+    expect(typeof sharedSecretHex).toBe('string')
+    expect(sharedSecretHex).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(sharedSecretBytes).toBeInstanceOf(Uint8Array)
+    expect(sharedSecretBytes.length).toBe(32) // 32 bytes for raw shared secret
+
+    // Verify they represent the same data
+    expect(Hex.fromBytes(sharedSecretBytes)).toEqual(sharedSecretHex)
+  })
+
+  test('behavior: compressed public key', async () => {
+    const { privateKey: privateKeyA, ...A } =
+      await WebCryptoP256.createKeyPairECDH()
+    const { privateKey: privateKeyB, ...B } =
+      await WebCryptoP256.createKeyPairECDH()
+
+    const publicKeyA = PublicKey.compress(A.publicKey)
+    const publicKeyB = PublicKey.compress(B.publicKey)
+
+    const sharedSecret = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+    const sharedSecret2 = await WebCryptoP256.getSharedSecret({
+      privateKey: privateKeyB,
+      publicKey: publicKeyA,
+    })
+
+    expect(sharedSecret).toEqual(sharedSecret2)
+  })
+
+  test('error: private key not for ECDH', async () => {
+    const { privateKey: ecdsaPrivateKey } = await WebCryptoP256.createKeyPair() // ECDSA key
+    const { publicKey: publicKeyB } = await WebCryptoP256.createKeyPairECDH()
+
+    await expect(
+      WebCryptoP256.getSharedSecret({
+        privateKey: ecdsaPrivateKey,
+        publicKey: publicKeyB,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: privateKey is not compatible with ECDH. please use \`createKeyPairECDH\` to create an ECDH key.]`,
+    )
+  })
+
+  test('error: invalid public key', async () => {
+    const { privateKey: privateKeyA } = await WebCryptoP256.createKeyPairECDH()
+    const invalidPublicKey = { prefix: 4, x: 0n, y: 0n } as const
+
+    await expect(
+      WebCryptoP256.getSharedSecret({
+        privateKey: privateKeyA,
+        publicKey: invalidPublicKey,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot('[DataError: Invalid keyData]')
   })
 })
 
@@ -39,6 +198,8 @@ test('exports', () => {
   expect(Object.keys(WebCryptoP256)).toMatchInlineSnapshot(`
     [
       "createKeyPair",
+      "createKeyPairECDH",
+      "getSharedSecret",
       "sign",
       "verify",
     ]


### PR DESCRIPTION
### Summary

- Added ECDH (Elliptic Curve Diffie-Hellman) shared secret computation to P256, Secp256k1, and WebCryptoP256 modules
- Enables secure key agreement between parties using elliptic curve cryptography for both secp256k1 and secp256r1 (P256) curves

### Details

- Added `getSharedSecret` function to `P256` module using @noble/curves implementation
- Added `getSharedSecret` function to `Secp256k1` module using @noble/curves implementation  
- Added `createKeyPairECDH` and `getSharedSecret` functions to `WebCryptoP256` module using Web Crypto APIs
- Comprehensive test coverage for all three modules including edge cases and error conditions
- Support for both Hex and Bytes output formats
- Proper error handling for invalid keys and incompatible key types
- Added changeset documenting the minor version change

### Modules Touched

- P256: `P256`
- Secp256k1: `Secp256k1`
- WebCrypto P256: `WebCryptoP256`

🤖 Generated with [Claude Code](https://claude.ai/code)