### PR TITLE
feat: add Ed25519 and X25519 cryptographic modules

### DIFF
--- a/.changesets/quiet-dolphins-jump.md
+++ b/.changesets/quiet-dolphins-jump.md
@@ -2,4 +2,4 @@
 'ox': minor
 ---
 
-Added `Ed25519` and `X25519` cryptographic modules for modern elliptic curve operations. The `Ed25519` module provides functionality for creating key pairs, signing messages, and verifying signatures using the Ed25519 signature scheme. The `X25519` module enables Elliptic Curve Diffie-Hellman (ECDH) key agreement operations for secure shared secret derivation between parties.
+Added `Ed25519` and `X25519` modules. The `Ed25519` module provides functionality for creating key pairs, signing messages, and verifying signatures using the Ed25519 signature scheme. The `X25519` module enables Elliptic Curve Diffie-Hellman (ECDH) key agreement operations for secure shared secret derivation.

--- a/.changesets/quiet-dolphins-jump.md
+++ b/.changesets/quiet-dolphins-jump.md
@@ -1,0 +1,5 @@
+---
+'ox': minor
+---
+
+Added `Ed25519` and `X25519` cryptographic modules for modern elliptic curve operations. The `Ed25519` module provides functionality for creating key pairs, signing messages, and verifying signatures using the Ed25519 signature scheme. The `X25519` module enables Elliptic Curve Diffie-Hellman (ECDH) key agreement operations for secure shared secret derivation between parties.

