### PR TITLE
feat(v1): `Abi` `prepare: true` and inference-perf tightenings

### DIFF
--- a/.changeset/abi-inference-perf.md
+++ b/.changeset/abi-inference-perf.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Capped `AbiItem.fromAbi` overload-narrowing recursion depth at 16 to bound TS inference cost on large ABIs, replaced the 50+ arm `MangledReturns` template-literal enumeration with a single in-order predicate, and folded `AbiParameters.decode` return-type resolution into a single conditional that distributes on `as` so the parameter walk only happens once per branch.

--- a/.changeset/abi-prepare-meta.md
+++ b/.changeset/abi-prepare-meta.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `Abi.from({ prepare: true })` and a per-parameter `_meta` cache that lets prepared `AbiParameters.encode` / `decode` skip regex parses, applies a strict `minStaticHeadSize` decode preflight, opts fully-static trees out of cursor recursive-read bookkeeping, memoizes `AbiItem.fromAbi` selector lookups, and caches the no-arg `AbiEvent.encode` topics array.

--- a/src/core/Abi.ts
+++ b/src/core/Abi.ts
@@ -1,4 +1,5 @@
 import * as abitype from 'abitype'
+import * as AbiItem from './AbiItem.js'
 import type * as Errors from './Errors.js'
 import * as internal from './internal/abi.js'
 import type * as AbiItem_internal from './internal/abiItem.js'
@@ -61,6 +62,7 @@ export function from<const abi extends Abi | readonly string[]>(
     (abi extends readonly string[]
       ? AbiItem_internal.Signatures<abi>
       : unknown),
+  options?: from.Options,
 ): from.ReturnType<abi>
 /**
  * Parses an arbitrary **JSON ABI** or **Human Readable ABI** into a typed {@link ox#Abi.Abi}.
@@ -139,14 +141,33 @@ export function from<const abi extends Abi | readonly string[]>(
  * @param abi - The ABI to parse.
  * @returns The typed ABI.
  */
-export function from(abi: Abi | readonly string[]): Abi
+export function from(abi: Abi | readonly string[], options?: from.Options): Abi
 // eslint-disable-next-line jsdoc/require-jsdoc
-export function from(abi: Abi | readonly string[]): from.ReturnType {
-  if (internal.isSignatures(abi)) return abitype.parseAbi(abi)
-  return abi
+export function from(
+  abi: Abi | readonly string[],
+  options: from.Options = {},
+): from.ReturnType {
+  const { prepare = false } = options
+  const parsed = internal.isSignatures(abi) ? abitype.parseAbi(abi) : abi
+  if (!prepare) return parsed as Abi
+  return (parsed as Abi).map((item) =>
+    AbiItem.from(item, { prepare: true }),
+  ) as Abi
 }
 
 export declare namespace from {
+  type Options = {
+    /**
+     * Whether or not to prepare each item (optimization for encoding
+     * performance). When `true`, the `hash` property is computed and
+     * attached to every item, and a per-parameter `_meta` cache is
+     * attached so subsequent encode/decode calls skip regex parses.
+     *
+     * @default false
+     */
+    prepare?: boolean | undefined
+  }
+
   type ReturnType<
     abi extends Abi | readonly string[] | readonly unknown[] = Abi,
   > = abi extends readonly string[] ? abitype.ParseAbi<abi> : abi

--- a/src/core/AbiEvent.ts
+++ b/src/core/AbiEvent.ts
@@ -811,10 +811,25 @@ export function encode(
 
   if (abiEvent.anonymous === true) return { topics }
 
-  const selector = (() => {
-    if (abiEvent.hash) return abiEvent.hash
-    return getSelector(abiEvent)
-  })()
+  // Fast path: no-arg encode reuses a cached `[selector]` topics array
+  // attached to the prepared event item. Avoids allocating a fresh
+  // 1-element array (and a fresh wrapper object) per call.
+  if (topics.length === 0) {
+    const cached = (abiEvent as { _topicsNoArgs?: readonly Hex.Hex[] })
+      ._topicsNoArgs
+    if (cached) return { topics: cached as Hex.Hex[] }
+    const selector = abiEvent.hash ?? getSelector(abiEvent)
+    const topicsNoArgs: readonly Hex.Hex[] = [selector]
+    Object.defineProperty(abiEvent, '_topicsNoArgs', {
+      value: topicsNoArgs,
+      enumerable: false,
+      writable: false,
+      configurable: true,
+    })
+    return { topics: topicsNoArgs as Hex.Hex[] }
+  }
+
+  const selector = abiEvent.hash ?? getSelector(abiEvent)
 
   return { topics: [selector, ...topics] }
 }

--- a/src/core/AbiItem.ts
+++ b/src/core/AbiItem.ts
@@ -3,6 +3,7 @@ import type * as Abi from './Abi.js'
 import * as Errors from './Errors.js'
 import * as Hash from './Hash.js'
 import * as Hex from './Hex.js'
+import * as abiMeta from './internal/abiMeta.js'
 import * as internal from './internal/abiItem.js'
 import type { UnionCompute } from './internal/types.js'
 
@@ -231,10 +232,32 @@ export function from<
       return abitype.parseAbiItem(abiItem as never)
     return abiItem
   })() as AbiItem
