### PR TITLE
refactor: narrow secp256k1 verify signature branches

### DIFF
--- a/.changeset/narrow-secp256k1-verify.md
+++ b/.changeset/narrow-secp256k1-verify.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `Secp256k1.verify` narrowing signature branches before address recovery.

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -386,13 +386,16 @@ export declare namespace sign {
  * @returns Whether the payload was signed by the provided address.
  */
 export function verify(options: verify.Options): boolean {
-  const { address, hash, payload, publicKey, signature } = options
-  if (address)
-    return Address.isEqual(address, recoverAddress({ payload, signature }))
+  const { hash, payload } = options
+  if (options.address)
+    return Address.isEqual(
+      options.address,
+      recoverAddress({ payload, signature: options.signature }),
+    )
   return secp256k1.verify(
-    signature,
+    options.signature,
     Bytes.from(payload),
-    PublicKey.toBytes(publicKey),
+    PublicKey.toBytes(options.publicKey),
     ...(hash ? [{ prehash: true, lowS: true }] : []),
   )
 }

--- a/src/core/_test/Secp256k1.snap-d.ts
+++ b/src/core/_test/Secp256k1.snap-d.ts
@@ -1,0 +1,44 @@
+import { Secp256k1, type Signature } from 'ox'
+import { expect, expectTypeOf, test } from 'vitest'
+import { accounts } from '../../../test/constants/accounts.js'
+
+test('verify', () => {
+  const payload = '0xdeadbeef'
+  const signature = Secp256k1.sign({
+    payload,
+    privateKey: accounts[0].privateKey,
+  })
+  const { yParity: _yParity, ...unrecoveredSignature } = signature
+
+  expectTypeOf(
+    Secp256k1.verify({
+      address: accounts[0].address,
+      payload,
+      signature,
+    }),
+  ).toEqualTypeOf<boolean>()
+
+  expectTypeOf(
+    Secp256k1.verify({
+      publicKey: Secp256k1.getPublicKey({ privateKey: accounts[0].privateKey }),
+      payload,
+      signature: unrecoveredSignature as Signature.Signature<false>,
+    }),
+  ).toEqualTypeOf<boolean>()
+
+  expect(
+    Secp256k1.verify({
+      address: accounts[0].address,
+      payload,
+      signature,
+    }),
+  ).toBe(true)
+
+  expect(
+    Secp256k1.verify({
+      publicKey: Secp256k1.getPublicKey({ privateKey: accounts[0].privateKey }),
+      payload,
+      signature: unrecoveredSignature as Signature.Signature<false>,
+    }),
+  ).toBe(true)
+})


### PR DESCRIPTION
## Summary
- Narrow `Secp256k1.verify` before passing signatures to address recovery or public-key verification
- Avoid leaking the address/public-key `OneOf` union into `recoverAddress`, where `yParity` must be present
- Add a focused type/runtime regression covering recovered address verification and unrecovered public-key verification

## Why
When `verify` destructures `options` before the branch check, TypeScript sees `signature` as a union of recovered and unrecovered signatures. The address branch passes that union to `recoverAddress`, which requires `yParity`, causing the optional/required mismatch reported downstream by viem users.

Related: wevm/viem#4379.

## Validation
- `pnpm check`
- `pnpm check:types`
- `pnpm test:types src/core/_test/Secp256k1.snap-d.ts`
- `pnpm test src/core/_test/Secp256k1.test.ts`