### PR TITLE
fix: rm invalid pure annotations preeceding the variable assignments

### DIFF
--- a/src/core/Address.ts
+++ b/src/core/Address.ts
@@ -5,7 +5,7 @@ import * as Errors from './Errors.js'
 import * as Hash from './Hash.js'
 import * as PublicKey from './PublicKey.js'
 
-const addressRegex = /*#__PURE__*/ /^0x[a-fA-F0-9]{40}$/
+const addressRegex = /^0x[a-fA-F0-9]{40}$/
 
 /** Root type for Address. */
 export type Address = abitype_Address

--- a/src/core/internal/cursor.ts
+++ b/src/core/internal/cursor.ts
@@ -37,7 +37,7 @@ export type Cursor = {
   _touch(): void
 }
 
-const staticCursor: Cursor = /*#__PURE__*/ {
+const staticCursor: Cursor = {
   bytes: new Uint8Array(),
   dataView: new DataView(new ArrayBuffer(0)),
   position: 0,


### PR DESCRIPTION
fixes #73

seems like pure annotations are useless when used before variable assignment. 
since I saw warnings in the rollup, I removed those annotations.

```js
const foo /* #__PURE__ */ = pureOperation(); // INVALID: "=" not allowed after annotation
```
[Reference to the spec](https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md#1-directly-preceding-a-call)

