### PR TITLE
feat: add createKeyPair functions to cryptographic modules

### DIFF
--- a/.changesets/clever-hamster-dance.md
+++ b/.changesets/clever-hamster-dance.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `createKeyPair` functions for BLS, P256, and Secp256k1 cryptographic modules. These functions provide a convenient way to generate complete key pairs (private key + public key) in a single operation, simplifying key generation workflows and reducing the need for separate `randomPrivateKey` and `getPublicKey` calls.

--- a/.changesets/clever-hamster-dance.md
+++ b/.changesets/clever-hamster-dance.md
@@ -2,4 +2,4 @@
 "ox": minor
 ---
 
-Added `createKeyPair` functions for BLS, P256, and Secp256k1 cryptographic modules. These functions provide a convenient way to generate complete key pairs (private key + public key) in a single operation, simplifying key generation workflows and reducing the need for separate `randomPrivateKey` and `getPublicKey` calls.
+Added `createKeyPair` helper functions for `Bls`, `P256`, and `Secp256k1` modules. These functions provide a convenient way to generate complete key pairs (private key + public key) in a single operation, simplifying key generation workflows and reducing the need for separate `randomPrivateKey` and `getPublicKey` calls.

--- a/src/core/Bls.ts
+++ b/src/core/Bls.ts
@@ -72,7 +72,7 @@ export declare namespace aggregate {
 
 /**
  * Creates a new BLS12-381 key pair consisting of a private key and its corresponding public key.
- * 
+ *
  * - G1 Point (Default):
  *   - short (48 bytes)
  *   - computes longer G2 Signatures (96 bytes)
@@ -172,14 +172,14 @@ export declare namespace aggregate {
  */
 export function createKeyPair<
   as extends 'Hex' | 'Bytes' = 'Hex',
-  size extends Size = 'short-key:long-sig'
+  size extends Size = 'short-key:long-sig',
 >(
   options: createKeyPair.Options<as, size> = {},
 ): createKeyPair.ReturnType<as, size> {
   const { as = 'Hex', size = 'short-key:long-sig' } = options
   const privateKey = randomPrivateKey({ as })
   const publicKey = getPublicKey({ privateKey, size })
-  
+
   return {
     privateKey: privateKey as never,
     publicKey: publicKey as never,
@@ -189,7 +189,7 @@ export function createKeyPair<
 export declare namespace createKeyPair {
   type Options<
     as extends 'Hex' | 'Bytes' = 'Hex',
-    size extends Size = 'short-key:long-sig'
+    size extends Size = 'short-key:long-sig',
   > = {
     /**
      * Format of the returned private key.
@@ -207,18 +207,15 @@ export declare namespace createKeyPair {
     size?: size | Size | undefined
   }
 
-  type ReturnType<
-    as extends 'Hex' | 'Bytes',
-    size extends Size
-  > = {
+  type ReturnType<as extends 'Hex' | 'Bytes', size extends Size> = {
     privateKey:
       | (as extends 'Bytes' ? Bytes.Bytes : never)
       | (as extends 'Hex' ? Hex.Hex : never)
     publicKey: size extends 'short-key:long-sig' ? BlsPoint.G1 : BlsPoint.G2
   }
 
-  type ErrorType = 
-    | Hex.fromBytes.ErrorType 
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
     | getPublicKey.ErrorType
     | Errors.GlobalErrorType
 }

--- a/src/core/Bls.ts
+++ b/src/core/Bls.ts
@@ -71,6 +71,159 @@ export declare namespace aggregate {
 }
 
 /**
+ * Creates a new BLS12-381 key pair consisting of a private key and its corresponding public key.
+ * 
+ * - G1 Point (Default):
+ *   - short (48 bytes)
+ *   - computes longer G2 Signatures (96 bytes)
+ * - G2 Point:
+ *   - long (96 bytes)
+ *   - computes short G1 Signatures (48 bytes)
+ *
+ * @example
+ * ### Short G1 Public Keys (Default)
+ *
+ * ```ts twoslash
+ * import { Bls } from 'ox'
+ *
+ * const { publicKey } = Bls.createKeyPair()
+ * //      ^?
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * ```
+ *
+ * @example
+ * ### Long G2 Public Keys
+ *
+ * A G2 Public Key can be derived as a G2 point (96 bytes) using `size: 'long-key:short-sig'`.
+ *
+ * This will allow you to compute G1 Signatures (48 bytes) with {@link ox#Bls.(sign:function)}.
+ *
+ * ```ts twoslash
+ * import { Bls } from 'ox'
+ *
+ * const { publicKey } = Bls.createKeyPair({
+ *   size: 'long-key:short-sig',
+ * })
+ *
+ * publicKey
+ * // ^?
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * ```
+ *
+ * ### Serializing
+ *
+ * Public Keys can be serialized to hex or bytes using {@link ox#BlsPoint.(toHex:function)} or {@link ox#BlsPoint.(toBytes:function)}:
+ *
+ * ```ts twoslash
+ * import { Bls, BlsPoint } from 'ox'
+ *
+ * const { publicKey } = Bls.createKeyPair()
+ *
+ * const publicKeyHex = BlsPoint.toHex(publicKey)
+ * //    ^?
+ *
+ *
+ * const publicKeyBytes = BlsPoint.toBytes(publicKey)
+ * //    ^?
+ *
+ * ```
+ *
+ * They can also be deserialized from hex or bytes using {@link ox#BlsPoint.(fromHex:function)} or {@link ox#BlsPoint.(fromBytes:function)}:
+ *
+ * ```ts twoslash
+ * import { Bls, BlsPoint } from 'ox'
+ *
+ * const publicKeyHex = '0x...'
+ *
+ * const publicKey = BlsPoint.fromHex(publicKeyHex, 'G1')
+ * //    ^?
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * ```
+ *
+ * @param options - The options to generate the key pair.
+ * @returns The generated key pair containing both private and public keys.
+ */
+export function createKeyPair<
+  as extends 'Hex' | 'Bytes' = 'Hex',
+  size extends Size = 'short-key:long-sig'
+>(
+  options: createKeyPair.Options<as, size> = {},
+): createKeyPair.ReturnType<as, size> {
+  const { as = 'Hex', size = 'short-key:long-sig' } = options
+  const privateKey = randomPrivateKey({ as })
+  const publicKey = getPublicKey({ privateKey, size })
+  
+  return {
+    privateKey: privateKey as never,
+    publicKey: publicKey as never,
+  }
+}
+
+export declare namespace createKeyPair {
+  type Options<
+    as extends 'Hex' | 'Bytes' = 'Hex',
+    size extends Size = 'short-key:long-sig'
+  > = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /**
+     * Size of the public key to compute.
+     *
+     * - `'short-key:long-sig'`: 48 bytes; computes long signatures (96 bytes)
+     * - `'long-key:short-sig'`: 96 bytes; computes short signatures (48 bytes)
+     *
+     * @default 'short-key:long-sig'
+     */
+    size?: size | Size | undefined
+  }
+
+  type ReturnType<
+    as extends 'Hex' | 'Bytes',
+    size extends Size
+  > = {
+    privateKey:
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
+      | (as extends 'Hex' ? Hex.Hex : never)
+    publicKey: size extends 'short-key:long-sig' ? BlsPoint.G1 : BlsPoint.G2
+  }
+
+  type ErrorType = 
+    | Hex.fromBytes.ErrorType 
+    | getPublicKey.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Computes the BLS12-381 public key from a provided private key.
  *
  * Public Keys can be derived as a point on one of the BLS12-381 groups:

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -28,7 +28,7 @@ export function createKeyPair<as extends 'Hex' | 'Bytes' = 'Hex'>(
   const { as = 'Hex' } = options
   const privateKey = randomPrivateKey({ as })
   const publicKey = getPublicKey({ privateKey })
-  
+
   return {
     privateKey: privateKey as never,
     publicKey,
@@ -51,8 +51,8 @@ export declare namespace createKeyPair {
     publicKey: PublicKey.PublicKey
   }
 
-  type ErrorType = 
-    | Hex.fromBytes.ErrorType 
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
     | PublicKey.from.ErrorType
     | Errors.GlobalErrorType
 }

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -10,6 +10,54 @@ import * as Entropy from './internal/entropy.js'
 export const noble = secp256r1
 
 /**
+ * Creates a new P256 ECDSA key pair consisting of a private key and its corresponding public key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { P256 } from 'ox'
+ *
+ * const { privateKey, publicKey } = P256.createKeyPair()
+ * ```
+ *
+ * @param options - The options to generate the key pair.
+ * @returns The generated key pair containing both private and public keys.
+ */
+export function createKeyPair<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: createKeyPair.Options<as> = {},
+): createKeyPair.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const privateKey = randomPrivateKey({ as })
+  const publicKey = getPublicKey({ privateKey })
+  
+  return {
+    privateKey: privateKey as never,
+    publicKey,
+  }
+}
+
+export declare namespace createKeyPair {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = {
+    privateKey:
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
+      | (as extends 'Hex' ? Hex.Hex : never)
+    publicKey: PublicKey.PublicKey
+  }
+
+  type ErrorType = 
+    | Hex.fromBytes.ErrorType 
+    | PublicKey.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Computes the P256 ECDSA public key from a provided private key.
  *
  * @example
@@ -52,8 +100,8 @@ export declare namespace getPublicKey {
  * ```ts twoslash
  * import { P256 } from 'ox'
  *
- * const privateKeyA = P256.randomPrivateKey()
- * const publicKeyB = P256.getPublicKey({ privateKey: '0x...' })
+ * const { privateKey: privateKeyA } = P256.createKeyPair()
+ * const { publicKey: publicKeyB } = P256.createKeyPair()
  *
  * const sharedSecret = P256.getSharedSecret({
  *   privateKey: privateKeyA,
@@ -269,8 +317,7 @@ export declare namespace sign {
  * ```ts twoslash
  * import { P256 } from 'ox'
  *
- * const privateKey = P256.randomPrivateKey()
- * const publicKey = P256.getPublicKey({ privateKey })
+ * const { privateKey, publicKey } = P256.createKeyPair()
  * const signature = P256.sign({ payload: '0xdeadbeef', privateKey })
  *
  * const verified = P256.verify({ // [!code focus]

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -12,6 +12,54 @@ import type { OneOf } from './internal/types.js'
 export const noble = secp256k1
 
 /**
+ * Creates a new secp256k1 ECDSA key pair consisting of a private key and its corresponding public key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Secp256k1 } from 'ox'
+ *
+ * const { privateKey, publicKey } = Secp256k1.createKeyPair()
+ * ```
+ *
+ * @param options - The options to generate the key pair.
+ * @returns The generated key pair containing both private and public keys.
+ */
+export function createKeyPair<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: createKeyPair.Options<as> = {},
+): createKeyPair.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const privateKey = randomPrivateKey({ as })
+  const publicKey = getPublicKey({ privateKey })
+  
+  return {
+    privateKey: privateKey as never,
+    publicKey,
+  }
+}
+
+export declare namespace createKeyPair {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = {
+    privateKey:
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
+      | (as extends 'Hex' ? Hex.Hex : never)
+    publicKey: PublicKey.PublicKey
+  }
+
+  type ErrorType = 
+    | Hex.fromBytes.ErrorType 
+    | PublicKey.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Computes the secp256k1 ECDSA public key from a provided private key.
  *
  * @example
@@ -55,8 +103,8 @@ export declare namespace getPublicKey {
  * ```ts twoslash
  * import { Secp256k1 } from 'ox'
  *
- * const privateKeyA = Secp256k1.randomPrivateKey()
- * const publicKeyB = Secp256k1.getPublicKey({ privateKey: '0x...' })
+ * const { privateKey: privateKeyA } = Secp256k1.createKeyPair()
+ * const { publicKey: publicKeyB } = Secp256k1.createKeyPair()
  *
  * const sharedSecret = Secp256k1.getSharedSecret({
  *   privateKey: privateKeyA,

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -30,7 +30,7 @@ export function createKeyPair<as extends 'Hex' | 'Bytes' = 'Hex'>(
   const { as = 'Hex' } = options
   const privateKey = randomPrivateKey({ as })
   const publicKey = getPublicKey({ privateKey })
-  
+
   return {
     privateKey: privateKey as never,
     publicKey,
@@ -53,8 +53,8 @@ export declare namespace createKeyPair {
     publicKey: PublicKey.PublicKey
   }
 
-  type ErrorType = 
-    | Hex.fromBytes.ErrorType 
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
     | PublicKey.from.ErrorType
     | Errors.GlobalErrorType
 }

--- a/src/core/_test/Bls.test.ts
+++ b/src/core/_test/Bls.test.ts
@@ -54,6 +54,62 @@ describe('aggregate', () => {
   })
 })
 
+describe('createKeyPair', () => {
+  it('default', () => {
+    const { privateKey, publicKey } = Bls.createKeyPair()
+    expect(privateKey).toBeDefined()
+    expect(privateKey.length).toBe(66)
+    expect(publicKey).toBeDefined()
+    expect(typeof publicKey.x).toBe('bigint')
+    expect(typeof publicKey.y).toBe('bigint')
+    expect(typeof publicKey.z).toBe('bigint')
+  })
+
+  it('as: bytes', () => {
+    const { privateKey, publicKey } = Bls.createKeyPair({ as: 'Bytes' })
+    expect(privateKey).toBeDefined()
+    expect(privateKey.length).toBe(32)
+    expect(publicKey).toBeDefined()
+    expect(typeof publicKey.x).toBe('bigint')
+    expect(typeof publicKey.y).toBe('bigint')
+    expect(typeof publicKey.z).toBe('bigint')
+  })
+
+  it('size: "long-key:short-sig"', () => {
+    const { privateKey, publicKey } = Bls.createKeyPair({
+      size: 'long-key:short-sig',
+    })
+    expect(privateKey).toBeDefined()
+    expect(privateKey.length).toBe(66)
+    expect(publicKey).toBeDefined()
+    expect(typeof publicKey.x).toBe('object')
+    expect(typeof publicKey.y).toBe('object')
+    expect(typeof publicKey.z).toBe('object')
+  })
+
+  it('should create functional key pair', () => {
+    const { privateKey, publicKey } = Bls.createKeyPair()
+    const payload = Hex.fromString('test message')
+    
+    const signature = Bls.sign({ payload, privateKey })
+    const verified = Bls.verify({ payload, publicKey, signature })
+    
+    expect(verified).toBe(true)
+  })
+
+  it('should create functional key pair with long-key:short-sig', () => {
+    const { privateKey, publicKey } = Bls.createKeyPair({
+      size: 'long-key:short-sig',
+    })
+    const payload = Hex.fromString('test message')
+    
+    const signature = Bls.sign({ payload, privateKey, size: 'long-key:short-sig' })
+    const verified = Bls.verify({ payload, publicKey, signature })
+    
+    expect(verified).toBe(true)
+  })
+})
+
 describe('getPublicKey', () => {
   it('default', () => {
     const publicKey = Bls.getPublicKey({ privateKey })

--- a/src/core/_test/Bls.test.ts
+++ b/src/core/_test/Bls.test.ts
@@ -90,10 +90,10 @@ describe('createKeyPair', () => {
   it('should create functional key pair', () => {
     const { privateKey, publicKey } = Bls.createKeyPair()
     const payload = Hex.fromString('test message')
-    
+
     const signature = Bls.sign({ payload, privateKey })
     const verified = Bls.verify({ payload, publicKey, signature })
-    
+
     expect(verified).toBe(true)
   })
 
@@ -102,10 +102,14 @@ describe('createKeyPair', () => {
       size: 'long-key:short-sig',
     })
     const payload = Hex.fromString('test message')
-    
-    const signature = Bls.sign({ payload, privateKey, size: 'long-key:short-sig' })
+
+    const signature = Bls.sign({
+      payload,
+      privateKey,
+      size: 'long-key:short-sig',
+    })
     const verified = Bls.verify({ payload, publicKey, signature })
-    
+
     expect(verified).toBe(true)
   })
 })

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -41,12 +41,106 @@ describe('getPublicKey', () => {
   })
 })
 
+describe('createKeyPair', () => {
+  test('default', () => {
+    const keyPair = P256.createKeyPair()
+    
+    expect(keyPair).toHaveProperty('privateKey')
+    expect(keyPair).toHaveProperty('publicKey')
+    expect(typeof keyPair.privateKey).toBe('string')
+    expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(keyPair.privateKey.length).toBe(66)
+    
+    expect(keyPair.publicKey).toHaveProperty('prefix')
+    expect(keyPair.publicKey).toHaveProperty('x')
+    expect(keyPair.publicKey).toHaveProperty('y')
+    expect(keyPair.publicKey.prefix).toBe(4)
+    expect(typeof keyPair.publicKey.x).toBe('bigint')
+    expect(typeof keyPair.publicKey.y).toBe('bigint')
+  })
+
+  test('behavior: deterministic public key derivation', () => {
+    const keyPair = P256.createKeyPair()
+    const derivedPublicKey = P256.getPublicKey({ privateKey: keyPair.privateKey })
+    
+    expect(keyPair.publicKey).toEqual(derivedPublicKey)
+  })
+
+  test('behavior: unique key pairs', () => {
+    const keyPair1 = P256.createKeyPair()
+    const keyPair2 = P256.createKeyPair()
+    
+    expect(keyPair1.privateKey).not.toEqual(keyPair2.privateKey)
+    expect(keyPair1.publicKey).not.toEqual(keyPair2.publicKey)
+  })
+
+  test('behavior: valid for signing and verification', () => {
+    const keyPair = P256.createKeyPair()
+    const payload = '0xdeadbeef'
+    
+    const signature = P256.sign({ payload, privateKey: keyPair.privateKey })
+    const isValid = P256.verify({ publicKey: keyPair.publicKey, payload, signature })
+    
+    expect(isValid).toBe(true)
+  })
+
+  test('behavior: valid for ECDH key agreement', () => {
+    const keyPairA = P256.createKeyPair()
+    const keyPairB = P256.createKeyPair()
+    
+    const sharedSecretA = P256.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+    })
+    
+    const sharedSecretB = P256.getSharedSecret({
+      privateKey: keyPairB.privateKey,
+      publicKey: keyPairA.publicKey,
+    })
+    
+    expect(sharedSecretA).toEqual(sharedSecretB)
+    expect(typeof sharedSecretA).toBe('string')
+    expect(sharedSecretA).toMatch(/^0x[0-9a-f]{66}$/)
+  })
+
+  test('options: as (Hex)', () => {
+    const keyPair = P256.createKeyPair({ as: 'Hex' })
+    
+    expect(typeof keyPair.privateKey).toBe('string')
+    expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(keyPair.privateKey.length).toBe(66)
+  })
+
+  test('options: as (Bytes)', () => {
+    const keyPair = P256.createKeyPair({ as: 'Bytes' })
+    
+    expect(keyPair.privateKey).toBeInstanceOf(Uint8Array)
+    expect(keyPair.privateKey.length).toBe(32)
+    expect(keyPair.publicKey).toHaveProperty('prefix')
+    expect(keyPair.publicKey.prefix).toBe(4)
+  })
+
+  test('behavior: bytes format works with other functions', () => {
+    const keyPair = P256.createKeyPair({ as: 'Bytes' })
+    const derivedPublicKey = P256.getPublicKey({ privateKey: keyPair.privateKey })
+    
+    expect(keyPair.publicKey).toEqual(derivedPublicKey)
+  })
+
+  test('behavior: public key recovery', () => {
+    const keyPair = P256.createKeyPair()
+    const payload = '0xdeadbeef'
+    const signature = P256.sign({ payload, privateKey: keyPair.privateKey })
+    const recoveredPublicKey = P256.recoverPublicKey({ payload, signature })
+    
+    expect(recoveredPublicKey).toEqual(keyPair.publicKey)
+  })
+})
+
 describe('getSharedSecret', () => {
   test('default', () => {
-    const privateKeyA = P256.randomPrivateKey()
-    const privateKeyB = P256.randomPrivateKey()
-    const publicKeyA = P256.getPublicKey({ privateKey: privateKeyA })
-    const publicKeyB = P256.getPublicKey({ privateKey: privateKeyB })
+    const { privateKey: privateKeyA, publicKey: publicKeyA } = P256.createKeyPair()
+    const { privateKey: privateKeyB, publicKey: publicKeyB } = P256.createKeyPair()
 
     // Compute shared secret from A's perspective
     const sharedSecretA = P256.getSharedSecret({
@@ -92,9 +186,8 @@ describe('getSharedSecret', () => {
   })
 
   test('behavior: different input types', () => {
-    const privateKeyA = P256.randomPrivateKey()
-    const privateKeyB = P256.randomPrivateKey()
-    const publicKeyB = P256.getPublicKey({ privateKey: privateKeyB })
+    const { privateKey: privateKeyA } = P256.createKeyPair()
+    const { privateKey: privateKeyB, publicKey: publicKeyB } = P256.createKeyPair()
 
     // Test with Hex private key
     const sharedSecret1 = P256.getSharedSecret({
@@ -112,9 +205,8 @@ describe('getSharedSecret', () => {
   })
 
   test('behavior: uncompressed public key', () => {
-    const privateKeyA = P256.randomPrivateKey()
-    const privateKeyB = P256.randomPrivateKey()
-    const publicKeyB = P256.getPublicKey({ privateKey: privateKeyB })
+    const { privateKey: privateKeyA } = P256.createKeyPair()
+    const { publicKey: publicKeyB } = P256.createKeyPair()
 
     // Ensure the public key is uncompressed (prefix 4)
     expect(publicKeyB.prefix).toBe(4)
@@ -129,9 +221,8 @@ describe('getSharedSecret', () => {
   })
 
   test('options: as', () => {
-    const privateKeyA = P256.randomPrivateKey()
-    const privateKeyB = P256.randomPrivateKey()
-    const publicKeyB = P256.getPublicKey({ privateKey: privateKeyB })
+    const { privateKey: privateKeyA } = P256.createKeyPair()
+    const { publicKey: publicKeyB } = P256.createKeyPair()
 
     // Test Hex output (default)
     const sharedSecretHex = P256.getSharedSecret({
@@ -442,6 +533,7 @@ test('exports', () => {
       "noble",
       "getPublicKey",
       "getSharedSecret",
+      "createKeyPair",
       "randomPrivateKey",
       "recoverPublicKey",
       "sign",

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -44,13 +44,13 @@ describe('getPublicKey', () => {
 describe('createKeyPair', () => {
   test('default', () => {
     const keyPair = P256.createKeyPair()
-    
+
     expect(keyPair).toHaveProperty('privateKey')
     expect(keyPair).toHaveProperty('publicKey')
     expect(typeof keyPair.privateKey).toBe('string')
     expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
     expect(keyPair.privateKey.length).toBe(66)
-    
+
     expect(keyPair.publicKey).toHaveProperty('prefix')
     expect(keyPair.publicKey).toHaveProperty('x')
     expect(keyPair.publicKey).toHaveProperty('y')
@@ -61,15 +61,17 @@ describe('createKeyPair', () => {
 
   test('behavior: deterministic public key derivation', () => {
     const keyPair = P256.createKeyPair()
-    const derivedPublicKey = P256.getPublicKey({ privateKey: keyPair.privateKey })
-    
+    const derivedPublicKey = P256.getPublicKey({
+      privateKey: keyPair.privateKey,
+    })
+
     expect(keyPair.publicKey).toEqual(derivedPublicKey)
   })
 
   test('behavior: unique key pairs', () => {
     const keyPair1 = P256.createKeyPair()
     const keyPair2 = P256.createKeyPair()
-    
+
     expect(keyPair1.privateKey).not.toEqual(keyPair2.privateKey)
     expect(keyPair1.publicKey).not.toEqual(keyPair2.publicKey)
   })
@@ -77,27 +79,31 @@ describe('createKeyPair', () => {
   test('behavior: valid for signing and verification', () => {
     const keyPair = P256.createKeyPair()
     const payload = '0xdeadbeef'
-    
+
     const signature = P256.sign({ payload, privateKey: keyPair.privateKey })
-    const isValid = P256.verify({ publicKey: keyPair.publicKey, payload, signature })
-    
+    const isValid = P256.verify({
+      publicKey: keyPair.publicKey,
+      payload,
+      signature,
+    })
+
     expect(isValid).toBe(true)
   })
 
   test('behavior: valid for ECDH key agreement', () => {
     const keyPairA = P256.createKeyPair()
     const keyPairB = P256.createKeyPair()
-    
+
     const sharedSecretA = P256.getSharedSecret({
       privateKey: keyPairA.privateKey,
       publicKey: keyPairB.publicKey,
     })
-    
+
     const sharedSecretB = P256.getSharedSecret({
       privateKey: keyPairB.privateKey,
       publicKey: keyPairA.publicKey,
     })
-    
+
     expect(sharedSecretA).toEqual(sharedSecretB)
     expect(typeof sharedSecretA).toBe('string')
     expect(sharedSecretA).toMatch(/^0x[0-9a-f]{66}$/)
@@ -105,7 +111,7 @@ describe('createKeyPair', () => {
 
   test('options: as (Hex)', () => {
     const keyPair = P256.createKeyPair({ as: 'Hex' })
-    
+
     expect(typeof keyPair.privateKey).toBe('string')
     expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
     expect(keyPair.privateKey.length).toBe(66)
@@ -113,7 +119,7 @@ describe('createKeyPair', () => {
 
   test('options: as (Bytes)', () => {
     const keyPair = P256.createKeyPair({ as: 'Bytes' })
-    
+
     expect(keyPair.privateKey).toBeInstanceOf(Uint8Array)
     expect(keyPair.privateKey.length).toBe(32)
     expect(keyPair.publicKey).toHaveProperty('prefix')
@@ -122,8 +128,10 @@ describe('createKeyPair', () => {
 
   test('behavior: bytes format works with other functions', () => {
     const keyPair = P256.createKeyPair({ as: 'Bytes' })
-    const derivedPublicKey = P256.getPublicKey({ privateKey: keyPair.privateKey })
-    
+    const derivedPublicKey = P256.getPublicKey({
+      privateKey: keyPair.privateKey,
+    })
+
     expect(keyPair.publicKey).toEqual(derivedPublicKey)
   })
 
@@ -132,15 +140,17 @@ describe('createKeyPair', () => {
     const payload = '0xdeadbeef'
     const signature = P256.sign({ payload, privateKey: keyPair.privateKey })
     const recoveredPublicKey = P256.recoverPublicKey({ payload, signature })
-    
+
     expect(recoveredPublicKey).toEqual(keyPair.publicKey)
   })
 })
 
 describe('getSharedSecret', () => {
   test('default', () => {
-    const { privateKey: privateKeyA, publicKey: publicKeyA } = P256.createKeyPair()
-    const { privateKey: privateKeyB, publicKey: publicKeyB } = P256.createKeyPair()
+    const { privateKey: privateKeyA, publicKey: publicKeyA } =
+      P256.createKeyPair()
+    const { privateKey: privateKeyB, publicKey: publicKeyB } =
+      P256.createKeyPair()
 
     // Compute shared secret from A's perspective
     const sharedSecretA = P256.getSharedSecret({
@@ -187,7 +197,8 @@ describe('getSharedSecret', () => {
 
   test('behavior: different input types', () => {
     const { privateKey: privateKeyA } = P256.createKeyPair()
-    const { privateKey: privateKeyB, publicKey: publicKeyB } = P256.createKeyPair()
+    const { privateKey: privateKeyB, publicKey: publicKeyB } =
+      P256.createKeyPair()
 
     // Test with Hex private key
     const sharedSecret1 = P256.getSharedSecret({

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -47,13 +47,13 @@ describe('getPublicKey', () => {
 describe('createKeyPair', () => {
   test('default', () => {
     const keyPair = Secp256k1.createKeyPair()
-    
+
     expect(keyPair).toHaveProperty('privateKey')
     expect(keyPair).toHaveProperty('publicKey')
     expect(typeof keyPair.privateKey).toBe('string')
     expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
     expect(keyPair.privateKey.length).toBe(66)
-    
+
     expect(keyPair.publicKey).toHaveProperty('prefix')
     expect(keyPair.publicKey).toHaveProperty('x')
     expect(keyPair.publicKey).toHaveProperty('y')
@@ -64,15 +64,17 @@ describe('createKeyPair', () => {
 
   test('behavior: deterministic public key derivation', () => {
     const keyPair = Secp256k1.createKeyPair()
-    const derivedPublicKey = Secp256k1.getPublicKey({ privateKey: keyPair.privateKey })
-    
+    const derivedPublicKey = Secp256k1.getPublicKey({
+      privateKey: keyPair.privateKey,
+    })
+
     expect(keyPair.publicKey).toEqual(derivedPublicKey)
   })
 
   test('behavior: unique key pairs', () => {
     const keyPair1 = Secp256k1.createKeyPair()
     const keyPair2 = Secp256k1.createKeyPair()
-    
+
     expect(keyPair1.privateKey).not.toEqual(keyPair2.privateKey)
     expect(keyPair1.publicKey).not.toEqual(keyPair2.publicKey)
   })
@@ -80,16 +82,23 @@ describe('createKeyPair', () => {
   test('behavior: valid for signing and verification', () => {
     const keyPair = Secp256k1.createKeyPair()
     const payload = '0xdeadbeef'
-    
-    const signature = Secp256k1.sign({ payload, privateKey: keyPair.privateKey })
-    const isValid = Secp256k1.verify({ publicKey: keyPair.publicKey, payload, signature })
-    
+
+    const signature = Secp256k1.sign({
+      payload,
+      privateKey: keyPair.privateKey,
+    })
+    const isValid = Secp256k1.verify({
+      publicKey: keyPair.publicKey,
+      payload,
+      signature,
+    })
+
     expect(isValid).toBe(true)
   })
 
   test('options: as (Hex)', () => {
     const keyPair = Secp256k1.createKeyPair({ as: 'Hex' })
-    
+
     expect(typeof keyPair.privateKey).toBe('string')
     expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/)
     expect(keyPair.privateKey.length).toBe(66)
@@ -97,7 +106,7 @@ describe('createKeyPair', () => {
 
   test('options: as (Bytes)', () => {
     const keyPair = Secp256k1.createKeyPair({ as: 'Bytes' })
-    
+
     expect(keyPair.privateKey).toBeInstanceOf(Uint8Array)
     expect(keyPair.privateKey.length).toBe(32)
     expect(keyPair.publicKey).toHaveProperty('prefix')
@@ -106,8 +115,10 @@ describe('createKeyPair', () => {
 
   test('behavior: bytes format works with other functions', () => {
     const keyPair = Secp256k1.createKeyPair({ as: 'Bytes' })
-    const derivedPublicKey = Secp256k1.getPublicKey({ privateKey: keyPair.privateKey })
-    
+    const derivedPublicKey = Secp256k1.getPublicKey({
+      privateKey: keyPair.privateKey,
+    })
+
     expect(keyPair.publicKey).toEqual(derivedPublicKey)
   })
 })

--- a/src/core/_test/WebAuthnP256.test.ts
+++ b/src/core/_test/WebAuthnP256.test.ts
@@ -762,8 +762,7 @@ describe('getSignPayload', () => {
   })
 
   test('behavior: P256.sign + WebAuthnP256.verify', async () => {
-    const privateKey = P256.randomPrivateKey()
-    const publicKey = P256.getPublicKey({ privateKey })
+    const { privateKey, publicKey } = P256.createKeyPair()
 
     const challenge =
       '0xf631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf' as const


### PR DESCRIPTION
### Summary

Added `createKeyPair` helper functions for `Bls`, `P256`, and `Secp256k1` modules. These functions provide a convenient way to generate complete key pairs (private key + public key) in a single operation, simplifying key generation workflows and reducing the need for separate `randomPrivateKey` and `getPublicKey` calls.

### Details

- Added `createKeyPair` function to `Bls` module with support for both G1 and G2 public keys
- Added `createKeyPair` function to `P256` module for ECDSA key pair generation  
- Added `createKeyPair` function to `Secp256k1` module for ECDSA key pair generation
- All functions support both `Hex` and `Bytes` output formats for private keys
- Comprehensive test coverage for all new functions including functional validation
- Updated existing test examples to use the new `createKeyPair` functions where appropriate
- Added detailed TSDoc documentation with examples for each function
- Created changeset documenting the new functionality

### Modules Touched

- BLS12-381: `Bls`
- P256 ECDSA: `P256` 
- secp256k1 ECDSA: `Secp256k1`

🤖 Generated with [Claude Code](https://claude.ai/code)