### PR TITLE
feat(erc4337): support entrypoint v0.8

### DIFF
--- a/.changeset/wild-mangos-applaud.md
+++ b/.changeset/wild-mangos-applaud.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Added support for EntryPoint 0.8.

--- a/src/erc4337/EntryPoint.ts
+++ b/src/erc4337/EntryPoint.ts
@@ -3,7 +3,7 @@
  *
  * @see https://github.com/eth-infinitism/account-abstraction/releases
  */
-export type Version = '0.6' | '0.7'
+export type Version = '0.6' | '0.7' | '0.8'
 
 /** EntryPoint 0.6 ABI. */
 export const abiV06 = [
@@ -1412,8 +1412,703 @@ export const abiV07 = [
   { stateMutability: 'payable', type: 'receive' },
 ] as const
 
+/** EntryPoint 0.8 ABI. */
+export const abiV08 = [
+  { inputs: [], stateMutability: 'nonpayable', type: 'constructor' },
+  {
+    inputs: [
+      { internalType: 'bool', name: 'success', type: 'bool' },
+      { internalType: 'bytes', name: 'ret', type: 'bytes' },
+    ],
+    name: 'DelegateAndRevert',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'opIndex', type: 'uint256' },
+      { internalType: 'string', name: 'reason', type: 'string' },
+    ],
+    name: 'FailedOp',
+    type: 'error',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'opIndex', type: 'uint256' },
+      { internalType: 'string', name: 'reason', type: 'string' },
+      { internalType: 'bytes', name: 'inner', type: 'bytes' },
+    ],
+    name: 'FailedOpWithRevert',
+    type: 'error',
+  },
+  { inputs: [], name: 'InvalidShortString', type: 'error' },
+  {
+    inputs: [{ internalType: 'bytes', name: 'returnData', type: 'bytes' }],
+    name: 'PostOpReverted',
+    type: 'error',
+  },
+  { inputs: [], name: 'ReentrancyGuardReentrantCall', type: 'error' },
+  {
+    inputs: [{ internalType: 'address', name: 'sender', type: 'address' }],
+    name: 'SenderAddressResult',
+    type: 'error',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'aggregator', type: 'address' }],
+    name: 'SignatureValidationFailed',
+    type: 'error',
+  },
+  {
+    inputs: [{ internalType: 'string', name: 'str', type: 'string' }],
+    name: 'StringTooLong',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'factory',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'paymaster',
+        type: 'address',
+      },
+    ],
+    name: 'AccountDeployed',
+    type: 'event',
+  },
+  { anonymous: false, inputs: [], name: 'BeforeExecution', type: 'event' },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalDeposit',
+        type: 'uint256',
+      },
+    ],
+    name: 'Deposited',
+    type: 'event',
+  },
+  { anonymous: false, inputs: [], name: 'EIP712DomainChanged', type: 'event' },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'revertReason',
+        type: 'bytes',
+      },
+    ],
+    name: 'PostOpRevertReason',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'aggregator',
+        type: 'address',
+      },
+    ],
+    name: 'SignatureAggregatorChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalStaked',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'unstakeDelaySec',
+        type: 'uint256',
+      },
+    ],
+    name: 'StakeLocked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'withdrawTime',
+        type: 'uint256',
+      },
+    ],
+    name: 'StakeUnlocked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'StakeWithdrawn',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'paymaster',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+      { indexed: false, internalType: 'bool', name: 'success', type: 'bool' },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'actualGasCost',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'actualGasUsed',
+        type: 'uint256',
+      },
+    ],
+    name: 'UserOperationEvent',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+    ],
+    name: 'UserOperationPrefundTooLow',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'userOpHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'nonce',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'revertReason',
+        type: 'bytes',
+      },
+    ],
+    name: 'UserOperationRevertReason',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdrawn',
+    type: 'event',
+  },
+  {
+    inputs: [
+      { internalType: 'uint32', name: 'unstakeDelaySec', type: 'uint32' },
+    ],
+    name: 'addStake',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'target', type: 'address' },
+      { internalType: 'bytes', name: 'data', type: 'bytes' },
+    ],
+    name: 'delegateAndRevert',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'depositTo',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'eip712Domain',
+    outputs: [
+      { internalType: 'bytes1', name: 'fields', type: 'bytes1' },
+      { internalType: 'string', name: 'name', type: 'string' },
+      { internalType: 'string', name: 'version', type: 'string' },
+      { internalType: 'uint256', name: 'chainId', type: 'uint256' },
+      { internalType: 'address', name: 'verifyingContract', type: 'address' },
+      { internalType: 'bytes32', name: 'salt', type: 'bytes32' },
+      { internalType: 'uint256[]', name: 'extensions', type: 'uint256[]' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'getDepositInfo',
+    outputs: [
+      {
+        components: [
+          { internalType: 'uint256', name: 'deposit', type: 'uint256' },
+          { internalType: 'bool', name: 'staked', type: 'bool' },
+          { internalType: 'uint112', name: 'stake', type: 'uint112' },
+          { internalType: 'uint32', name: 'unstakeDelaySec', type: 'uint32' },
+          { internalType: 'uint48', name: 'withdrawTime', type: 'uint48' },
+        ],
+        internalType: 'struct IStakeManager.DepositInfo',
+        name: 'info',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getDomainSeparatorV4',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'sender', type: 'address' },
+      { internalType: 'uint192', name: 'key', type: 'uint192' },
+    ],
+    name: 'getNonce',
+    outputs: [{ internalType: 'uint256', name: 'nonce', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getPackedUserOpTypeHash',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'bytes', name: 'initCode', type: 'bytes' }],
+    name: 'getSenderAddress',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          {
+            internalType: 'bytes32',
+            name: 'accountGasLimits',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { internalType: 'bytes32', name: 'gasFees', type: 'bytes32' },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct PackedUserOperation',
+        name: 'userOp',
+        type: 'tuple',
+      },
+    ],
+    name: 'getUserOpHash',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+              { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+              { internalType: 'bytes', name: 'callData', type: 'bytes' },
+              {
+                internalType: 'bytes32',
+                name: 'accountGasLimits',
+                type: 'bytes32',
+              },
+              {
+                internalType: 'uint256',
+                name: 'preVerificationGas',
+                type: 'uint256',
+              },
+              { internalType: 'bytes32', name: 'gasFees', type: 'bytes32' },
+              {
+                internalType: 'bytes',
+                name: 'paymasterAndData',
+                type: 'bytes',
+              },
+              { internalType: 'bytes', name: 'signature', type: 'bytes' },
+            ],
+            internalType: 'struct PackedUserOperation[]',
+            name: 'userOps',
+            type: 'tuple[]',
+          },
+          {
+            internalType: 'contract IAggregator',
+            name: 'aggregator',
+            type: 'address',
+          },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct IEntryPoint.UserOpsPerAggregator[]',
+        name: 'opsPerAggregator',
+        type: 'tuple[]',
+      },
+      { internalType: 'address payable', name: 'beneficiary', type: 'address' },
+    ],
+    name: 'handleAggregatedOps',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'sender', type: 'address' },
+          { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+          { internalType: 'bytes', name: 'initCode', type: 'bytes' },
+          { internalType: 'bytes', name: 'callData', type: 'bytes' },
+          {
+            internalType: 'bytes32',
+            name: 'accountGasLimits',
+            type: 'bytes32',
+          },
+          {
+            internalType: 'uint256',
+            name: 'preVerificationGas',
+            type: 'uint256',
+          },
+          { internalType: 'bytes32', name: 'gasFees', type: 'bytes32' },
+          { internalType: 'bytes', name: 'paymasterAndData', type: 'bytes' },
+          { internalType: 'bytes', name: 'signature', type: 'bytes' },
+        ],
+        internalType: 'struct PackedUserOperation[]',
+        name: 'ops',
+        type: 'tuple[]',
+      },
+      { internalType: 'address payable', name: 'beneficiary', type: 'address' },
+    ],
+    name: 'handleOps',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint192', name: 'key', type: 'uint192' }],
+    name: 'incrementNonce',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'bytes', name: 'callData', type: 'bytes' },
+      {
+        components: [
+          {
+            components: [
+              { internalType: 'address', name: 'sender', type: 'address' },
+              { internalType: 'uint256', name: 'nonce', type: 'uint256' },
+              {
+                internalType: 'uint256',
+                name: 'verificationGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'callGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'paymasterVerificationGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'paymasterPostOpGasLimit',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'preVerificationGas',
+                type: 'uint256',
+              },
+              { internalType: 'address', name: 'paymaster', type: 'address' },
+              {
+                internalType: 'uint256',
+                name: 'maxFeePerGas',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'maxPriorityFeePerGas',
+                type: 'uint256',
+              },
+            ],
+            internalType: 'struct EntryPoint.MemoryUserOp',
+            name: 'mUserOp',
+            type: 'tuple',
+          },
+          { internalType: 'bytes32', name: 'userOpHash', type: 'bytes32' },
+          { internalType: 'uint256', name: 'prefund', type: 'uint256' },
+          { internalType: 'uint256', name: 'contextOffset', type: 'uint256' },
+          { internalType: 'uint256', name: 'preOpGas', type: 'uint256' },
+        ],
+        internalType: 'struct EntryPoint.UserOpInfo',
+        name: 'opInfo',
+        type: 'tuple',
+      },
+      { internalType: 'bytes', name: 'context', type: 'bytes' },
+    ],
+    name: 'innerHandleOp',
+    outputs: [
+      { internalType: 'uint256', name: 'actualGasCost', type: 'uint256' },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: '', type: 'address' },
+      { internalType: 'uint192', name: '', type: 'uint192' },
+    ],
+    name: 'nonceSequenceNumber',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'senderCreator',
+    outputs: [
+      { internalType: 'contract ISenderCreator', name: '', type: 'address' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'bytes4', name: 'interfaceId', type: 'bytes4' }],
+    name: 'supportsInterface',
+    outputs: [{ internalType: 'bool', name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'unlockStake',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+    ],
+    name: 'withdrawStake',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address payable',
+        name: 'withdrawAddress',
+        type: 'address',
+      },
+      { internalType: 'uint256', name: 'withdrawAmount', type: 'uint256' },
+    ],
+    name: 'withdrawTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  { stateMutability: 'payable', type: 'receive' },
+] as const
+
 /** EntryPoint 0.6 address. */
 export const addressV06 = '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789' as const
 
 /** EntryPoint 0.7 address. */
 export const addressV07 = '0x0000000071727De22E5E9d8BAf0edAc6f37da032' as const
