### PR TITLE
feat(Base64): lenient decoding to match Rust SDK

### DIFF
--- a/.changeset/gentle-bytes-decode.md
+++ b/.changeset/gentle-bytes-decode.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Updated Base64.toBytes to strip invalid characters before decoding for lenient parsing.

--- a/src/core/Base64.ts
+++ b/src/core/Base64.ts
@@ -238,7 +238,7 @@ export declare namespace fromString {
  * @returns The Base64 decoded {@link ox#Bytes.Bytes}.
  */
 export function toBytes(value: string): Bytes.Bytes {
-  const base64 = value.replace(/=+$/, '')
+  const base64 = value.replace(/[^A-Za-z0-9+/_-]/g, '')
 
   const size = base64.length
 

--- a/src/core/_test/Base64.test.ts
+++ b/src/core/_test/Base64.test.ts
@@ -59,6 +59,16 @@ describe('toBytes', () => {
       Bytes.fromString('hello wo�d'),
     )
   })
+
+  test('strips invalid characters', () => {
+    expect(Base64.toBytes('aGVsbG8!')).toStrictEqual(Bytes.fromString('hello'))
+    expect(Base64.toBytes('  aGVsbG8  ')).toStrictEqual(
+      Bytes.fromString('hello'),
+    )
+    expect(Base64.toBytes('aGVs\nbG8=')).toStrictEqual(
+      Bytes.fromString('hello'),
+    )
+  })
 })
 
 describe('toHex', () => {


### PR DESCRIPTION
Strip non-base64 characters before decoding instead of only stripping trailing padding. 