### PR TITLE
feat(tempo): add TransactionRequest.fromRpc, fold to/data/value into calls in toRpc

### DIFF
--- a/.changeset/transaction-request-from-rpc.md
+++ b/.changeset/transaction-request-from-rpc.md
@@ -2,4 +2,4 @@
 "ox": patch
 ---
 
-Added `TransactionRequest.fromRpc` to `ox/tempo`. `TransactionRequest.toRpc` now folds top-level `to`/`data`/`value` into `calls` when `calls` is not provided.
+Fixed `TransactionRequest.fromRpc` in `ox/tempo`. `TransactionRequest.toRpc` now folds top-level `to`/`data`/`value` into `calls` when `calls` is not provided.

--- a/.changeset/transaction-request-from-rpc.md
+++ b/.changeset/transaction-request-from-rpc.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Added `TransactionRequest.fromRpc` to `ox/tempo`. `TransactionRequest.toRpc` now folds top-level `to`/`data`/`value` into `calls` when `calls` is not provided.

--- a/src/tempo/TransactionRequest.test.ts
+++ b/src/tempo/TransactionRequest.test.ts
@@ -100,6 +100,28 @@ describe('toRpc', () => {
       }
     `)
   })
+
+  test('behavior: to/data/value folded into calls', () => {
+    const request = TransactionRequest.toRpc({
+      to: '0xcafebabecafebabecafebabecafebabecafebabe',
+      data: '0xdeadbeef',
+      value: 1000n,
+      feeToken: '0x20c0000000000000000000000000000000000000',
+    })
+    expect(request).toMatchInlineSnapshot(`
+      {
+        "calls": [
+          {
+            "data": "0xdeadbeef",
+            "to": "0xcafebabecafebabecafebabecafebabecafebabe",
+            "value": "0x3e8",
+          },
+        ],
+        "feeToken": "0x20c0000000000000000000000000000000000000",
+        "type": "0x76",
+      }
+    `)
+  })
 })
 
 describe('roundtrip', () => {

--- a/src/tempo/TransactionRequest.ts
+++ b/src/tempo/TransactionRequest.ts
@@ -189,6 +189,14 @@ export function toRpc(request: TransactionRequest): Rpc {
       value: call.value ? Hex.fromNumber(call.value) : '0x',
       data: call.data ?? '0x',
     }))
+  else if (request.to || request.data || request.value)
+    request_rpc.calls = [
+      {
+        to: request.to ? TempoAddress.resolve(request.to) : undefined,
+        value: request.value ? Hex.fromNumber(request.value) : '0x',
+        data: request.data ?? '0x',
+      },
+    ]
   if (typeof request.feeToken !== 'undefined')
     request_rpc.feeToken = TokenId.toAddress(request.feeToken)
   if (request.keyAuthorization)


### PR DESCRIPTION
- Added `TransactionRequest.fromRpc` to `ox/tempo`
- `TransactionRequest.toRpc` now folds top-level `to`/`data`/`value` into `calls` when `calls` is not provided
- Added roundtrip tests