### PR TITLE
fix(Secp256k1): resolve yParity type mismatch in verify

### DIFF
--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -386,9 +386,13 @@ export declare namespace sign {
  * @returns Whether the payload was signed by the provided address.
  */
 export function verify(options: verify.Options): boolean {
-  const { address, hash, payload, publicKey, signature } = options
-  if (address)
-    return Address.isEqual(address, recoverAddress({ payload, signature }))
+  const { hash, payload } = options
+  if ('address' in options && options.address)
+    return Address.isEqual(
+      options.address,
+      recoverAddress({ payload, signature: options.signature }),
+    )
+  const { publicKey, signature } = options
   return secp256k1.verify(
     signature,
     Bytes.from(payload),


### PR DESCRIPTION
Destructuring the `OneOf` union in `verify()` causes TypeScript to lose the correlation between `address` and the correct `Signature` type. After destructuring, `signature` becomes `Signature<true> | Signature<false>`, but `recoverAddress` expects `Signature<true>` (with required `yParity`).

This surfaces as a build error in downstream projects that type-check `node_modules` source files (e.g. `next build`), since ox ships raw `.ts` files.

The fix avoids destructuring branch-dependent properties upfront and instead accesses them from the options object after narrowing, so the type checker can resolve the correct union member.

Fixes wevm/viem#4379