### PR TITLE
docs: fix incorrect examples of `Address.from` checksum behaviour

### DIFF
--- a/src/core/Address.ts
+++ b/src/core/Address.ts
@@ -112,14 +112,14 @@ export declare namespace checksum {
 }
 
 /**
- * Converts a stringified address to a typed (checksummed) {@link ox#Address.Address}.
+ * Converts a stringified address to a typed (optionally checksummed) {@link ox#Address.Address}.
  *
  * @example
  * ```ts twoslash
  * import { Address } from 'ox'
  *
  * Address.from('0xa0cf798816d4b9b9866b5330eea46a18382f251e')
- * // @log: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e'
+ * // @log: '0xa0cf798816d4b9b9866b5330eea46a18382f251e'
  * ```
  *
  * @example
@@ -127,9 +127,9 @@ export declare namespace checksum {
  * import { Address } from 'ox'
  *
  * Address.from('0xa0cf798816d4b9b9866b5330eea46a18382f251e', {
- *   checksum: false
+ *   checksum: true
  * })
- * // @log: '0xa0cf798816d4b9b9866b5330eea46a18382f251e'
+ * // @log: '0xA0Cf798816D4b9b9866b5330EEa46a18382f251e'
  * ```
  *
  * @example


### PR DESCRIPTION
Updated documentation to clarify checksumming behavior.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/wevm/ox/blob/main/.github/CONTRIBUTING.md
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us review it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR, but pass with it.

Thank you for contributing to Ox!
----------------------------------------------------------------------->

