### PR TITLE
refactor: add micro-optimizations

### DIFF
--- a/src/core/Bytes.ts
+++ b/src/core/Bytes.ts
@@ -231,7 +231,7 @@ export function fromHex(value: Hex.Hex, options: fromHex.Options = {}): Bytes {
         `Invalid byte sequence ("${hexString[j - 2]}${hexString[j - 1]}" in "${hexString}").`,
       )
     }
-    bytes[index] = nibbleLeft * 16 + nibbleRight
+    bytes[index] = (nibbleLeft << 4) | nibbleRight
   }
   return bytes
 }

--- a/src/core/Hex.ts
+++ b/src/core/Hex.ts
@@ -256,7 +256,7 @@ export function fromNumber(
   }
 
   const stringValue = (
-    signed && value_ < 0 ? (1n << BigInt(size * 8)) + BigInt(value_) : value_
+    signed && value_ < 0 ? BigInt.asUintN(size * 8, BigInt(value_)) : value_
   ).toString(16)
 
   const hex = `0x${stringValue}` as Hex

--- a/src/core/Rlp.ts
+++ b/src/core/Rlp.ts
@@ -359,9 +359,9 @@ function getEncodableBytes(bytesOrHex: Bytes.Bytes | Hex.Hex): Encodable {
 }
 
 function getSizeOfLength(length: number) {
-  if (length < 2 ** 8) return 1
-  if (length < 2 ** 16) return 2
-  if (length < 2 ** 24) return 3
-  if (length < 2 ** 32) return 4
+  if (length <= 0xff) return 1
+  if (length <= 0xff_ff) return 2
+  if (length <= 0xff_ff_ff) return 3
+  if (length <= 0xff_ff_ff_ff) return 4
   throw new Errors.BaseError('Length is too large.')
 }


### PR DESCRIPTION
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/ox/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Ox!
----------------------------------------------------------------------->
Adds a few micro-optimizations:

1. Switches to bitwise operators in `Bytes.fromHex` when combining nibbles.
2. Switches to `BigInt.asUintN` for two's complement conversions in `Hex.fromNumber`.
3. Switches to hardcoded hex numbers in `getSizeOfLength` (Rlp.ts) which has the added benefit of creating a visual association between the number returned and the number of hex pairs.