+
+/** EntryPoint 0.8 address. */
+export const addressV08 = '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108' as const

--- a/src/erc4337/UserOperation.ts
+++ b/src/erc4337/UserOperation.ts
@@ -546,6 +546,7 @@ export declare namespace hash {
  *
  * @example
  * ```ts twoslash
+ * import { Value } from 'ox'
  * import { UserOperation } from 'ox/erc4337'
  *
  * const initCode = UserOperation.toInitCode({
@@ -553,7 +554,7 @@ export declare namespace hash {
  *     address: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
  *     chainId: 1,
  *     nonce: 69n,
- *     yParity: 0n,
+ *     yParity: 0,
  *     r: 1n,
  *     s: 2n,
  *   },
@@ -572,12 +573,7 @@ export declare namespace hash {
  * @param userOperation - The user operation to convert.
  * @returns The init code.
  */
-export function toInitCode(
-  userOperation: Pick<
-    UserOperation,
-    'authorization' | 'factory' | 'factoryData'
-  >,
-): Hex.Hex {
+export function toInitCode(userOperation: Partial<UserOperation>): Hex.Hex {
   const { authorization, factory, factoryData } = userOperation
   if (
     factory === '0x7702' ||
@@ -740,7 +736,7 @@ export declare namespace toRpc {
  *     chainId: 1,
  *     address: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
  *     nonce: 69n,
- *     yParity: 0n,
+ *     yParity: 0,
  *     r: 1n,
  *     s: 2n,
  *   },
@@ -751,7 +747,11 @@ export declare namespace toRpc {
  *   nonce: 69n,
  *   preVerificationGas: 100_000n,
  *   sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+ *   signature: '0x...',
  *   verificationGasLimit: 100_000n,
+ * }, {
+ *   chainId: 1,
+ *   entryPointAddress: '0x1234567890123456789012345678901234567890',
  * })
  * ```
  *

--- a/src/erc4337/_test/UserOperation.test.ts
+++ b/src/erc4337/_test/UserOperation.test.ts
@@ -145,6 +145,245 @@ describe('getSignPayload', () => {
 })
 
 describe('hash', () => {
+  describe('v0.8', () => {
+    test('default', () => {
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0xa2224e732a1d4e2f923c7c05d586a0aa6cbc42172ec02f31d35fa9a2b8ba9208"`,
+      )
+    })
+
+    test('args: factory + factoryData', () => {
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            factory: '0x1234567890123456789012345678901234567890',
+            factoryData: '0xdeadbeef',
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0x3146c70a9ef7538e9b9aca8b00ad4b127ca7eef7817a557f1801acbf8d68c206"`,
+      )
+    })
+
+    test('args: paymaster', () => {
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0x364bff8f9104a3854dce4f61f8479ce3019a3bd23e1c8db4da0d7c22850835b9"`,
+      )
+    })
+
+    test('args: paymasterVerificationGasLimit', () => {
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+            paymasterVerificationGasLimit: 6942069n,
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0x9cb735eb4278caf0a9f53ad81e5f592e965c9d034f6e2780befa4cd09a990b04"`,
+      )
+    })
+
+    test('args: paymasterPostOpGasLimit', () => {
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+            paymasterVerificationGasLimit: 6942069n,
+            paymasterPostOpGasLimit: 6942069n,
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0x745602113988c3a6f18215d96eecc85775998dcb190e374a0955e637d40fe018"`,
+      )
+    })
+
+    test('args: paymasterData', () => {
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+            paymasterVerificationGasLimit: 6942069n,
+            paymasterPostOpGasLimit: 6942069n,
+            paymasterData: '0xdeadbeef',
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0xf10ef9afcf27a4fd17e477cd19f37e588e3ff7d48eade07ab5b7eb8caf75667f"`,
+      )
+    })
+
+    test('args: authorization', () => {
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+            paymasterVerificationGasLimit: 6942069n,
+            paymasterPostOpGasLimit: 6942069n,
+            paymasterData: '0xdeadbeef',
+            factory: '0x7702',
+            factoryData: '0xdeadbeef',
+            authorization: {
+              address: '0x1234567890123456789012345678901234567890',
+              chainId: 1,
+              nonce: 0n,
+              yParity: 0,
+              r: 0n,
+              s: 0n,
+            },
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0xd96232eb5d02f483166b9b23dca3ec2b963d70f09b961fce348c51d306278462"`,
+      )
+
+      expect(
+        UserOperation.hash(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+            paymasterVerificationGasLimit: 6942069n,
+            paymasterPostOpGasLimit: 6942069n,
+            paymasterData: '0xdeadbeef',
+            factory: '0x7702',
+            authorization: {
+              address: '0x1234567890123456789012345678901234567890',
+              chainId: 1,
+              nonce: 0n,
+              yParity: 0,
+              r: 0n,
+              s: 0n,
+            },
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+            entryPointVersion: '0.8',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `"0x66fe6eaaaf1d6727d404384354a720cb24694c697bfbab77b3d02345c2d6e1da"`,
+      )
+    })
+  })
+
   describe('v0.7', () => {
     test('default', () => {
       const hash = UserOperation.hash(
@@ -511,6 +750,109 @@ describe('toPacked', () => {
   })
 })
 
+describe('toInitCode', () => {
+  test('behavior: no factory', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: undefined,
+        factoryData: undefined,
+        authorization: undefined,
+      }),
+    ).toBe('0x')
+  })
+
+  test('behavior: regular factory without factoryData', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: '0x1234567890123456789012345678901234567890',
+        factoryData: undefined,
+        authorization: undefined,
+      }),
+    ).toBe('0x1234567890123456789012345678901234567890')
+  })
+
+  test('behavior: regular factory with factoryData', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: '0x1234567890123456789012345678901234567890',
+        factoryData: '0xdeadbeef',
+        authorization: undefined,
+      }),
+    ).toBe('0x1234567890123456789012345678901234567890deadbeef')
+  })
+
+  test('behavior: ERC-7702 factory (short form) without authorization', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: '0x7702',
+        factoryData: undefined,
+        authorization: undefined,
+      }),
+    ).toBe('0x7702000000000000000000000000000000000000')
+  })
+
+  test('behavior: ERC-7702 factory (full form) without authorization', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: '0x7702000000000000000000000000000000000000',
+        factoryData: undefined,
+        authorization: undefined,
+      }),
+    ).toBe('0x7702000000000000000000000000000000000000')
+  })
+
+  test('behavior: ERC-7702 factory with authorization and no factoryData', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: '0x7702',
+        factoryData: undefined,
+        authorization: {
+          address: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+          chainId: 1,
+          nonce: 69n,
+          yParity: 0,
+          r: 1n,
+          s: 2n,
+        },
+      }),
+    ).toBe('0x9f1fdab6458c5fc642fa0f4c5af7473c46837357')
+  })
+
+  test('behavior: ERC-7702 factory with authorization and factoryData', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: '0x7702',
+        factoryData: '0xdeadbeef',
+        authorization: {
+          address: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+          chainId: 1,
+          nonce: 69n,
+          yParity: 0,
+          r: 1n,
+          s: 2n,
+        },
+      }),
+    ).toBe('0x9f1fdab6458c5fc642fa0f4c5af7473c46837357deadbeef')
+  })
+
+  test('behavior: ERC-7702 factory (full form) with authorization and factoryData', () => {
+    expect(
+      UserOperation.toInitCode({
+        factory: '0x7702000000000000000000000000000000000000',
+        factoryData: '0xcafebabe',
+        authorization: {
+          address: '0x1234567890123456789012345678901234567890',
+          chainId: 1,
+          nonce: 42n,
+          yParity: 1,
+          r: 123n,
+          s: 456n,
+        },
+      }),
+    ).toBe('0x1234567890123456789012345678901234567890cafebabe')
+  })
+})
+
 describe('toRpc', () => {
   test('default', () => {
     expect(
@@ -576,5 +918,277 @@ describe('toRpc', () => {
         "verificationGasLimit": "0x186a0",
       }
     `)
+  })
+})
+
+describe('toTypedData', () => {
+  describe('v0.8', () => {
+    test('default', () => {
+      expect(
+        UserOperation.toTypedData(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `
+        {
+          "domain": {
+            "chainId": 1,
+            "name": "ERC4337",
+            "verifyingContract": "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+            "version": "1",
+          },
+          "message": {
+            "accountGasLimits": "0x0000000000000000000000000069ed750000000000000000000000000069ed75",
+            "callData": "0x",
+            "gasFees": "0x0000000000000000000000000000004500000000000000000000000000010f2c",
+            "initCode": "0x",
+            "nonce": 0n,
+            "paymasterAndData": "0x",
+            "preVerificationGas": 6942069n,
+            "sender": "0x1234567890123456789012345678901234567890",
+            "signature": "0x",
+          },
+          "primaryType": "PackedUserOperation",
+          "types": {
+            "PackedUserOperation": [
+              {
+                "name": "sender",
+                "type": "address",
+              },
+              {
+                "name": "nonce",
+                "type": "uint256",
+              },
+              {
+                "name": "initCode",
+                "type": "bytes",
+              },
+              {
+                "name": "callData",
+                "type": "bytes",
+              },
+              {
+                "name": "accountGasLimits",
+                "type": "bytes32",
+              },
+              {
+                "name": "preVerificationGas",
+                "type": "uint256",
+              },
+              {
+                "name": "gasFees",
+                "type": "bytes32",
+              },
+              {
+                "name": "paymasterAndData",
+                "type": "bytes",
+              },
+            ],
+          },
+        }
+      `,
+      )
+    })
+
+    test('args: authorization', () => {
+      expect(
+        UserOperation.toTypedData(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+            paymasterVerificationGasLimit: 6942069n,
+            paymasterPostOpGasLimit: 6942069n,
+            paymasterData: '0xdeadbeef',
+            factory: '0x7702',
+            factoryData: '0xdeadbeef',
+            authorization: {
+              address: '0x1234567890123456789012345678901234567890',
+              chainId: 1,
+              nonce: 0n,
+              yParity: 0,
+              r: 1n,
+              s: 2n,
+            },
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `
+        {
+          "domain": {
+            "chainId": 1,
+            "name": "ERC4337",
+            "verifyingContract": "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+            "version": "1",
+          },
+          "message": {
+            "accountGasLimits": "0x0000000000000000000000000069ed750000000000000000000000000069ed75",
+            "callData": "0x",
+            "gasFees": "0x0000000000000000000000000000004500000000000000000000000000010f2c",
+            "initCode": "0x1234567890123456789012345678901234567890deadbeef",
+            "nonce": 0n,
+            "paymasterAndData": "0x12345678901234567890123456789012345678900000000000000000000000000069ed750000000000000000000000000069ed75deadbeef",
+            "preVerificationGas": 6942069n,
+            "sender": "0x1234567890123456789012345678901234567890",
+            "signature": "0x",
+          },
+          "primaryType": "PackedUserOperation",
+          "types": {
+            "PackedUserOperation": [
+              {
+                "name": "sender",
+                "type": "address",
+              },
+              {
+                "name": "nonce",
+                "type": "uint256",
+              },
+              {
+                "name": "initCode",
+                "type": "bytes",
+              },
+              {
+                "name": "callData",
+                "type": "bytes",
+              },
+              {
+                "name": "accountGasLimits",
+                "type": "bytes32",
+              },
+              {
+                "name": "preVerificationGas",
+                "type": "uint256",
+              },
+              {
+                "name": "gasFees",
+                "type": "bytes32",
+              },
+              {
+                "name": "paymasterAndData",
+                "type": "bytes",
+              },
+            ],
+          },
+        }
+      `,
+      )
+
+      expect(
+        UserOperation.toTypedData(
+          {
+            callData: '0x',
+            callGasLimit: 6942069n,
+            maxFeePerGas: 69420n,
+            maxPriorityFeePerGas: 69n,
+            nonce: 0n,
+            preVerificationGas: 6942069n,
+            sender: '0x1234567890123456789012345678901234567890',
+            signature: '0x',
+            verificationGasLimit: 6942069n,
+            paymaster: '0x1234567890123456789012345678901234567890',
+            paymasterVerificationGasLimit: 6942069n,
+            paymasterPostOpGasLimit: 6942069n,
+            paymasterData: '0xdeadbeef',
+            factory: '0x7702',
+            authorization: {
+              address: '0x1234567890123456789012345678901234567890',
+              chainId: 1,
+              nonce: 0n,
+              yParity: 0,
+              r: 1n,
+              s: 2n,
+            },
+          },
+          {
+            chainId: 1,
+            entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+          },
+        ),
+      ).toMatchInlineSnapshot(
+        `
+        {
+          "domain": {
+            "chainId": 1,
+            "name": "ERC4337",
+            "verifyingContract": "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+            "version": "1",
+          },
+          "message": {
+            "accountGasLimits": "0x0000000000000000000000000069ed750000000000000000000000000069ed75",
+            "callData": "0x",
+            "gasFees": "0x0000000000000000000000000000004500000000000000000000000000010f2c",
+            "initCode": "0x1234567890123456789012345678901234567890",
+            "nonce": 0n,
+            "paymasterAndData": "0x12345678901234567890123456789012345678900000000000000000000000000069ed750000000000000000000000000069ed75deadbeef",
+            "preVerificationGas": 6942069n,
+            "sender": "0x1234567890123456789012345678901234567890",
+            "signature": "0x",
+          },
+          "primaryType": "PackedUserOperation",
+          "types": {
+            "PackedUserOperation": [
+              {
+                "name": "sender",
+                "type": "address",
+              },
+              {
+                "name": "nonce",
+                "type": "uint256",
+              },
+              {
+                "name": "initCode",
+                "type": "bytes",
+              },
+              {
+                "name": "callData",
+                "type": "bytes",
+              },
+              {
+                "name": "accountGasLimits",
+                "type": "bytes32",
+              },
+              {
+                "name": "preVerificationGas",
+                "type": "uint256",
+              },
+              {
+                "name": "gasFees",
+                "type": "bytes32",
+              },
+              {
+                "name": "paymasterAndData",
+                "type": "bytes",
+              },
+            ],
+          },
+        }
+      `,
+      )
+    })
   })
 })


### PR DESCRIPTION
## Summary

Added support for EntryPoint 0.8 in the ERC-4337 module, including new ABI definitions, address constants, and updated UserOperation types and functions.

## Details

- Added `abiV08` constant with EntryPoint 0.8 ABI definitions
- Added `addressV08` constant for EntryPoint 0.8 address
- Extended `Version` type to include '0.8'
- Added `V08` UserOperation type with new fields for authorization, factory/factoryData separation, and paymaster gas limits
- Implemented `toInitCode` function for converting UserOperation to init code format
- Added `toTypedData` function for EIP-712 typed data conversion (EntryPoint 0.8 specific)
- Updated `hash` function to support EntryPoint 0.8 with EIP-712 signature verification
- Updated `toPacked` function to work with both 0.7 and 0.8 versions
- Added comprehensive test coverage for all new functionality

## Modules Touched

- ERC-4337 EntryPoint: `EntryPoint`
- ERC-4337 UserOperation: `UserOperation`

🤖 Generated with [Claude Code](https://claude.ai/code)