### PR TITLE
fix: make node:worker_threads import non-literal for webpack compatibility

### DIFF
--- a/.changeset/fix-webpack-worker-threads.md
+++ b/.changeset/fix-webpack-worker-threads.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed webpack compatibility for `VirtualMaster` by making the `node:worker_threads` import specifier non-literal, preventing bundlers from statically analyzing and failing on the `node:` scheme.

--- a/src/tempo/internal/virtualMasterPool.ts
+++ b/src/tempo/internal/virtualMasterPool.ts
@@ -69,8 +69,8 @@ export async function resolveNode(): Promise<Pool | undefined> {
         },
       })
       worker.on('message', (msg: Message) => onMessage(msg))
-      worker.on('error', (err) => onError(err))
-      worker.on('exit', (code) => {
+      worker.on('error', (err: unknown) => onError(err))
+      worker.on('exit', (code: number) => {
         if (code !== 0)
           onError(
             new Errors.BaseError(

--- a/src/tempo/internal/virtualMasterPool.ts
+++ b/src/tempo/internal/virtualMasterPool.ts
@@ -54,7 +54,8 @@ export async function resolve(): Promise<Pool | undefined> {
  * @internal
  */
 export async function resolveNode(): Promise<Pool | undefined> {
-  const { Worker } = await import('node:worker_threads')
+  const id = 'node:worker_threads'
+  const { Worker } = await import(id)
   const { wasmBase64 } = await import('./mine.wasm.js')
   const workerSource = getNodeWorkerSource()
 


### PR DESCRIPTION
Webpack fails when bundling `VirtualMaster` because it statically analyzes the dynamic `import('node:worker_threads')` and cannot handle the `node:` URI scheme.

This makes the import specifier non-literal (`const id = 'node:worker_threads'; await import(id)`) so all bundlers (webpack, Rollup, Vite, esbuild) skip static resolution. The runtime behavior is unchanged — the `isNode` guard ensures it's only called in Node.js.

Fixes: https://github.com/wevm/viem/actions/runs/24742287706/job/72386255131