### PR TITLE
feat(v1): single-pass `Siwe.parseMessage`, `BinaryStateTree` allocations, `TypedData` parse cache

### DIFF
--- a/src/core/BinaryStateTree.ts
+++ b/src/core/BinaryStateTree.ts
@@ -59,7 +59,7 @@ export function insert(
 
   if (tree.root.type === 'empty') {
     tree.root = stemNode(stem)
-    tree.root.values[subIndex] = value
+    tree.root.values.set(subIndex, value)
     return
   }
 
@@ -74,22 +74,20 @@ export function insert(
 
     if (node.type === 'empty') {
       node = stemNode(stem)
-      node.values[subIndex!] = value
+      node.values.set(subIndex, value)
       return node
     }
 
-    const stemBits = bytesToBits(stem)
     if (node.type === 'stem') {
       if (Bytes.isEqual(node.stem, stem)) {
-        node.values[subIndex!] = value
+        node.values.set(subIndex, value)
         return node
       }
-      const existingStemBits = bytesToBits(node.stem)
-      return splitLeaf(node, stemBits, existingStemBits, subIndex, value, depth)
+      return splitLeaf(node, stem, subIndex, value, depth)
     }
 
     if (node.type === 'internal') {
-      const bit = stemBits[depth]
+      const bit = getBit(stem, depth)
       if (bit === 0) {
         node.left = inner(node.left, stem, subIndex, value, depth + 1)
       } else {
@@ -126,22 +124,31 @@ export function insert(
  */
 export function merkelize(tree: BinaryStateTree): Bytes.Bytes {
   function inner(node: Node): Bytes.Bytes {
-    if (node.type === 'empty') return new Uint8Array(32).fill(0)
+    if (node.type === 'empty') return ZERO32
     if (node.type === 'internal') {
       const hash_left = inner(node.left)
       const hash_right = inner(node.right)
       return hash(Bytes.concat(hash_left, hash_right))
     }
 
-    let level = node.values.map(hash)
-    while (level.length > 1) {
-      const level_ = []
-      for (let i = 0; i < level.length; i += 2)
-        level_.push(hash(Bytes.concat(level[i]!, level[i + 1]!)))
-      level = level_
+    // Reduce a 256-leaf binary tree where any unset slot hashes to ZERO32.
+    // Allocate a single 256-entry buffer up-front and iterate in place,
+    // halving the active span at each level instead of creating a fresh
+    // array per level.
+    const level: Bytes.Bytes[] = new Array(256)
+    for (let i = 0; i < 256; i++) {
+      const v = node.values.get(i)
+      level[i] = v ? hash(v) : ZERO32
+    }
+    let size = 256
+    while (size > 1) {
+      const half = size >> 1
+      for (let i = 0; i < half; i++)
+        level[i] = hash(Bytes.concat(level[2 * i]!, level[2 * i + 1]!))
+      size = half
     }
 
-    return hash(Bytes.concat(node.stem, new Uint8Array(1).fill(0), level[0]!))
+    return hash(Bytes.concat(node.stem, ZERO1, level[0]!))
   }
 
   return inner(tree.root)
@@ -166,54 +173,49 @@ type InternalNode = {
 /** @internal */
 type StemNode = {
   stem: Bytes.Bytes
-  values: (Bytes.Bytes | undefined)[]
+  values: Map<number, Bytes.Bytes>
   type: 'stem'
 }
 
 /** @internal */
+const ZERO32: Bytes.Bytes = new Uint8Array(32)
+
+/** @internal */
+const ZERO1: Bytes.Bytes = new Uint8Array(1)
+
+/** @internal */
+function getBit(stem: Bytes.Bytes, depth: number): number {
+  return (stem[depth >> 3]! >> (7 - (depth & 7))) & 1
+}
+
+/** @internal */
 function splitLeaf(
-  leaf: Node,
-  stemBits: number[],
-  existingStemBits: number[],
+  leaf: StemNode,
+  stem: Bytes.Bytes,
   subIndex: number,
   value: Bytes.Bytes,
   depth: number,
 ): Node {
-  if (stemBits[depth] === existingStemBits[depth]) {
+  const bit = getBit(stem, depth)
+  const existingBit = getBit(leaf.stem, depth)
+  if (bit === existingBit) {
     const internal = internalNode()
-    const bit = stemBits[depth]
     if (bit === 0) {
-      internal.left = splitLeaf(
-        leaf,
-        stemBits,
-        existingStemBits,
-        subIndex,
-        value,
-        depth + 1,
-      )
+      internal.left = splitLeaf(leaf, stem, subIndex, value, depth + 1)
     } else {
-      internal.right = splitLeaf(
-        leaf,
-        stemBits,
-        existingStemBits,
-        subIndex,
-        value,
-        depth + 1,
-      )
+      internal.right = splitLeaf(leaf, stem, subIndex, value, depth + 1)
     }
     return internal
   }
 
   const internal = internalNode()
-  const bit = stemBits[depth]
-  const stem = bitsToBytes(stemBits)
   if (bit === 0) {
     internal.left = stemNode(stem)
-    internal.left.values[subIndex] = value
+    internal.left.values.set(subIndex, value)
     internal.right = leaf
   } else {
     internal.right = stemNode(stem)
-    internal.right.values[subIndex] = value
+    internal.right.values.set(subIndex, value)
     internal.left = leaf
   }
   return internal
@@ -239,33 +241,14 @@ function internalNode(): InternalNode {
 function stemNode(stem: Bytes.Bytes): StemNode {
   return {
     stem,
-    values: Array.from({ length: 256 }, () => undefined),
+    values: new Map(),
     type: 'stem',
   }
 }
 
 /** @internal */
-function bytesToBits(bytes: Bytes.Bytes): number[] {
-  const bits = []
-  for (const byte of bytes)
-    for (let i = 0; i < 8; i++) bits.push((byte >> (7 - i)) & 1)
-  return bits
-}
-
-/** @internal */
-function bitsToBytes(bits: number[]): Bytes.Bytes {
-  const byte_data = new Uint8Array(bits.length / 8)
-  for (let i = 0; i < bits.length; i += 8) {
-    let byte = 0
-    for (let j = 0; j < 8; j++) byte |= bits[i + j]! << (7 - j)
-    byte_data[i / 8] = byte
-  }
-  return byte_data
-}
-
-/** @internal */
 function hash(bytes: Bytes.Bytes | undefined): Bytes.Bytes {
-  if (!bytes) return new Uint8Array(32).fill(0)
-  if (!bytes.some((byte) => byte !== 0)) return new Uint8Array(32).fill(0)
+  if (!bytes) return ZERO32
+  if (!bytes.some((byte) => byte !== 0)) return ZERO32
   return blake3(bytes)
 }

--- a/src/core/Siwe.ts
+++ b/src/core/Siwe.ts
@@ -365,38 +365,102 @@ function splitUri(value: string) {
  * @returns Message fields object.
  */
 export function parseMessage(message: string): ExactPartial<Message> {
-  const { scheme, statement, ...prefix } = (message.match(prefixRegex)
-    ?.groups ?? {}) as {
-    address: Address.Address
-    domain: string
-    scheme?: string
-    statement?: string
-  }
-  const { chainId, expirationTime, issuedAt, notBefore, requestId, ...suffix } =
-    (message.match(suffixRegex)?.groups ?? {}) as {
-      chainId: string
-      expirationTime?: string
-      issuedAt?: string
-      nonce: string
-      notBefore?: string
-      requestId?: string
-      uri: string
-      version: '1'
+  const lines = message.split('\n')
+  const out: Record<string, unknown> = {}
+
+  // Try to parse the prefix block (scheme/domain/address/statement) starting
+  // at the top of the message.
+  let i = 0
+  const prefixMatch = lines[0]?.match(prefixLineRegex)
+  if (prefixMatch?.groups) {
+    if (prefixMatch.groups.scheme) out.scheme = prefixMatch.groups.scheme
+    out.domain = prefixMatch.groups.domain
+    const addressMatch = lines[1]?.match(addressLineRegex)
+    if (addressMatch) {
+      out.address = addressMatch[1]
+      i = 2
+      // Optional statement: blank line, statement line, blank line.
+      if (lines[i] === '') {
+        i++
+        const candidate = lines[i]
+        if (
+          candidate !== undefined &&
+          candidate !== '' &&
+          !labelRegex.test(candidate) &&
+          candidate !== 'Resources:'
+        ) {
+          out.statement = candidate
+          i++
+        }
+        if (lines[i] === '') i++
+      }
+    } else {
+      // Prefix line matched but the address line didn't. The original
+      // regex required them as a pair, so reject the partial prefix to
+      // stay consistent.
+      delete out.scheme
+      delete out.domain
     }
-  const resources = message.split('Resources:')[1]?.split('\n- ').slice(1)
-  return {
-    ...prefix,
-    ...suffix,
-    ...(chainId ? { chainId: Number(chainId) } : {}),
-    ...(expirationTime ? { expirationTime: new Date(expirationTime) } : {}),
-    ...(issuedAt ? { issuedAt: new Date(issuedAt) } : {}),
-    ...(notBefore ? { notBefore: new Date(notBefore) } : {}),
-    ...(requestId ? { requestId } : {}),
-    ...(resources ? { resources } : {}),
-    ...(scheme ? { scheme } : {}),
-    ...(statement ? { statement } : {}),
   }
+
+  // Walk the remainder for `Key: value` labels and the optional resources block.
+  for (; i < lines.length; i++) {
+    const line = lines[i]!
+    if (line === 'Resources:') {
+      const resources: string[] = []
+      while (i + 1 < lines.length && lines[i + 1]!.startsWith('- ')) {
+        i++
+        resources.push(lines[i]!.slice(2))
+      }
+      if (resources.length > 0) out.resources = resources
+      continue
+    }
+    const labelMatch = line.match(labelRegex)
+    if (!labelMatch) continue
+    const [, key, value] = labelMatch as unknown as [string, string, string]
+    switch (key) {
+      case 'URI':
+        out.uri = value
+        break
+      case 'Version':
+        out.version = value
+        break
+      case 'Chain ID': {
+        const n = Number(value)
+        if (Number.isFinite(n)) out.chainId = n
+        break
+      }
+      case 'Nonce':
+        out.nonce = value
+        break
+      case 'Issued At':
+        out.issuedAt = new Date(value)
+        break
+      case 'Expiration Time':
+        out.expirationTime = new Date(value)
+        break
+      case 'Not Before':
+        out.notBefore = new Date(value)
+        break
+      case 'Request ID':
+        out.requestId = value
+        break
+    }
+  }
+
+  return out as ExactPartial<Message>
 }
+
+/** @internal */
+const prefixLineRegex =
+  /^(?:(?<scheme>[a-zA-Z][a-zA-Z0-9+\-.]*):\/\/)?(?<domain>[a-zA-Z0-9+\-.]*(?::[0-9]{1,5})?) wants you to sign in with your Ethereum account:$/
+
+/** @internal */
+const addressLineRegex = /^(0x[a-fA-F0-9]{40})$/
+
+/** @internal */
+const labelRegex =
+  /^(URI|Version|Chain ID|Nonce|Issued At|Expiration Time|Not Before|Request ID): (.+)$/
 
 /**
  * Validates [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) message.

--- a/src/core/TypedData.ts
+++ b/src/core/TypedData.ts
@@ -107,42 +107,36 @@ export function assert<
     value as unknown as assert.Value
 
   const validateValue = (type: string, value: unknown, name: string) => {
-    // Array types: validate length (if fixed) and recurse into each element.
-    const arrayMatch = type.match(Solidity.arrayRegex)
-    if (arrayMatch) {
-      const [, elementType, lengthStr] = arrayMatch
+    const parsed = getParsedType(types, type)
+    if (parsed.kind === 'array') {
       if (!Array.isArray(value))
         throw new InvalidArrayError({ name, type, value })
-      if (lengthStr) {
-        const expected = Number.parseInt(lengthStr, 10)
-        if (value.length !== expected)
-          throw new InvalidArrayLengthError({
-            name,
-            type,
-            expectedLength: expected,
-            givenLength: value.length,
-          })
-      }
-      for (const element of value) validateValue(elementType!, element, name)
+      if (parsed.length !== undefined && value.length !== parsed.length)
+        throw new InvalidArrayLengthError({
+          name,
+          type,
+          expectedLength: parsed.length,
+          givenLength: value.length,
+        })
+      for (const element of value)
+        validateValue(parsed.elementType, element, name)
       return
     }
 
-    const integerMatch = type.match(Solidity.integerRegex)
     if (
-      integerMatch &&
+      parsed.kind === 'integer' &&
       (typeof value === 'number' || typeof value === 'bigint')
     ) {
-      const [, base, size_] = integerMatch
       // If number cannot be cast to a sized hex value, it is out of range
       // and will throw.
       Hex.fromNumber(value, {
-        signed: base === 'int',
-        size: Number.parseInt(size_ ?? '', 10) / 8,
+        signed: parsed.signed,
+        size: parsed.sizeBytes,
       })
     }
 
     if (
-      type === 'address' &&
+      parsed.kind === 'address' &&
       typeof value === 'string' &&
       !Address.validate(value)
     )
@@ -151,20 +145,17 @@ export function assert<
         cause: new Address.InvalidInputError(),
       })
 
-    const bytesMatch = type.match(Solidity.bytesRegex)
-    if (bytesMatch) {
-      const [, size] = bytesMatch
-      if (size && Hex.size(value as Hex.Hex) !== Number.parseInt(size, 10))
+    if (parsed.kind === 'fixedBytes') {
+      if (Hex.size(value as Hex.Hex) !== parsed.size)
         throw new BytesSizeMismatchError({
-          expectedSize: Number.parseInt(size, 10),
+          expectedSize: parsed.size,
           givenSize: Hex.size(value as Hex.Hex),
         })
     }
 
-    const struct = types[type]
-    if (struct) {
+    if (parsed.kind === 'struct') {
       validateReference(type)
-      validateData(struct, value as Record<string, unknown>)
+      validateData(types[type]!, value as Record<string, unknown>)
     }
   }
 
@@ -901,8 +892,9 @@ export function encodeField(properties: {
   typeHashes?: Map<string, Hex.Hex> | undefined
 }): [type: AbiParameters.Parameter, value: Hex.Hex] {
   let { types, name, type, value, typeHashes } = properties
+  const parsed = getParsedType(types, type)
 
-  if (types[type] !== undefined)
+  if (parsed.kind === 'struct')
     return [
       { type: 'bytes32' },
       Hash.keccak256(
@@ -910,40 +902,33 @@ export function encodeField(properties: {
       ),
     ]
 
-  if (type === 'bytes') {
+  if (parsed.kind === 'bytes') {
     const prepend = value.length % 2 ? '0' : ''
     value = `0x${prepend + value.slice(2)}`
     return [{ type: 'bytes32' }, Hash.keccak256(value, { as: 'Hex' })]
   }
 
-  if (type === 'string')
+  if (parsed.kind === 'string')
     return [
       { type: 'bytes32' },
       Hash.keccak256(Bytes.fromString(value), { as: 'Hex' }),
     ]
 
-  if (type.lastIndexOf(']') === type.length - 1) {
-    const arrayMatch = type.match(Solidity.arrayRegex)
-    const parsedType = arrayMatch
-      ? arrayMatch[1]!
-      : type.slice(0, type.lastIndexOf('['))
-    const fixedLength = arrayMatch?.[2]
-      ? Number.parseInt(arrayMatch[2], 10)
-      : undefined
+  if (parsed.kind === 'array') {
     if (!Array.isArray(value))
       throw new InvalidArrayError({ name, type, value })
-    if (fixedLength !== undefined && value.length !== fixedLength)
+    if (parsed.length !== undefined && value.length !== parsed.length)
       throw new InvalidArrayLengthError({
         name,
         type,
-        expectedLength: fixedLength,
+        expectedLength: parsed.length,
         givenLength: value.length,
       })
     const typeValuePairs = (value as [AbiParameters.Parameter, any][]).map(
       (item) =>
         encodeField({
           name,
-          type: parsedType,
+          type: parsed.elementType,
           types,
           value: item,
           typeHashes,
@@ -1012,4 +997,106 @@ function validateReference(type: string) {
     type.startsWith('int')
   )
     throw new InvalidStructTypeError({ type })
+}
+
+/** @internal */
+type ParsedType =
+  | { kind: 'array'; elementType: string; length: number | undefined }
+  | { kind: 'integer'; signed: boolean; sizeBytes: number }
+  | { kind: 'address' }
+  | { kind: 'bool' }
+  | { kind: 'string' }
+  | { kind: 'bytes' }
+  | { kind: 'fixedBytes'; size: number }
+  | { kind: 'struct' }
+  | { kind: 'unknown' }
+
+/**
+ * Per-`types`-reference cache of parsed type metadata. Avoids re-running
+ * `Solidity.arrayRegex` / `Solidity.integerRegex` / `Solidity.bytesRegex`
+ * (and the `types[type]` lookup) on every call into `assert.validateValue`
+ * and `encodeField` for the same `(types, type)` pair.
+ *
+ * @internal
+ */
+const parsedTypeCache = new WeakMap<object, Map<string, ParsedType>>()
+
+/** @internal */
+function getParsedType(
+  types: TypedData | Record<string, unknown>,
+  type: string,
+): ParsedType {
+  let perTypes = parsedTypeCache.get(types as object)
+  if (!perTypes) {
+    perTypes = new Map()
+    parsedTypeCache.set(types as object, perTypes)
+  }
+  const cached = perTypes.get(type)
+  if (cached) return cached
+  const parsed = parseType(types, type)
+  perTypes.set(type, parsed)
+  return parsed
+}
+
+/** @internal */
+function parseType(
+  types: TypedData | Record<string, unknown>,
+  type: string,
+): ParsedType {
+  // User-defined types take precedence so a struct named after a Solidity
+  // primitive (e.g. `address`) reaches `validateReference` and throws
+  // `InvalidStructTypeError`, matching the original lookup-after-primitive
+  // ordering in `validateValue`.
+  if ((types as Record<string, unknown>)[type] !== undefined)
+    return { kind: 'struct' }
+
+  // array (e.g. `uint256[2]`, `Person[]`)
+  if (type.charCodeAt(type.length - 1) === 0x5d /* `]` */) {
+    const arrayMatch = type.match(Solidity.arrayRegex)
+    if (arrayMatch) {
+      const [, elementType, lengthStr] = arrayMatch
+      return {
+        kind: 'array',
+        elementType: elementType!,
+        length: lengthStr ? Number.parseInt(lengthStr, 10) : undefined,
+      }
+    }
+  }
+
+  if (type === 'address') return { kind: 'address' }
+  if (type === 'bool') return { kind: 'bool' }
+  if (type === 'string') return { kind: 'string' }
+  if (type === 'bytes') return { kind: 'bytes' }
+
+  // fixed bytes (e.g. `bytes32`)
+  if (type.startsWith('bytes')) {
+    const bytesMatch = type.match(Solidity.bytesRegex)
+    if (bytesMatch) {
+      const [, sizeStr] = bytesMatch
+      // `bytes` (no width) is handled above; the regex only matches sized
+      // variants here, so `sizeStr` is always defined.
+      return {
+        kind: 'fixedBytes',
+        size: Number.parseInt(sizeStr ?? '0', 10),
+      }
+    }
+  }
+
+  // (u)int (e.g. `uint8`, `int256`)
+  if (type.startsWith('int') || type.startsWith('uint')) {
+    const integerMatch = type.match(Solidity.integerRegex)
+    if (integerMatch) {
+      const [, base, sizeStr] = integerMatch
+      return {
+        kind: 'integer',
+        signed: base === 'int',
+        // Preserves legacy behavior for unsized `uint` / `int`: passes
+        // `NaN` through to `Hex.fromNumber({ size })`, matching what the
+        // original inline regex code did.
+        sizeBytes: Number.parseInt(sizeStr ?? '', 10) / 8,
+      }
+    }
+  }
+
+  return { kind: 'unknown' }
 }

--- a/src/core/_test/BinaryStateTree.test.ts
+++ b/src/core/_test/BinaryStateTree.test.ts
@@ -137,7 +137,7 @@ describe('insert', () => {
       Bytes.fromHex(('0x' + '02'.repeat(32)) as Hex.Hex),
     )
     expect(getHeight(tree.root)).toBe(1)
-    expect(Hex.fromBytes(tree.root.values![1]!)).toMatchInlineSnapshot(
+    expect(Hex.fromBytes(tree.root.values!.get(1)!)).toMatchInlineSnapshot(
       `"0x0202020202020202020202020202020202020202020202020202020202020202"`,
     )
   })


### PR DESCRIPTION
Perf + parsing rewrites for `Siwe`, `BinaryStateTree`, and `TypedData`.

Highlights:

- Rewrites `Siwe.parseMessage` as a single-pass line iterator that pulls the prefix block off the top, then iterates the remainder once for `Key: value` labels and the optional `Resources:` block. The exported `prefixRegex` / `suffixRegex` constants stay for back-compat; only internal call sites change.
- `BinaryStateTree` gains a `getBit(stem, depth)` direct-bit accessor used from `insert` / `splitLeaf`, removing per-recursion `bytesToBits(stem)` allocations and the `bitsToBytes(stemBits)` reconstruction in `splitLeaf`. `StemNode.values` switches from a 256-slot array to a `Map<number, Bytes>`, and `merkelize` reuses module-level `ZERO32` / `ZERO1` buffers and a single 256-entry scratch array halved in place across the 8 reduction levels.
- `TypedData.assert` and `TypedData.encodeField` share a per-`types` `WeakMap<types, Map<typeString, ParsedType>>` so `Solidity.arrayRegex` / `integerRegex` / `bytesRegex` and `types[type]` lookups run once per unique `(types, type)` pair instead of once per field per call.