--- a/src/core/Ed25519.ts
+++ b/src/core/Ed25519.ts
@@ -1,0 +1,237 @@
+import { ed25519 } from '@noble/curves/ed25519'
+import * as Bytes from './Bytes.js'
+import type * as Errors from './Errors.js'
+import * as Hex from './Hex.js'
+
+/** Re-export of noble/curves Ed25519 utilities. */
+export const noble = ed25519
+
+/**
+ * Creates a new Ed25519 key pair consisting of a private key and its corresponding public key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const { privateKey, publicKey } = Ed25519.createKeyPair()
+ * ```
+ *
+ * @param options - The options to generate the key pair.
+ * @returns The generated key pair containing both private and public keys.
+ */
+export function createKeyPair<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: createKeyPair.Options<as> = {},
+): createKeyPair.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const privateKey = randomPrivateKey({ as })
+  const publicKey = getPublicKey({ privateKey, as })
+
+  return {
+    privateKey: privateKey as never,
+    publicKey: publicKey as never,
+  }
+}
+
+export declare namespace createKeyPair {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private and public keys.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = {
+    privateKey:
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
+      | (as extends 'Hex' ? Hex.Hex : never)
+    publicKey:
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
+      | (as extends 'Hex' ? Hex.Hex : never)
+  }
+
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
+    | randomPrivateKey.ErrorType
+    | getPublicKey.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Computes the Ed25519 public key from a provided private key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const publicKey = Ed25519.getPublicKey({ privateKey: '0x...' })
+ * ```
+ *
+ * @param options - The options to compute the public key.
+ * @returns The computed public key.
+ */
+export function getPublicKey<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: getPublicKey.Options<as>,
+): getPublicKey.ReturnType<as> {
+  const { as = 'Hex', privateKey } = options
+  const privateKeyBytes = Bytes.from(privateKey)
+  const publicKeyBytes = ed25519.getPublicKey(privateKeyBytes)
+  if (as === 'Hex') return Hex.fromBytes(publicKeyBytes) as never
+  return publicKeyBytes as never
+}
+
+export declare namespace getPublicKey {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned public key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /**
+     * Private key to compute the public key from.
+     */
+    privateKey: Hex.Hex | Bytes.Bytes
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Generates a random Ed25519 private key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const privateKey = Ed25519.randomPrivateKey()
+ * ```
+ *
+ * @param options - The options to generate the private key.
+ * @returns The generated private key.
+ */
+export function randomPrivateKey<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: randomPrivateKey.Options<as> = {},
+): randomPrivateKey.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = ed25519.utils.randomPrivateKey()
+  if (as === 'Hex') return Hex.fromBytes(bytes) as never
+  return bytes as never
+}
+
+export declare namespace randomPrivateKey {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType = Hex.fromBytes.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Signs the payload with the provided private key and returns an Ed25519 signature.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const signature = Ed25519.sign({ // [!code focus]
+ *   payload: '0xdeadbeef', // [!code focus]
+ *   privateKey: '0x...' // [!code focus]
+ * }) // [!code focus]
+ * ```
+ *
+ * @param options - The signing options.
+ * @returns The Ed25519 signature.
+ */
+export function sign<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: sign.Options<as>,
+): sign.ReturnType<as> {
+  const { as = 'Hex', payload, privateKey } = options
+  const payloadBytes = Bytes.from(payload)
+  const privateKeyBytes = Bytes.from(privateKey)
+  const signatureBytes = ed25519.sign(payloadBytes, privateKeyBytes)
+  if (as === 'Hex') return Hex.fromBytes(signatureBytes) as never
+  return signatureBytes as never
+}
+
+export declare namespace sign {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned signature.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /**
+     * Payload to sign.
+     */
+    payload: Hex.Hex | Bytes.Bytes
+    /**
+     * Ed25519 private key.
+     */
+    privateKey: Hex.Hex | Bytes.Bytes
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Verifies a payload was signed by the provided public key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const { privateKey, publicKey } = Ed25519.createKeyPair()
+ * const signature = Ed25519.sign({ payload: '0xdeadbeef', privateKey })
+ *
+ * const verified = Ed25519.verify({ // [!code focus]
+ *   publicKey, // [!code focus]
+ *   payload: '0xdeadbeef', // [!code focus]
+ *   signature, // [!code focus]
+ * }) // [!code focus]
+ * ```
+ *
+ * @param options - The verification options.
+ * @returns Whether the payload was signed by the provided public key.
+ */
+export function verify(options: verify.Options): boolean {
+  const { payload, publicKey, signature } = options
+  const payloadBytes = Bytes.from(payload)
+  const publicKeyBytes = Bytes.from(publicKey)
+  const signatureBytes = Bytes.from(signature)
+  return ed25519.verify(signatureBytes, payloadBytes, publicKeyBytes)
+}
+
+export declare namespace verify {
+  type Options = {
+    /** Payload that was signed. */
+    payload: Hex.Hex | Bytes.Bytes
+    /** Public key that signed the payload. */
+    publicKey: Hex.Hex | Bytes.Bytes
+    /** Signature of the payload. */
+    signature: Hex.Hex | Bytes.Bytes
+  }
+
+  type ErrorType = Bytes.from.ErrorType | Errors.GlobalErrorType
+}

--- a/src/core/X25519.ts
+++ b/src/core/X25519.ts
@@ -1,0 +1,202 @@
+import { x25519 } from '@noble/curves/ed25519'
+import * as Bytes from './Bytes.js'
+import type * as Errors from './Errors.js'
+import * as Hex from './Hex.js'
+
+/** Re-export of noble/curves X25519 utilities. */
+export const noble = x25519
+
+/**
+ * Creates a new X25519 key pair consisting of a private key and its corresponding public key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { X25519 } from 'ox'
+ *
+ * const { privateKey, publicKey } = X25519.createKeyPair()
+ * ```
+ *
+ * @param options - The options to generate the key pair.
+ * @returns The generated key pair containing both private and public keys.
+ */
+export function createKeyPair<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: createKeyPair.Options<as> = {},
+): createKeyPair.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const privateKey = randomPrivateKey({ as })
+  const publicKey = getPublicKey({ privateKey, as })
+
+  return {
+    privateKey: privateKey as never,
+    publicKey: publicKey as never,
+  }
+}
+
+export declare namespace createKeyPair {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private and public keys.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = {
+    privateKey:
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
+      | (as extends 'Hex' ? Hex.Hex : never)
+    publicKey:
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
+      | (as extends 'Hex' ? Hex.Hex : never)
+  }
+
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
+    | randomPrivateKey.ErrorType
+    | getPublicKey.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Computes the X25519 public key from a provided private key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { X25519 } from 'ox'
+ *
+ * const publicKey = X25519.getPublicKey({ privateKey: '0x...' })
+ * ```
+ *
+ * @param options - The options to compute the public key.
+ * @returns The computed public key.
+ */
+export function getPublicKey<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: getPublicKey.Options<as>,
+): getPublicKey.ReturnType<as> {
+  const { as = 'Hex', privateKey } = options
+  const privateKeyBytes = Bytes.from(privateKey)
+  const publicKeyBytes = x25519.getPublicKey(privateKeyBytes)
+  if (as === 'Hex') return Hex.fromBytes(publicKeyBytes) as never
+  return publicKeyBytes as never
+}
+
+export declare namespace getPublicKey {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned public key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /**
+     * Private key to compute the public key from.
+     */
+    privateKey: Hex.Hex | Bytes.Bytes
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Computes a shared secret using X25519 elliptic curve Diffie-Hellman between a private key and a public key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { X25519 } from 'ox'
+ *
+ * const { privateKey: privateKeyA } = X25519.createKeyPair()
+ * const { publicKey: publicKeyB } = X25519.createKeyPair()
+ *
+ * const sharedSecret = X25519.getSharedSecret({
+ *   privateKey: privateKeyA,
+ *   publicKey: publicKeyB
+ * })
+ * ```
+ *
+ * @param options - The options to compute the shared secret.
+ * @returns The computed shared secret.
+ */
+export function getSharedSecret<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: getSharedSecret.Options<as>,
+): getSharedSecret.ReturnType<as> {
+  const { as = 'Hex', privateKey, publicKey } = options
+  const privateKeyBytes = Bytes.from(privateKey)
+  const publicKeyBytes = Bytes.from(publicKey)
+  const sharedSecretBytes = x25519.getSharedSecret(
+    privateKeyBytes,
+    publicKeyBytes,
+  )
+  if (as === 'Hex') return Hex.fromBytes(sharedSecretBytes) as never
+  return sharedSecretBytes as never
+}
+
+export declare namespace getSharedSecret {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned shared secret.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /**
+     * Private key to use for the shared secret computation.
+     */
+    privateKey: Hex.Hex | Bytes.Bytes
+    /**
+     * Public key to use for the shared secret computation.
+     */
+    publicKey: Hex.Hex | Bytes.Bytes
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Generates a random X25519 private key.
+ *
+ * @example
+ * ```ts twoslash
+ * import { X25519 } from 'ox'
+ *
+ * const privateKey = X25519.randomPrivateKey()
+ * ```
+ *
+ * @param options - The options to generate the private key.
+ * @returns The generated private key.
+ */
+export function randomPrivateKey<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: randomPrivateKey.Options<as> = {},
+): randomPrivateKey.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = x25519.utils.randomPrivateKey()
+  if (as === 'Hex') return Hex.fromBytes(bytes) as never
+  return bytes as never
+}
+
+export declare namespace randomPrivateKey {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType = Hex.fromBytes.ErrorType | Errors.GlobalErrorType
+}