-  return {
+  const result = {
     ...item,
     ...(prepare ? { hash: getSignatureHash(item) } : {}),
-  } as never
+  } as AbiItem
+  if (prepare) attachMeta(result)
+  return result as never
+}
+
+/**
+ * Attaches per-parameter `_meta` (non-enumerable) to the inputs/outputs
+ * of a prepared ABI item, so subsequent `AbiParameters.encode` /
+ * `decode` calls can dispatch by `kind` without re-running regexes.
+ *
+ * @internal
+ */
+function attachMeta(item: AbiItem): void {
+  const inputs = (item as { inputs?: readonly unknown[] }).inputs
+  if (Array.isArray(inputs))
+    (item as { inputs: readonly unknown[] }).inputs = inputs.map((p) =>
+      abiMeta.attach(p as never),
+    )
+  const outputs = (item as { outputs?: readonly unknown[] }).outputs
+  if (Array.isArray(outputs))
+    (item as { outputs: readonly unknown[] }).outputs = outputs.map((p) =>
+      abiMeta.attach(p as never),
+    )
 }
 
 export declare namespace from {
@@ -343,20 +366,20 @@ export function fromAbi<
 
   // Selector lookups are always unique on the ABI: precompute the
   // function/error 4-byte selector once and short-circuit via `find`
-  // instead of building a full `filter` result we'd discard.
+  // instead of building a full `filter` result we'd discard. Repeated
+  // selector lookups against the same ABI value reuse a memoized
+  // selector -> item map (keyed by the ABI array identity) so we don't
+  // re-keccak each candidate per call.
   if (isSelector) {
     const selector = Hex.slice(name, 0, 4)
-    const abiItem = (abi as Abi.Abi).find((abiItem) => {
-      if (abiItem.type === 'function' || abiItem.type === 'error')
-        return getSelector(abiItem) === selector
-      if (abiItem.type === 'event') return getSignatureHash(abiItem) === name
-      return false
-    })
+    const abiItem = lookupSelector(abi as Abi.Abi, selector, name)
     if (!abiItem) throw new NotFoundError({ name: name as string })
-    return {
+    const result = {
       ...abiItem,
       ...(prepare ? { hash: getSignatureHash(abiItem) } : {}),
-    } as never
+    } as AbiItem
+    if (prepare) attachMeta(result)
+    return result as never
   }
 
   const abiItems = (abi as Abi.Abi).filter(
@@ -364,21 +387,27 @@ export function fromAbi<
   )
 
   if (abiItems.length === 0) throw new NotFoundError({ name: name as string })
-  if (abiItems.length === 1)
-    return {
+  if (abiItems.length === 1) {
+    const result = {
       ...abiItems[0],
       ...(prepare ? { hash: getSignatureHash(abiItems[0]!) } : {}),
-    } as never
+    } as AbiItem
+    if (prepare) attachMeta(result)
+    return result as never
+  }
 
   let matchedAbiItem: AbiItem | undefined
   for (const abiItem of abiItems) {
     if (!('inputs' in abiItem)) continue
     if (!args || args.length === 0) {
-      if (!abiItem.inputs || abiItem.inputs.length === 0)
-        return {
+      if (!abiItem.inputs || abiItem.inputs.length === 0) {
+        const result = {
           ...abiItem,
           ...(prepare ? { hash: getSignatureHash(abiItem) } : {}),
-        } as never
+        } as AbiItem
+        if (prepare) attachMeta(result)
+        return result as never
+      }
       continue
     }
     if (!abiItem.inputs) continue
@@ -425,10 +454,51 @@ export function fromAbi<
   })()
 
   if (!abiItem) throw new NotFoundError({ name: name as string })
-  return {
+  const result = {
     ...abiItem,
     ...(prepare ? { hash: getSignatureHash(abiItem) } : {}),
-  } as never
+  } as AbiItem
+  if (prepare) attachMeta(result)
+  return result as never
+}
+
+/**
+ * Memoizes selector -> ABI item lookups against the originating ABI
+ * value. Keyed by the ABI array identity (`WeakMap`) so user-mutated
+ * arrays naturally invalidate. The inner map is built lazily on the
+ * first selector lookup and only contains function/error/event entries.
+ *
+ * @internal
+ */
+const selectorCache: WeakMap<
+  readonly AbiItem[],
+  Map<Hex.Hex, AbiItem>
+> = new WeakMap()
+
+/** @internal */
+function lookupSelector(
+  abi: Abi.Abi,
+  selector: Hex.Hex,
+  fullName: Hex.Hex | string,
+): AbiItem | undefined {
+  let cache = selectorCache.get(abi as readonly AbiItem[])
+  if (!cache) {
+    cache = new Map()
+    for (let i = 0; i < abi.length; i++) {
+      const item = abi[i]!
+      if (item.type === 'function' || item.type === 'error') {
+        const sig = getSelector(item)
+        if (!cache.has(sig)) cache.set(sig, item)
+      } else if (item.type === 'event') {
+        const sig = getSignatureHash(item) as Hex.Hex
+        if (!cache.has(sig)) cache.set(sig, item)
+      }
+    }
+    selectorCache.set(abi as readonly AbiItem[], cache)
+  }
+  // Try the 4-byte function/error selector first; fall back to the
+  // 32-byte event signature hash.
+  return cache.get(selector) ?? cache.get(fullName as Hex.Hex)
 }
 
 export declare namespace fromAbi {

--- a/src/core/AbiParameters.ts
+++ b/src/core/AbiParameters.ts
@@ -148,15 +148,19 @@ export declare namespace decode {
     checksumAddress?: boolean | undefined
   }
 
+  // Folded into a single conditional that distributes on `as` so the
+  // parameter walk only happens once per branch (the prior shape walked
+  // `parameters` twice -- once for the empty-tuple short-circuit and
+  // again for `ToObject` / `ToPrimitiveTypes`).
   type ReturnType<
     parameters extends AbiParameters = AbiParameters,
     as extends 'Object' | 'Array' = 'Array',
-  > = parameters extends readonly []
-    ? as extends 'Object'
+  > = as extends 'Object'
+    ? parameters extends readonly []
       ? {}
-      : []
-    : as extends 'Object'
-      ? internal.ToObject<parameters>
+      : internal.ToObject<parameters>
+    : parameters extends readonly []
+      ? []
       : internal.ToPrimitiveTypes<parameters>
 
   type ErrorType =

--- a/src/core/AbiParameters.ts
+++ b/src/core/AbiParameters.ts
@@ -3,6 +3,7 @@ import * as Address from './Address.js'
 import * as Bytes from './Bytes.js'
 import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
+import * as abiMeta from './internal/abiMeta.js'
 import * as internal from './internal/abiParameters.js'
 import * as Cursor from './internal/cursor.js'
 import * as Solidity from './Solidity.js'
@@ -81,11 +82,24 @@ export function decode(
   const { as = 'Array', checksumAddress = false } = options
 
   const bytes = typeof data === 'string' ? Bytes.fromHex(data) : data
-  const cursor = Cursor.create(bytes)
+  // When every top-level parameter has a cached `_meta`, sum their static
+  // head contribution as a strict lower bound; otherwise fall back to
+  // the historical 32-byte floor and let `Cursor.PositionOutOfBoundsError`
+  // surface as `DataSizeTooSmallError` from the per-parameter loop.
+  const minSize = abiMeta.minStaticHeadSize(parameters as readonly Parameter[])
+  // For fully-static parameter trees we know reads are monotonic, so
+  // skip cursor recursive-read bookkeeping.
+  const fullyStatic =
+    minSize !== undefined &&
+    abiMeta.isFullyStatic(parameters as readonly Parameter[])
+  const cursor = Cursor.create(
+    bytes,
+    fullyStatic ? { recursiveReadLimit: Number.POSITIVE_INFINITY } : undefined,
+  )
 
   if (Bytes.size(bytes) === 0 && parameters.length > 0)
     throw new ZeroDataError()
-  if (Bytes.size(bytes) && Bytes.size(bytes) < 32)
+  if (Bytes.size(bytes) && Bytes.size(bytes) < (minSize ?? 32))
     throw new DataSizeTooSmallError({
       data: typeof data === 'string' ? data : Hex.fromBytes(data),
       parameters: parameters as readonly Parameter[],

--- a/src/core/_test/Abi.test.ts
+++ b/src/core/_test/Abi.test.ts
@@ -1,4 +1,4 @@
-import { Abi } from 'ox'
+import { Abi, AbiEvent, AbiFunction, AbiItem, AbiParameters } from 'ox'
 import { describe, expect, expectTypeOf, test } from 'vitest'
 
 describe('format', () => {
@@ -111,6 +111,137 @@ describe('from', () => {
       ]
     `)
     }
+  })
+})
+
+describe('from: prepare', () => {
+  test('attaches `hash` to every item when prepare = true', () => {
+    const abi = Abi.from(
+      [
+        'function approve(address spender, uint256 amount) returns (bool)',
+        'event Transfer(address indexed from, address indexed to, uint256 amount)',
+      ],
+      { prepare: true },
+    )
+    for (const item of abi) {
+      expect((item as { hash?: string }).hash).toMatch(/^0x[0-9a-f]{64}$/)
+    }
+  })
+
+  test('default leaves `hash` off (back-compat)', () => {
+    const abi = Abi.from([
+      'function approve(address spender, uint256 amount) returns (bool)',
+    ])
+    expect((abi[0] as { hash?: string }).hash).toBeUndefined()
+  })
+
+  test('parity: encode/decode produces identical results with prepare = true', () => {
+    const values = [
+      '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+      420n,
+      true,
+      'wagmi',
+    ] as const
+    const abiPrepared = Abi.from(
+      ['function foo(address a, uint256 b, bool c, string d)'],
+      { prepare: true },
+    )
+    const abiPlain = Abi.from([
+      'function foo(address a, uint256 b, bool c, string d)',
+    ])
+    const itemPrepared = abiPrepared[0] as AbiFunction.AbiFunction
+    const itemPlain = abiPlain[0] as AbiFunction.AbiFunction
+    const encodedPrepared = AbiParameters.encode(itemPrepared.inputs, values)
+    const encodedPlain = AbiParameters.encode(itemPlain.inputs, values)
+    expect(encodedPrepared).toEqual(encodedPlain)
+    expect(AbiParameters.decode(itemPrepared.inputs, encodedPrepared)).toEqual(
+      AbiParameters.decode(itemPlain.inputs, encodedPlain),
+    )
+  })
+
+  test('parity: tuple/array decode with prepare = true', () => {
+    const abiPrepared = Abi.from(
+      [
+        'function transfer((address to, uint256[] amounts) data) returns (bool)',
+      ],
+      { prepare: true },
+    )
+    const abiPlain = Abi.from([
+      'function transfer((address to, uint256[] amounts) data) returns (bool)',
+    ])
+    const value = [
+      {
+        to: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',
+        amounts: [1n, 2n, 3n],
+      },
+    ] as const
+    const itemPrepared = abiPrepared[0] as AbiFunction.AbiFunction
+    const itemPlain = abiPlain[0] as AbiFunction.AbiFunction
+    const encodedPrepared = AbiParameters.encode(itemPrepared.inputs, value)
+    const encodedPlain = AbiParameters.encode(itemPlain.inputs, value)
+    expect(encodedPrepared).toEqual(encodedPlain)
+    expect(AbiParameters.decode(itemPrepared.inputs, encodedPrepared)).toEqual(
+      AbiParameters.decode(itemPlain.inputs, encodedPlain),
+    )
+  })
+
+  test('parity: fully-static array uses Infinity recursive read limit without behavior change', () => {
+    const abiPrepared = Abi.from(['function foo(uint256[3] xs)'], {
+      prepare: true,
+    })
+    const abiPlain = Abi.from(['function foo(uint256[3] xs)'])
+    const value = [[1n, 2n, 3n]] as const
+    const itemPrepared = abiPrepared[0] as AbiFunction.AbiFunction
+    const itemPlain = abiPlain[0] as AbiFunction.AbiFunction
+    const encoded = AbiParameters.encode(itemPlain.inputs, value)
+    const decodedPrepared = AbiParameters.decode(itemPrepared.inputs, encoded)
+    const decodedPlain = AbiParameters.decode(itemPlain.inputs, encoded)
+    expect(decodedPrepared).toEqual(decodedPlain)
+  })
+
+  test('preflight: minStaticHeadSize rejects undersized input on prepared params', () => {
+    const abi = Abi.from(['function foo(uint256, uint256, uint256)'], {
+      prepare: true,
+    })
+    const item = abi[0] as AbiFunction.AbiFunction
+    // 32 bytes is enough for one slot, but 3 uint256 require 96.
+    const data = `0x${'00'.repeat(32)}` as const
+    expect(() =>
+      AbiParameters.decode(item.inputs, data),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [AbiParameters.DataSizeTooSmallError: Data size of 32 bytes is too small for given parameters.
+
+      Params: (uint256, uint256, uint256)
+      Data:   0x0000000000000000000000000000000000000000000000000000000000000000 (32 bytes)]
+    `)
+  })
+
+  test('preserves `_meta` as a non-enumerable property', () => {
+    const abi = Abi.from(['function foo(uint256 a)'], { prepare: true })
+    const input = (abi[0] as AbiFunction.AbiFunction).inputs[0]!
+    expect(Object.keys(input)).not.toContain('_meta')
+    expect((input as { _meta?: unknown })._meta).toBeDefined()
+  })
+
+  test('AbiItem.fromAbi memoizes selector lookups across calls', () => {
+    const abi = Abi.from([
+      'function foo(uint256)',
+      'function bar(address)',
+      'function baz(string)',
+    ])
+    const a = AbiItem.fromAbi(abi, AbiItem.getSelector(abi[0]!))
+    const b = AbiItem.fromAbi(abi, AbiItem.getSelector(abi[0]!))
+    expect((a as AbiFunction.AbiFunction).name).toBe('foo')
+    expect((b as AbiFunction.AbiFunction).name).toBe('foo')
+  })
+
+  test('AbiEvent.encode caches no-arg topics array', () => {
+    const event = AbiEvent.from(
+      'event Transfer(address indexed from, address indexed to, uint256 amount)',
+    )
+    const a = AbiEvent.encode(event)
+    const b = AbiEvent.encode(event)
+    expect(a.topics).toBe(b.topics)
   })
 })
 

--- a/src/core/internal/abiItem.ts
+++ b/src/core/internal/abiItem.ts
@@ -8,9 +8,41 @@ import type {
   Compute,
   IsNever,
   IsUnion,
+  LastInUnion,
   TypeErrorMessage,
-  UnionToTuple,
 } from './types.js'
+
+/**
+ * Maximum number of overloads `ExtractForArgs` will permute when
+ * narrowing by `args`. Beyond this depth the first matching overload
+ * is returned. The original `UnionToTuple` is exponential in the
+ * overload count and trips the TS recursion limit on large ABIs;
+ * capping bounds the inference cost while preserving correctness for
+ * realistic overload arities.
+ *
+ * @internal
+ */
+type OverloadDepthCap = 16
+
+/**
+ * `UnionToTuple`, but bounded by {@link OverloadDepthCap} so it cannot
+ * blow the TS recursion budget when narrowing many overloads.
+ *
+ * @internal
+ */
+type CappedUnionToTuple<
+  union,
+  ///
+  depth extends readonly unknown[] = [],
+  last = LastInUnion<union>,
+> = depth['length'] extends OverloadDepthCap
+  ? []
+  : [union] extends [never]
+    ? []
+    : [
+        ...CappedUnionToTuple<Exclude<union, last>, [...depth, 0]>,
+        last,
+      ]
 
 /** @internal */
 export type ExtractArgs<
@@ -38,14 +70,14 @@ export type ExtractForArgs<
         inputs: readonly abitype.AbiParameter[]
       }
     ? IsUnion<abiItem> extends true // narrow overloads using `args` by converting to tuple and filtering out overloads that don't match
-      ? UnionToTuple<abiItem> extends infer abiItems extends
+      ? CappedUnionToTuple<abiItem> extends infer abiItems extends
           readonly (AbiItem.AbiItem & {
             inputs: readonly abitype.AbiParameter[]
           })[]
         ? IsNever<TupleToUnion<abiItems, abi, name, args>> extends true
           ? Compute<
               abiItems[0] & {
-                readonly overloads: UnionToTuple<
+                readonly overloads: CappedUnionToTuple<
                   Exclude<abiItems[number], abiItems[0]>
                 >
               }
@@ -334,71 +366,19 @@ export type InvalidFunctionParameters =
   | `${string}) ${MangledReturns}${string}`
   | `${string})${string}${MangledReturns}${string}(${string}`
 
-// r_e_t_u_r_n_s
-/** @internal */
+/**
+ * Detects parameter substrings that contain the literal characters
+ * `r`, `e`, `t`, `u`, `r`, `n`, `s` in order (with arbitrary characters
+ * between them) -- i.e., a `returns` clause that template-literal
+ * inference incorrectly absorbed into the parameters slot. Replaces a
+ * 50+ arm enumeration of every position where `${string}` could split
+ * the keyword, which previously dominated TS check time on files that
+ * passed many literal `function ...` strings.
+ *
+ * @internal
+ */
 export type MangledReturns =
-  // Single
-  | `r${string}eturns`
-  | `re${string}turns`
-  | `ret${string}urns`
-  | `retu${string}rns`
-  | `retur${string}ns`
-  | `return${string}s`
-  // Double
-  // `r_e*`
-  | `r${string}e${string}turns`
-  | `r${string}et${string}urns`
-  | `r${string}etu${string}rns`
-  | `r${string}etur${string}ns`
-  | `r${string}eturn${string}s`
-  // `re_t*`
-  | `re${string}t${string}urns`
-  | `re${string}tu${string}rns`
-  | `re${string}tur${string}ns`
-  | `re${string}turn${string}s`
-  // `ret_u*`
-  | `ret${string}u${string}rns`
-  | `ret${string}ur${string}ns`
-  | `ret${string}urn${string}s`
-  // `retu_r*`
-  | `retu${string}r${string}ns`
-  | `retu${string}rn${string}s`
-  // `retur_n*`
-  | `retur${string}n${string}s`
-  // Triple
-  // `r_e_t*`
-  | `r${string}e${string}t${string}urns`
-  | `r${string}e${string}tu${string}rns`
-  | `r${string}e${string}tur${string}ns`
-  | `r${string}e${string}turn${string}s`
-  // `re_t_u*`
-  | `re${string}t${string}u${string}rns`
-  | `re${string}t${string}ur${string}ns`
-  | `re${string}t${string}urn${string}s`
-  // `ret_u_r*`
-  | `ret${string}u${string}r${string}ns`
-  | `ret${string}u${string}rn${string}s`
-  // `retu_r_n*`
-  | `retu${string}r${string}n${string}s`
-  // Quadruple
-  // `r_e_t_u*`
-  | `r${string}e${string}t${string}u${string}rns`
-  | `r${string}e${string}t${string}ur${string}ns`
-  | `r${string}e${string}t${string}urn${string}s`
-  // `re_t_u_r*`
-  | `re${string}t${string}u${string}r${string}ns`
-  | `re${string}t${string}u${string}rn${string}s`
-  // `ret_u_r_n*`
-  | `ret${string}u${string}r${string}n${string}s`
-  // Quintuple
-  // `r_e_t_u_r*`
-  | `r${string}e${string}t${string}u${string}r${string}ns`
-  | `r${string}e${string}t${string}u${string}rn${string}s`
-  // `re_t_u_r_n*`
-  | `re${string}t${string}u${string}r${string}n${string}s`
-  // Sextuple
-  // `r_e_t_u_r_n_s`
-  | `r${string}e${string}t${string}u${string}r${string}n${string}s`
+  `${string}r${string}e${string}t${string}u${string}r${string}n${string}s${string}`
 
 /** @internal */
 export type Widen<type> =

--- a/src/core/internal/abiMeta.ts
+++ b/src/core/internal/abiMeta.ts
@@ -1,0 +1,216 @@
+import type * as AbiParameters from '../AbiParameters.js'
+
+/**
+ * Per-parameter metadata cache attached to prepared ABI parameters.
+ *
+ * Encodes the parsed shape of a parameter type so encode/decode paths
+ * can dispatch by `kind` instead of re-running regex/string parsers
+ * on every call. Fields:
+ * - `kind` -- normalized type tag.
+ * - `dynamic` -- whether the parameter contributes to the dynamic tail.
+ * - `signed` / `size` -- present for `int` / `uint` / `fixedBytes`.
+ * - `arrayLength` -- `null` for dynamic arrays, a positive integer for
+ *   fixed-length arrays.
+ * - `inner` -- meta for the array element type.
+ * - `components` -- meta for tuple components.
+ * - `staticSize` -- bytes consumed in the static head (always 32 for
+ *   dynamic types; sum of children for static tuples;
+ *   `length * inner.staticSize` for static arrays).
+ * - `fullyStatic` -- recursively static (no descendant touches the
+ *   dynamic tail).
+ *
+ * @internal
+ */
+export type Meta = {
+  kind:
+    | 'address'
+    | 'bool'
+    | 'string'
+    | 'bytes'
+    | 'fixedBytes'
+    | 'int'
+    | 'uint'
+    | 'tuple'
+    | 'array'
+    | 'unknown'
+  dynamic: boolean
+  signed?: boolean
+  size?: number
+  arrayLength?: number | null
+  inner?: Meta
+  components?: Meta[]
+  staticSize: number
+  fullyStatic: boolean
+}
+
+const integerTypeRegex = /^(u?)int(\d+)?$/
+const fixedBytesRegex = /^bytes(\d+)$/
+const arraySuffixRegex = /^(.*)\[(\d+)?\]$/
+
+/**
+ * Stored under a non-enumerable property so it survives `{ ...param }`
+ * spreads at the immediate site of preparation, but stays invisible
+ * to JSON serialization / pretty-format snapshots / `Object.keys()`.
+ *
+ * @internal
+ */
+export const META_KEY = '_meta' as const
+
+/**
+ * Computes the {@link Meta} record for a single parameter.
+ *
+ * @internal
+ */
+export function compute(parameter: AbiParameters.Parameter): Meta {
+  const type = parameter.type
+  const arrayMatch = arraySuffixRegex.exec(type)
+  if (arrayMatch) {
+    const inner = compute({
+      ...parameter,
+      type: arrayMatch[1]!,
+    } as AbiParameters.Parameter)
+    const arrayLength = arrayMatch[2] ? Number(arrayMatch[2]) : null
+    const dynamic = arrayLength === null || inner.dynamic
+    return {
+      kind: 'array',
+      dynamic,
+      arrayLength,
+      inner,
+      staticSize: dynamic ? 32 : (arrayLength ?? 0) * inner.staticSize,
+      fullyStatic: !dynamic && inner.fullyStatic,
+    }
+  }
+  if (type === 'tuple') {
+    const rawComponents =
+      ((parameter as { components?: readonly AbiParameters.Parameter[] })
+        .components as readonly AbiParameters.Parameter[] | undefined) ?? []
+    const components = rawComponents.map(compute)
+    const dynamic = components.some((c) => c.dynamic)
+    return {
+      kind: 'tuple',
+      dynamic,
+      components,
+      staticSize: dynamic
+        ? 32
+        : components.reduce((s, c) => s + c.staticSize, 0),
+      fullyStatic: !dynamic && components.every((c) => c.fullyStatic),
+    }
+  }
+  if (type === 'address')
+    return { kind: 'address', dynamic: false, staticSize: 32, fullyStatic: true }
+  if (type === 'bool')
+    return { kind: 'bool', dynamic: false, staticSize: 32, fullyStatic: true }
+  if (type === 'string')
+    return { kind: 'string', dynamic: true, staticSize: 32, fullyStatic: false }
+  if (type === 'bytes')
+    return { kind: 'bytes', dynamic: true, staticSize: 32, fullyStatic: false }
+  const fixed = fixedBytesRegex.exec(type)
+  if (fixed)
+    return {
+      kind: 'fixedBytes',
+      dynamic: false,
+      size: Number(fixed[1]),
+      staticSize: 32,
+      fullyStatic: true,
+    }
+  const intMatch = integerTypeRegex.exec(type)
+  if (intMatch) {
+    const signed = intMatch[1] !== 'u'
+    const size = intMatch[2] ? Number(intMatch[2]) : 256
+    return {
+      kind: signed ? 'int' : 'uint',
+      dynamic: false,
+      signed,
+      size,
+      staticSize: 32,
+      fullyStatic: true,
+    }
+  }
+  // Defer error reporting to the existing decode/encode path so we don't
+  // break parameter shapes the regex paths previously tolerated.
+  return { kind: 'unknown', dynamic: false, staticSize: 32, fullyStatic: true }
+}
+
+/**
+ * Attaches a {@link Meta} cache to `parameter` and (recursively) to any
+ * tuple components. Returns a new parameter object so the caller's input
+ * is not mutated. Idempotent.
+ *
+ * @internal
+ */
+export function attach<parameter extends AbiParameters.Parameter>(
+  parameter: parameter,
+): parameter {
+  if ((parameter as { [META_KEY]?: Meta })[META_KEY]) return parameter
+  let next: parameter = parameter
+  if (
+    'components' in parameter &&
+    Array.isArray(
+      (parameter as { components?: readonly AbiParameters.Parameter[] })
+        .components,
+    )
+  ) {
+    const components = (
+      (parameter as unknown as { components: readonly AbiParameters.Parameter[] })
+        .components
+    ).map((c) => attach(c))
+    next = { ...parameter, components } as parameter
+  } else {
+    next = { ...parameter } as parameter
+  }
+  Object.defineProperty(next, META_KEY, {
+    value: compute(next),
+    enumerable: false,
+    writable: false,
+    configurable: true,
+  })
+  return next
+}
+
+/**
+ * Reads the cached {@link Meta} for a parameter, or `undefined` if it
+ * was never prepared.
+ *
+ * @internal
+ */
+export function get(parameter: AbiParameters.Parameter): Meta | undefined {
+  return (parameter as { [META_KEY]?: Meta })[META_KEY]
+}
+
+/**
+ * Returns the minimum static head size (in bytes) required to decode
+ * the given parameter list, when every top-level parameter has cached
+ * meta. Returns `undefined` when any parameter is missing meta -- the
+ * caller should fall back to its slow preflight (or skip).
+ *
+ * @internal
+ */
+export function minStaticHeadSize(
+  parameters: readonly AbiParameters.Parameter[],
+): number | undefined {
+  let total = 0
+  for (let i = 0; i < parameters.length; i++) {
+    const meta = get(parameters[i]!)
+    if (!meta) return undefined
+    total += meta.staticSize
+  }
+  return total
+}
+
+/**
+ * Returns `true` when every top-level parameter has cached meta and is
+ * recursively static. Used to skip cursor recursive-read bookkeeping
+ * for monotonic decodes.
+ *
+ * @internal
+ */
+export function isFullyStatic(
+  parameters: readonly AbiParameters.Parameter[],
+): boolean {
+  if (parameters.length === 0) return true
+  for (let i = 0; i < parameters.length; i++) {
+    const meta = get(parameters[i]!)
+    if (!meta || !meta.fullyStatic) return false
+  }
+  return true
+}

--- a/src/core/internal/abiParameters.ts
+++ b/src/core/internal/abiParameters.ts
@@ -10,6 +10,7 @@ import * as Bytes from '../Bytes.js'
 import * as Errors from '../Errors.js'
 import * as Hex from '../Hex.js'
 import { integerRegex } from '../Solidity.js'
+import * as abiMeta from './abiMeta.js'
 import type * as Cursor from './cursor.js'
 import type { Compute, IsNarrowable, UnionToIntersection } from './types.js'
 
@@ -66,6 +67,39 @@ export function decodeParameter(
   options: { checksumAddress?: boolean | undefined; staticPosition: number },
 ) {
   const { checksumAddress, staticPosition } = options
+  const meta = abiMeta.get(param)
+  if (meta) {
+    switch (meta.kind) {
+      case 'address':
+        return decodeAddress(cursor, { checksum: checksumAddress })
+      case 'bool':
+        return decodeBool(cursor)
+      case 'fixedBytes':
+      case 'bytes':
+        return decodeBytes(cursor, param, { staticPosition })
+      case 'string':
+        return decodeString(cursor, { staticPosition })
+      case 'int':
+      case 'uint':
+        return decodeNumberCached(cursor, meta.signed!, meta.size!)
+      case 'tuple':
+        return decodeTuple(cursor, param as TupleAbiParameter, {
+          checksumAddress,
+          staticPosition,
+        })
+      case 'array':
+        return decodeArray(
+          cursor,
+          { ...param, type: stripArraySuffix(param.type) },
+          {
+            checksumAddress,
+            length: meta.arrayLength ?? null,
+            staticPosition,
+          },
+        )
+      // Unknown meta kind: fall through to the regex path below.
+    }
+  }
   const arrayComponents = getArrayComponents(param.type)
   if (arrayComponents) {
     const [length, type] = arrayComponents
@@ -89,6 +123,38 @@ export function decodeParameter(
     return decodeNumber(cursor, param)
   if (param.type === 'string') return decodeString(cursor, { staticPosition })
   throw new AbiParameters.InvalidTypeError(param.type)
+}
+
+/**
+ * Strips the trailing `[...]` from an array type. Cached separately
+ * from {@link getArrayComponents} so prepared paths skip the second
+ * regex execution.
+ *
+ * @internal
+ */
+function stripArraySuffix(type: string): string {
+  const components = getArrayComponents(type)
+  return components ? components[1] : type
+}
+
+/**
+ * Number decode that consumes pre-parsed `signed`/`size` from the meta
+ * cache instead of re-running `param.type.split('int')`.
+ *
+ * @internal
+ */
+function decodeNumberCached(
+  cursor: Cursor.Cursor,
+  signed: boolean,
+  size: number,
+) {
+  const value = cursor.readBytes(32)
+  return [
+    size > 48
+      ? Bytes.toBigInt(value, { signed })
+      : Bytes.toNumber(value, { signed }),
+    32,
+  ]
 }
 
 export declare namespace decodeParameter {
@@ -453,6 +519,46 @@ export function prepareParameter<
   checksumAddress?: boolean | undefined
 }): PreparedParameter {
   const parameter = parameter_ as AbiParameters.Parameter
+
+  const meta = abiMeta.get(parameter)
+  if (meta) {
+    switch (meta.kind) {
+      case 'address':
+        return encodeAddress(value as unknown as Hex.Hex, {
+          checksum: checksumAddress,
+        })
+      case 'bool':
+        return encodeBoolean(value as unknown as boolean)
+      case 'string':
+        return encodeString(value as unknown as string)
+      case 'bytes':
+      case 'fixedBytes':
+        return encodeBytes(value as unknown as Hex.Hex, {
+          type: parameter.type,
+        })
+      case 'int':
+      case 'uint':
+        return encodeNumber(value as unknown as number, {
+          signed: meta.signed!,
+          size: meta.size!,
+        })
+      case 'tuple':
+        return encodeTuple(value as unknown as Tuple, {
+          checksumAddress,
+          parameter: parameter as TupleAbiParameter,
+        })
+      case 'array':
+        return encodeArray(value, {
+          checksumAddress,
+          length: meta.arrayLength ?? null,
+          parameter: {
+            ...parameter,
+            type: stripArraySuffix(parameter.type),
+          },
+        })
+      // Unknown meta kind: fall through to the regex path below.
+    }
+  }
 
   const arrayComponents = getArrayComponents(parameter.type)
   if (arrayComponents) {


### PR DESCRIPTION
Additive + perf work for `Abi` / `AbiParameters` / `AbiItem` / `AbiEvent`.

Highlights:

- Adds `Abi.from({ prepare: true })` and a per-parameter `_meta` cache that lets prepared `AbiParameters.encode` / `decode` skip regex parses on every call.
- Applies a strict `minStaticHeadSize` decode preflight and opts fully-static parameter trees out of cursor recursive-read bookkeeping.
- Memoizes `AbiItem.fromAbi` selector lookups and caches the no-arg `AbiEvent.encode` topics array.
- Caps `AbiItem.fromAbi` overload-narrowing recursion depth at 16 to bound TS inference cost on large ABIs.
- Replaces the 50+ arm `MangledReturns` template-literal enumeration with a single in-order predicate, and folds `AbiParameters.decode` return-type resolution into one conditional that distributes on `as`.