--- a/src/core/_test/Ed25519.test-d.ts
+++ b/src/core/_test/Ed25519.test-d.ts
@@ -1,0 +1,155 @@
+import { attest } from '@ark/attest'
+import { Ed25519 } from 'ox'
+import { expectTypeOf, test } from 'vitest'
+
+test('createKeyPair', () => {
+  // Default behavior (Hex)
+  {
+    const keyPair = Ed25519.createKeyPair()
+    attest(keyPair).type.toString.snap()
+    expectTypeOf(keyPair.privateKey).toMatchTypeOf<`0x${string}`>()
+    expectTypeOf(keyPair.publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const keyPair = Ed25519.createKeyPair({ as: 'Hex' })
+    attest(keyPair).type.toString.snap()
+    expectTypeOf(keyPair.privateKey).toMatchTypeOf<`0x${string}`>()
+    expectTypeOf(keyPair.publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const keyPair = Ed25519.createKeyPair({ as: 'Bytes' })
+    attest(keyPair).type.toString.snap()
+    expectTypeOf(keyPair.privateKey).toMatchTypeOf<Uint8Array>()
+    expectTypeOf(keyPair.publicKey).toMatchTypeOf<Uint8Array>()
+  }
+})
+
+test('getPublicKey', () => {
+  // Default behavior (Hex)
+  {
+    const publicKey = Ed25519.getPublicKey({ privateKey: '0x1234' })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const publicKey = Ed25519.getPublicKey({ privateKey: '0x1234', as: 'Hex' })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const publicKey = Ed25519.getPublicKey({
+      privateKey: '0x1234',
+      as: 'Bytes',
+    })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<Uint8Array>()
+  }
+
+  // Bytes input
+  {
+    const publicKey = Ed25519.getPublicKey({ privateKey: new Uint8Array(32) })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+})
+
+test('randomPrivateKey', () => {
+  // Default behavior (Hex)
+  {
+    const privateKey = Ed25519.randomPrivateKey()
+    attest(privateKey).type.toString.snap()
+    expectTypeOf(privateKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const privateKey = Ed25519.randomPrivateKey({ as: 'Hex' })
+    attest(privateKey).type.toString.snap()
+    expectTypeOf(privateKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const privateKey = Ed25519.randomPrivateKey({ as: 'Bytes' })
+    attest(privateKey).type.toString.snap()
+    expectTypeOf(privateKey).toMatchTypeOf<Uint8Array>()
+  }
+})
+
+test('sign', () => {
+  // Default behavior (Hex)
+  {
+    const signature = Ed25519.sign({
+      payload: '0xdeadbeef',
+      privateKey: '0x1234',
+    })
+    attest(signature).type.toString.snap()
+    expectTypeOf(signature).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const signature = Ed25519.sign({
+      payload: '0xdeadbeef',
+      privateKey: '0x1234',
+      as: 'Hex',
+    })
+    attest(signature).type.toString.snap()
+    expectTypeOf(signature).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const signature = Ed25519.sign({
+      payload: '0xdeadbeef',
+      privateKey: '0x1234',
+      as: 'Bytes',
+    })
+    attest(signature).type.toString.snap()
+    expectTypeOf(signature).toMatchTypeOf<Uint8Array>()
+  }
+
+  // Bytes inputs
+  {
+    const signature = Ed25519.sign({
+      payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+      privateKey: new Uint8Array(32),
+    })
+    attest(signature).type.toString.snap()
+    expectTypeOf(signature).toMatchTypeOf<`0x${string}`>()
+  }
+})
+
+test('verify', () => {
+  const result = Ed25519.verify({
+    payload: '0xdeadbeef',
+    publicKey: '0x1234',
+    signature: '0x5678',
+  })
+
+  attest(result).type.toString.snap()
+  expectTypeOf(result).toMatchTypeOf<boolean>()
+
+  // With Bytes inputs
+  const resultWithBytes = Ed25519.verify({
+    payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+    publicKey: new Uint8Array(32),
+    signature: new Uint8Array(64),
+  })
+
+  expectTypeOf(resultWithBytes).toMatchTypeOf<boolean>()
+})
+
+test('noble export', () => {
+  expectTypeOf(Ed25519.noble).toMatchTypeOf<
+    typeof import('@noble/curves/ed25519').ed25519
+  >()
+})

--- a/src/core/_test/Ed25519.test.ts
+++ b/src/core/_test/Ed25519.test.ts
@@ -1,0 +1,335 @@
+import { Bytes, Ed25519, Hex } from 'ox'
+import { describe, expect, test } from 'vitest'
+
+describe('createKeyPair', () => {
+  test('default', () => {
+    const keyPair = Ed25519.createKeyPair()
+
+    expect(keyPair).toHaveProperty('privateKey')
+    expect(keyPair).toHaveProperty('publicKey')
+    expect(typeof keyPair.privateKey).toBe('string')
+    expect(typeof keyPair.publicKey).toBe('string')
+    expect(keyPair.privateKey).toMatch(/^0x[0-9a-fA-F]{64}$/)
+    expect(keyPair.publicKey).toMatch(/^0x[0-9a-fA-F]{64}$/)
+  })
+
+  test('with as: Hex', () => {
+    const keyPair = Ed25519.createKeyPair({ as: 'Hex' })
+
+    expect(keyPair).toHaveProperty('privateKey')
+    expect(keyPair).toHaveProperty('publicKey')
+    expect(typeof keyPair.privateKey).toBe('string')
+    expect(typeof keyPair.publicKey).toBe('string')
+    expect(keyPair.privateKey).toMatch(/^0x[0-9a-fA-F]{64}$/)
+    expect(keyPair.publicKey).toMatch(/^0x[0-9a-fA-F]{64}$/)
+  })
+
+  test('with as: Bytes', () => {
+    const keyPair = Ed25519.createKeyPair({ as: 'Bytes' })
+
+    expect(keyPair).toHaveProperty('privateKey')
+    expect(keyPair).toHaveProperty('publicKey')
+    expect(keyPair.privateKey).toBeInstanceOf(Uint8Array)
+    expect(keyPair.publicKey).toBeInstanceOf(Uint8Array)
+    expect(keyPair.privateKey).toHaveLength(32)
+    expect(keyPair.publicKey).toHaveLength(32)
+  })
+
+  test('unique keys', () => {
+    const keyPair1 = Ed25519.createKeyPair()
+    const keyPair2 = Ed25519.createKeyPair()
+
+    expect(keyPair1.privateKey).not.toBe(keyPair2.privateKey)
+    expect(keyPair1.publicKey).not.toBe(keyPair2.publicKey)
+  })
+})
+
+describe('getPublicKey', () => {
+  const privateKey =
+    '0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
+  const expectedPublicKey =
+    '0xd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a'
+
+  test('default (Hex)', () => {
+    const publicKey = Ed25519.getPublicKey({ privateKey })
+    expect(publicKey).toBe(expectedPublicKey)
+  })
+
+  test('with as: Hex', () => {
+    const publicKey = Ed25519.getPublicKey({ privateKey, as: 'Hex' })
+    expect(publicKey).toBe(expectedPublicKey)
+  })
+
+  test('with as: Bytes', () => {
+    const publicKey = Ed25519.getPublicKey({ privateKey, as: 'Bytes' })
+    expect(publicKey).toBeInstanceOf(Uint8Array)
+    expect(publicKey).toHaveLength(32)
+    expect(Hex.fromBytes(publicKey)).toBe(expectedPublicKey)
+  })
+
+  test('with Bytes private key', () => {
+    const privateKeyBytes = Bytes.fromHex(privateKey)
+    const publicKey = Ed25519.getPublicKey({ privateKey: privateKeyBytes })
+    expect(publicKey).toBe(expectedPublicKey)
+  })
+
+  test('with Bytes private key, as: Bytes', () => {
+    const privateKeyBytes = Bytes.fromHex(privateKey)
+    const publicKey = Ed25519.getPublicKey({
+      privateKey: privateKeyBytes,
+      as: 'Bytes',
+    })
+    expect(publicKey).toBeInstanceOf(Uint8Array)
+    expect(publicKey).toHaveLength(32)
+    expect(Hex.fromBytes(publicKey)).toBe(expectedPublicKey)
+  })
+})
+
+describe('randomPrivateKey', () => {
+  test('default (Hex)', () => {
+    const privateKey = Ed25519.randomPrivateKey()
+    expect(typeof privateKey).toBe('string')
+    expect(privateKey).toMatch(/^0x[0-9a-fA-F]{64}$/)
+  })
+
+  test('with as: Hex', () => {
+    const privateKey = Ed25519.randomPrivateKey({ as: 'Hex' })
+    expect(typeof privateKey).toBe('string')
+    expect(privateKey).toMatch(/^0x[0-9a-fA-F]{64}$/)
+  })
+
+  test('with as: Bytes', () => {
+    const privateKey = Ed25519.randomPrivateKey({ as: 'Bytes' })
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
+  })
+
+  test('unique keys', () => {
+    const privateKey1 = Ed25519.randomPrivateKey()
+    const privateKey2 = Ed25519.randomPrivateKey()
+    expect(privateKey1).not.toBe(privateKey2)
+  })
+})
+
+describe('sign', () => {
+  const privateKey =
+    '0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
+  const payload = '0xdeadbeef'
+
+  test('default (Hex)', () => {
+    const signature = Ed25519.sign({ payload, privateKey })
+    expect(typeof signature).toBe('string')
+    expect(signature).toMatch(/^0x[0-9a-fA-F]{128}$/)
+  })
+
+  test('with as: Hex', () => {
+    const signature = Ed25519.sign({ payload, privateKey, as: 'Hex' })
+    expect(typeof signature).toBe('string')
+    expect(signature).toMatch(/^0x[0-9a-fA-F]{128}$/)
+  })
+
+  test('with as: Bytes', () => {
+    const signature = Ed25519.sign({ payload, privateKey, as: 'Bytes' })
+    expect(signature).toBeInstanceOf(Uint8Array)
+    expect(signature).toHaveLength(64)
+  })
+
+  test('with Bytes payload', () => {
+    const payloadBytes = Bytes.fromHex(payload)
+    const signature = Ed25519.sign({ payload: payloadBytes, privateKey })
+    expect(typeof signature).toBe('string')
+    expect(signature).toMatch(/^0x[0-9a-fA-F]{128}$/)
+  })
+
+  test('with Bytes private key', () => {
+    const privateKeyBytes = Bytes.fromHex(privateKey)
+    const signature = Ed25519.sign({ payload, privateKey: privateKeyBytes })
+    expect(typeof signature).toBe('string')
+    expect(signature).toMatch(/^0x[0-9a-fA-F]{128}$/)
+  })
+
+  test('with all Bytes', () => {
+    const payloadBytes = Bytes.fromHex(payload)
+    const privateKeyBytes = Bytes.fromHex(privateKey)
+    const signature = Ed25519.sign({
+      payload: payloadBytes,
+      privateKey: privateKeyBytes,
+      as: 'Bytes',
+    })
+    expect(signature).toBeInstanceOf(Uint8Array)
+    expect(signature).toHaveLength(64)
+  })
+
+  test('deterministic', () => {
+    const signature1 = Ed25519.sign({ payload, privateKey })
+    const signature2 = Ed25519.sign({ payload, privateKey })
+    expect(signature1).toBe(signature2)
+  })
+
+  test('known test vector', () => {
+    // From RFC 8032 test vectors
+    const testPrivateKey =
+      '0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
+    const testPayload = '0x' // empty message
+    const signature = Ed25519.sign({
+      payload: testPayload,
+      privateKey: testPrivateKey,
+    })
+
+    expect(signature).toBe(
+      '0xe5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b',
+    )
+  })
+
+  describe('integration', () => {
+    test('sign and verify cycle', () => {
+      const { privateKey, publicKey } = Ed25519.createKeyPair()
+      const payload = '0x48656c6c6f2c20576f726c6421'
+
+      const signature = Ed25519.sign({ payload, privateKey })
+      const isValid = Ed25519.verify({ payload, publicKey, signature })
+
+      expect(isValid).toBe(true)
+    })
+
+    test('sign and verify cycle with Bytes', () => {
+      const { privateKey, publicKey } = Ed25519.createKeyPair({ as: 'Bytes' })
+      const payload = Bytes.fromString('Hello, World!')
+
+      const signature = Ed25519.sign({ payload, privateKey, as: 'Bytes' })
+      const isValid = Ed25519.verify({ payload, publicKey, signature })
+
+      expect(isValid).toBe(true)
+    })
+
+    test('multiple signatures with same key', () => {
+      const { privateKey, publicKey } = Ed25519.createKeyPair()
+      const payloads = [
+        '0x48656c6c6f',
+        '0x576f726c64',
+        '0x546573744d657373616765',
+      ] as const
+
+      for (const payload of payloads) {
+        const signature = Ed25519.sign({ payload, privateKey })
+        const isValid = Ed25519.verify({ payload, publicKey, signature })
+        expect(isValid).toBe(true)
+      }
+    })
+  })
+})
+
+describe('verify', () => {
+  const privateKey =
+    '0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
+  const publicKey =
+    '0xd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a'
+  const payload = '0xdeadbeef'
+
+  test('valid signature', () => {
+    const signature = Ed25519.sign({ payload, privateKey })
+    const isValid = Ed25519.verify({ payload, publicKey, signature })
+    expect(isValid).toBe(true)
+  })
+
+  test('invalid signature', () => {
+    const signature = ('0x' + '00'.repeat(64)) as Hex.Hex
+    const isValid = Ed25519.verify({ payload, publicKey, signature })
+    expect(isValid).toBe(false)
+  })
+
+  test('wrong payload', () => {
+    const signature = Ed25519.sign({ payload, privateKey })
+    const isValid = Ed25519.verify({
+      payload: '0xcafebabe',
+      publicKey,
+      signature,
+    })
+    expect(isValid).toBe(false)
+  })
+
+  test('wrong public key', () => {
+    const signature = Ed25519.sign({ payload, privateKey })
+    const wrongPublicKey = ('0x' + '11'.repeat(32)) as Hex.Hex
+    const isValid = Ed25519.verify({
+      payload,
+      publicKey: wrongPublicKey,
+      signature,
+    })
+    expect(isValid).toBe(false)
+  })
+
+  test('with Bytes payload', () => {
+    const payloadBytes = Bytes.fromHex(payload)
+    const signature = Ed25519.sign({ payload, privateKey })
+    const isValid = Ed25519.verify({
+      payload: payloadBytes,
+      publicKey,
+      signature,
+    })
+    expect(isValid).toBe(true)
+  })
+
+  test('with Bytes public key', () => {
+    const publicKeyBytes = Bytes.fromHex(publicKey)
+    const signature = Ed25519.sign({ payload, privateKey })
+    const isValid = Ed25519.verify({
+      payload,
+      publicKey: publicKeyBytes,
+      signature,
+    })
+    expect(isValid).toBe(true)
+  })
+
+  test('with Bytes signature', () => {
+    const signatureHex = Ed25519.sign({ payload, privateKey })
+    const signatureBytes = Bytes.fromHex(signatureHex)
+    const isValid = Ed25519.verify({
+      payload,
+      publicKey,
+      signature: signatureBytes,
+    })
+    expect(isValid).toBe(true)
+  })
+
+  test('with all Bytes', () => {
+    const payloadBytes = Bytes.fromHex(payload)
+    const publicKeyBytes = Bytes.fromHex(publicKey)
+    const signatureBytes = Ed25519.sign({
+      payload: payloadBytes,
+      privateKey,
+      as: 'Bytes',
+    })
+    const isValid = Ed25519.verify({
+      payload: payloadBytes,
+      publicKey: publicKeyBytes,
+      signature: signatureBytes,
+    })
+    expect(isValid).toBe(true)
+  })
+
+  test('known test vector', () => {
+    // From RFC 8032 test vectors
+    const testPublicKey =
+      '0xd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a'
+    const testPayload = '0x' // empty message
+    const testSignature =
+      '0xe5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b'
+
+    const isValid = Ed25519.verify({
+      payload: testPayload,
+      publicKey: testPublicKey,
+      signature: testSignature,
+    })
+    expect(isValid).toBe(true)
+  })
+})
+
+describe('noble export', () => {
+  test('exports noble curves ed25519', () => {
+    expect(Ed25519.noble).toBeDefined()
+    expect(Ed25519.noble.sign).toBeDefined()
+    expect(Ed25519.noble.verify).toBeDefined()
+    expect(Ed25519.noble.getPublicKey).toBeDefined()
+  })
+})

--- a/src/core/_test/X25519.test-d.ts
+++ b/src/core/_test/X25519.test-d.ts
@@ -1,0 +1,132 @@
+import { attest } from '@ark/attest'
+import { X25519 } from 'ox'
+import { expectTypeOf, test } from 'vitest'
+
+test('createKeyPair', () => {
+  // Default behavior (Hex)
+  {
+    const keyPair = X25519.createKeyPair()
+    attest(keyPair).type.toString.snap()
+    expectTypeOf(keyPair.privateKey).toMatchTypeOf<`0x${string}`>()
+    expectTypeOf(keyPair.publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const keyPair = X25519.createKeyPair({ as: 'Hex' })
+    attest(keyPair).type.toString.snap()
+    expectTypeOf(keyPair.privateKey).toMatchTypeOf<`0x${string}`>()
+    expectTypeOf(keyPair.publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const keyPair = X25519.createKeyPair({ as: 'Bytes' })
+    attest(keyPair).type.toString.snap()
+    expectTypeOf(keyPair.privateKey).toMatchTypeOf<Uint8Array>()
+    expectTypeOf(keyPair.publicKey).toMatchTypeOf<Uint8Array>()
+  }
+})
+
+test('getPublicKey', () => {
+  // Default behavior (Hex)
+  {
+    const publicKey = X25519.getPublicKey({ privateKey: '0x1234' })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const publicKey = X25519.getPublicKey({ privateKey: '0x1234', as: 'Hex' })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const publicKey = X25519.getPublicKey({ privateKey: '0x1234', as: 'Bytes' })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<Uint8Array>()
+  }
+
+  // Bytes input
+  {
+    const publicKey = X25519.getPublicKey({ privateKey: new Uint8Array(32) })
+    attest(publicKey).type.toString.snap()
+    expectTypeOf(publicKey).toMatchTypeOf<`0x${string}`>()
+  }
+})
+
+test('getSharedSecret', () => {
+  // Default behavior (Hex)
+  {
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: '0x1234',
+      publicKey: '0x5678',
+    })
+    attest(sharedSecret).type.toString.snap()
+    expectTypeOf(sharedSecret).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: '0x1234',
+      publicKey: '0x5678',
+      as: 'Hex',
+    })
+    attest(sharedSecret).type.toString.snap()
+    expectTypeOf(sharedSecret).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: '0x1234',
+      publicKey: '0x5678',
+      as: 'Bytes',
+    })
+    attest(sharedSecret).type.toString.snap()
+    expectTypeOf(sharedSecret).toMatchTypeOf<Uint8Array>()
+  }
+
+  // Bytes inputs
+  {
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: new Uint8Array(32),
+      publicKey: new Uint8Array(32),
+    })
+    attest(sharedSecret).type.toString.snap()
+    expectTypeOf(sharedSecret).toMatchTypeOf<`0x${string}`>()
+  }
+})
+
+test('randomPrivateKey', () => {
+  // Default behavior (Hex)
+  {
+    const privateKey = X25519.randomPrivateKey()
+    attest(privateKey).type.toString.snap()
+    expectTypeOf(privateKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Explicit Hex format
+  {
+    const privateKey = X25519.randomPrivateKey({ as: 'Hex' })
+    attest(privateKey).type.toString.snap()
+    expectTypeOf(privateKey).toMatchTypeOf<`0x${string}`>()
+  }
+
+  // Bytes format
+  {
+    const privateKey = X25519.randomPrivateKey({ as: 'Bytes' })
+    attest(privateKey).type.toString.snap()
+    expectTypeOf(privateKey).toMatchTypeOf<Uint8Array>()
+  }
+})
+
+test('noble export', () => {
+  expectTypeOf(X25519.noble).toMatchTypeOf<
+    typeof import('@noble/curves/ed25519').x25519
+  >()
+})

--- a/src/core/_test/X25519.test.ts
+++ b/src/core/_test/X25519.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from 'vitest'
+import * as Bytes from '../Bytes.js'
+import * as Hex from '../Hex.js'
+import * as X25519 from '../X25519.js'
+
+describe('noble', () => {
+  test('exports noble curves x25519', () => {
+    expect(X25519.noble).toBeDefined()
+    expect(typeof X25519.noble.getPublicKey).toBe('function')
+    expect(typeof X25519.noble.getSharedSecret).toBe('function')
+    expect(typeof X25519.noble.utils.randomPrivateKey).toBe('function')
+  })
+})
+
+describe('createKeyPair', () => {
+  test('creates key pair with default format (Hex)', () => {
+    const keyPair = X25519.createKeyPair()
+    expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/i)
+    expect(keyPair.publicKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('creates key pair with Hex format', () => {
+    const keyPair = X25519.createKeyPair({ as: 'Hex' })
+    expect(keyPair.privateKey).toMatch(/^0x[0-9a-f]{64}$/i)
+    expect(keyPair.publicKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('creates key pair with Bytes format', () => {
+    const keyPair = X25519.createKeyPair({ as: 'Bytes' })
+    expect(keyPair.privateKey).toBeInstanceOf(Uint8Array)
+    expect(keyPair.publicKey).toBeInstanceOf(Uint8Array)
+    expect(keyPair.privateKey).toHaveLength(32)
+    expect(keyPair.publicKey).toHaveLength(32)
+  })
+
+  test('creates different key pairs on each call', () => {
+    const keyPair1 = X25519.createKeyPair()
+    const keyPair2 = X25519.createKeyPair()
+    expect(keyPair1.privateKey).not.toBe(keyPair2.privateKey)
+    expect(keyPair1.publicKey).not.toBe(keyPair2.publicKey)
+  })
+
+  test('public key is derived from private key', () => {
+    const keyPair = X25519.createKeyPair()
+    const publicKey = X25519.getPublicKey({ privateKey: keyPair.privateKey })
+    expect(publicKey).toBe(keyPair.publicKey)
+  })
+})
+
+describe('getPublicKey', () => {
+  test('computes public key from private key (Hex input)', () => {
+    const privateKey =
+      '0x7777777777777777777777777777777777777777777777777777777777777777'
+    const publicKey = X25519.getPublicKey({ privateKey })
+    expect(publicKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('computes public key from private key (Bytes input)', () => {
+    const privateKey = new Uint8Array(32).fill(0x77)
+    const publicKey = X25519.getPublicKey({ privateKey })
+    expect(publicKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('returns public key in Hex format by default', () => {
+    const privateKey = X25519.randomPrivateKey()
+    const publicKey = X25519.getPublicKey({ privateKey })
+    expect(publicKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('returns public key in Hex format when specified', () => {
+    const privateKey = X25519.randomPrivateKey()
+    const publicKey = X25519.getPublicKey({ privateKey, as: 'Hex' })
+    expect(publicKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('returns public key in Bytes format when specified', () => {
+    const privateKey = X25519.randomPrivateKey()
+    const publicKey = X25519.getPublicKey({ privateKey, as: 'Bytes' })
+    expect(publicKey).toBeInstanceOf(Uint8Array)
+    expect(publicKey).toHaveLength(32)
+  })
+
+  test('is deterministic - same private key produces same public key', () => {
+    const privateKey =
+      '0x7777777777777777777777777777777777777777777777777777777777777777'
+    const publicKey1 = X25519.getPublicKey({ privateKey })
+    const publicKey2 = X25519.getPublicKey({ privateKey })
+    expect(publicKey1).toBe(publicKey2)
+  })
+
+  test('different private keys produce different public keys', () => {
+    const privateKey1 =
+      '0x7777777777777777777777777777777777777777777777777777777777777777'
+    const privateKey2 =
+      '0x8888888888888888888888888888888888888888888888888888888888888888'
+    const publicKey1 = X25519.getPublicKey({ privateKey: privateKey1 })
+    const publicKey2 = X25519.getPublicKey({ privateKey: privateKey2 })
+    expect(publicKey1).not.toBe(publicKey2)
+  })
+})
+
+describe('getSharedSecret', () => {
+  test('computes shared secret between two key pairs', () => {
+    const keyPairA = X25519.createKeyPair()
+    const keyPairB = X25519.createKeyPair()
+
+    const sharedSecretA = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+    })
+    const sharedSecretB = X25519.getSharedSecret({
+      privateKey: keyPairB.privateKey,
+      publicKey: keyPairA.publicKey,
+    })
+
+    expect(sharedSecretA).toBe(sharedSecretB)
+    expect(sharedSecretA).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('computes shared secret with Hex inputs', () => {
+    const privateKeyA =
+      '0x7777777777777777777777777777777777777777777777777777777777777777'
+    const publicKeyB = X25519.getPublicKey({
+      privateKey:
+        '0x8888888888888888888888888888888888888888888888888888888888888888',
+    })
+
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    expect(sharedSecret).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('computes shared secret with Bytes inputs', () => {
+    const privateKeyA = new Uint8Array(32).fill(0x77)
+    const publicKeyB = X25519.getPublicKey({
+      privateKey: new Uint8Array(32).fill(0x88),
+    })
+
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    expect(sharedSecret).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('returns shared secret in Hex format by default', () => {
+    const keyPairA = X25519.createKeyPair()
+    const keyPairB = X25519.createKeyPair()
+
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+    })
+
+    expect(sharedSecret).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('returns shared secret in Hex format when specified', () => {
+    const keyPairA = X25519.createKeyPair()
+    const keyPairB = X25519.createKeyPair()
+
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+      as: 'Hex',
+    })
+
+    expect(sharedSecret).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('returns shared secret in Bytes format when specified', () => {
+    const keyPairA = X25519.createKeyPair()
+    const keyPairB = X25519.createKeyPair()
+
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+      as: 'Bytes',
+    })
+
+    expect(sharedSecret).toBeInstanceOf(Uint8Array)
+    expect(sharedSecret).toHaveLength(32)
+  })
+
+  test('is deterministic - same inputs produce same shared secret', () => {
+    const privateKeyA =
+      '0x7777777777777777777777777777777777777777777777777777777777777777'
+    const publicKeyB = X25519.getPublicKey({
+      privateKey:
+        '0x8888888888888888888888888888888888888888888888888888888888888888',
+    })
+
+    const sharedSecret1 = X25519.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+    const sharedSecret2 = X25519.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+
+    expect(sharedSecret1).toBe(sharedSecret2)
+  })
+
+  test('different key pairs produce different shared secrets', () => {
+    const keyPairA = X25519.createKeyPair()
+    const keyPairB = X25519.createKeyPair()
+    const keyPairC = X25519.createKeyPair()
+
+    const sharedSecretAB = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+    })
+    const sharedSecretAC = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairC.publicKey,
+    })
+
+    expect(sharedSecretAB).not.toBe(sharedSecretAC)
+  })
+
+  test('mixed format inputs work correctly', () => {
+    const privateKeyHex =
+      '0x7777777777777777777777777777777777777777777777777777777777777777'
+    const publicKeyBytes = X25519.getPublicKey({
+      privateKey:
+        '0x8888888888888888888888888888888888888888888888888888888888888888',
+      as: 'Bytes',
+    })
+
+    const sharedSecret = X25519.getSharedSecret({
+      privateKey: privateKeyHex,
+      publicKey: publicKeyBytes,
+    })
+
+    expect(sharedSecret).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+})
+
+describe('randomPrivateKey', () => {
+  test('generates private key in Hex format by default', () => {
+    const privateKey = X25519.randomPrivateKey()
+    expect(privateKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('generates private key in Hex format when specified', () => {
+    const privateKey = X25519.randomPrivateKey({ as: 'Hex' })
+    expect(privateKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('generates private key in Bytes format when specified', () => {
+    const privateKey = X25519.randomPrivateKey({ as: 'Bytes' })
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
+  })
+
+  test('generates different private keys on each call', () => {
+    const privateKey1 = X25519.randomPrivateKey()
+    const privateKey2 = X25519.randomPrivateKey()
+    expect(privateKey1).not.toBe(privateKey2)
+  })
+
+  test('generated private keys are valid (can derive public keys)', () => {
+    const privateKey = X25519.randomPrivateKey()
+    const publicKey = X25519.getPublicKey({ privateKey })
+    expect(publicKey).toMatch(/^0x[0-9a-f]{64}$/i)
+  })
+
+  test('generated private keys work for ECDH', () => {
+    const privateKeyA = X25519.randomPrivateKey()
+    const privateKeyB = X25519.randomPrivateKey()
+    const publicKeyA = X25519.getPublicKey({ privateKey: privateKeyA })
+    const publicKeyB = X25519.getPublicKey({ privateKey: privateKeyB })
+
+    const sharedSecretA = X25519.getSharedSecret({
+      privateKey: privateKeyA,
+      publicKey: publicKeyB,
+    })
+    const sharedSecretB = X25519.getSharedSecret({
+      privateKey: privateKeyB,
+      publicKey: publicKeyA,
+    })
+
+    expect(sharedSecretA).toBe(sharedSecretB)
+  })
+})
+
+describe('error handling', () => {
+  test('handles invalid private key format', () => {
+    expect(() => {
+      X25519.getPublicKey({ privateKey: 'invalid' as any })
+    }).toThrow()
+  })
+
+  test('handles invalid public key format in getSharedSecret', () => {
+    const privateKey = X25519.randomPrivateKey()
+    expect(() => {
+      X25519.getSharedSecret({
+        privateKey,
+        publicKey: 'invalid' as any,
+      })
+    }).toThrow()
+  })
+
+  test('handles short private key', () => {
+    expect(() => {
+      X25519.getPublicKey({ privateKey: '0x1234' })
+    }).toThrow()
+  })
+
+  test('handles short public key in getSharedSecret', () => {
+    const privateKey = X25519.randomPrivateKey()
+    expect(() => {
+      X25519.getSharedSecret({
+        privateKey,
+        publicKey: '0x1234',
+      })
+    }).toThrow()
+  })
+})
+
+describe('format conversion consistency', () => {
+  test('Hex and Bytes formats represent same values', () => {
+    const privateKeyHex =
+      '0x7777777777777777777777777777777777777777777777777777777777777777'
+    const privateKeyBytes = Bytes.from(privateKeyHex)
+
+    const publicKeyHex = X25519.getPublicKey({
+      privateKey: privateKeyHex,
+      as: 'Hex',
+    })
+    const publicKeyBytes = X25519.getPublicKey({
+      privateKey: privateKeyBytes,
+      as: 'Bytes',
+    })
+
+    expect(Hex.fromBytes(publicKeyBytes)).toBe(publicKeyHex)
+  })
+
+  test('shared secret format conversion consistency', () => {
+    const keyPairA = X25519.createKeyPair()
+    const keyPairB = X25519.createKeyPair()
+
+    const sharedSecretHex = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+      as: 'Hex',
+    })
+    const sharedSecretBytes = X25519.getSharedSecret({
+      privateKey: keyPairA.privateKey,
+      publicKey: keyPairB.publicKey,
+      as: 'Bytes',
+    })
+
+    expect(Hex.fromBytes(sharedSecretBytes)).toBe(sharedSecretHex)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1337,6 +1337,38 @@ export * as Caches from './core/Caches.js'
 export * as ContractAddress from './core/ContractAddress.js'
 
 /**
+ * Utilities for working with Ed25519 signatures and key pairs.
+ *
+ * Ed25519 is a modern elliptic curve signature scheme that provides strong security
+ * guarantees and high performance. It is widely used in various cryptographic applications.
+ *
+ * @example
+ * ### Creating Key Pairs
+ *
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const { privateKey, publicKey } = Ed25519.createKeyPair()
+ * ```
+ *
+ * @example
+ * ### Signing & Verifying
+ *
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const { privateKey, publicKey } = Ed25519.createKeyPair()
+ * const payload = '0xdeadbeef'
+ *
+ * const signature = Ed25519.sign({ payload, privateKey })
+ * const isValid = Ed25519.verify({ payload, publicKey, signature })
+ * ```
+ *
+ * @category Cryptography
+ */
+export * as Ed25519 from './core/Ed25519.js'
+
+/**
  * Utility functions for working with ENS names.
  *
  * @example
@@ -3515,3 +3547,38 @@ export * as WebCryptoP256 from './core/WebCryptoP256.js'
  * @category Execution Spec
  */
 export * as Withdrawal from './core/Withdrawal.js'
+
+/**
+ * Utilities for working with X25519 elliptic curve Diffie-Hellman key agreement.
+ *
+ * X25519 is a high-performance elliptic curve that can be used to perform
+ * Diffie-Hellman key agreement to derive shared secrets between parties.
+ * It is designed for use with the elliptic curve Diffie-Hellman (ECDH) key agreement scheme.
+ *
+ * @example
+ * ### Creating Key Pairs
+ *
+ * ```ts twoslash
+ * import { X25519 } from 'ox'
+ *
+ * const { privateKey, publicKey } = X25519.createKeyPair()
+ * ```
+ *
+ * @example
+ * ### Deriving Shared Secrets
+ *
+ * ```ts twoslash
+ * import { X25519 } from 'ox'
+ *
+ * const { privateKey: privateKeyA } = X25519.createKeyPair()
+ * const { publicKey: publicKeyB } = X25519.createKeyPair()
+ *
+ * const sharedSecret = X25519.getSharedSecret({
+ *   privateKey: privateKeyA,
+ *   publicKey: publicKeyB
+ * })
+ * ```
+ *
+ * @category Cryptography
+ */
+export * as X25519 from './core/X25519.js'


### PR DESCRIPTION
### Summary

Added comprehensive Ed25519 and X25519 cryptographic modules to the core library, providing digital signature capabilities and secure key agreement functionality.

### Details

- Added `Ed25519` module with functions for key pair generation, message signing, signature verification, and random key generation
- Added `X25519` module with functions for key pair generation, shared secret computation via ECDH, and random key generation  
- Both modules support flexible output formats (Hex or Bytes) with TypeScript type safety
- Integrated with @noble/curves library for cryptographic operations
- Added comprehensive test suites including unit tests and type-level tests
- Added changeset documenting the new functionality
- All functions follow existing codebase patterns and conventions

### Modules Touched

- Ed25519: `Ed25519`
- X25519: `X25519`

🤖 Generated with [Claude Code](https://claude.ai/code)