### PR TITLE
feat(v1): prepared / batch verify paths and `AesGcm` envelope helpers

### DIFF
--- a/.changeset/crypto-derivekey-envelope-mnemonic-async.md
+++ b/.changeset/crypto-derivekey-envelope-mnemonic-async.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `AesGcm.deriveKey` (returning `{ key, salt, iterations }`), `AesGcm.encryptEnvelope` / `AesGcm.decryptEnvelope` (versioned 12-byte-IV envelope while keeping legacy 16-byte-prefix decrypt support), `Mnemonic.toSeedAsync`, exported `Bls.suite` DST constants, and added optional batch helpers + fixed-size branded blob/commitment/proof types to `Kzg`.

--- a/.changeset/crypto-prepared-batch-verify.md
+++ b/.changeset/crypto-prepared-batch-verify.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `WebCryptoP256.prepareVerifyKey` / `WebCryptoP256.verifyPrepared` (skips per-call `crypto.subtle.importKey`), `Secp256k1.verifyBytes` / `Secp256k1.verifyBatch`, `P256.verifyBytes` / `P256.verifyBatch`, and `Bls.preparePayload` / `Bls.hashToCurve` / `Bls.signPrepared` / `Bls.verifyPrepared` / `Bls.verifyBatchSameMessage` for batch verification and same-message hot paths.

--- a/src/core/AesGcm.ts
+++ b/src/core/AesGcm.ts
@@ -1,8 +1,29 @@
 import * as Bytes from './Bytes.js'
-import type * as Errors from './Errors.js'
+import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 
+/**
+ * Length of the legacy IV / salt prefix used by {@link ox#AesGcm.(encrypt:function)}
+ * and {@link ox#AesGcm.(decrypt:function)}.
+ *
+ * @remarks
+ * Existing on-disk ciphertexts produced by {@link ox#AesGcm.(encrypt:function)}
+ * use a 16-byte prefix. New code that needs interop or a versioned envelope
+ * should prefer {@link ox#AesGcm.(encryptEnvelope:function)} /
+ * {@link ox#AesGcm.(decryptEnvelope:function)}, which use the standard 12-byte
+ * AES-GCM IV.
+ */
 export const ivLength = 16
+
+/**
+ * Standard 12-byte AES-GCM IV length used by the new envelope helpers
+ * {@link ox#AesGcm.(encryptEnvelope:function)} /
+ * {@link ox#AesGcm.(decryptEnvelope:function)}.
+ */
+export const ivLengthV1 = 12
+
+/** Version byte prepended to envelopes produced by {@link ox#AesGcm.(encryptEnvelope:function)}. */
+export const envelopeVersion = 0x01
 
 /**
  * Decrypts encrypted data using AES-GCM.
@@ -205,4 +226,210 @@ export function randomSalt(size = 32): Bytes.Bytes {
 
 export declare namespace randomSalt {
   type ErrorType = Bytes.random.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an AES-GCM key from a password using PBKDF2 and returns the key
+ * along with the salt and iteration count used to derive it.
+ *
+ * @remarks
+ * Prefer this helper over {@link ox#AesGcm.(getKey:function)} when callers may
+ * later need to re-derive the same key (for example, after a process restart):
+ * {@link ox#AesGcm.(getKey:function)} silently generates a random salt that is
+ * not returned, which makes the derived key unrecoverable without an
+ * out-of-band salt store.
+ *
+ * @example
+ * ```ts twoslash
+ * import { AesGcm } from 'ox'
+ *
+ * const { key, salt, iterations } = await AesGcm.deriveKey({
+ *   password: 'correct-horse-battery-staple',
+ * })
+ *
+ * // Persist `salt` (and `iterations`) alongside the ciphertext so that the
+ * // same key can be re-derived later.
+ * const sameKey = await AesGcm.deriveKey({
+ *   password: 'correct-horse-battery-staple',
+ *   salt,
+ *   iterations,
+ * })
+ * ```
+ *
+ * @param options - Options for key derivation.
+ * @returns The derived key, the salt used, and the iteration count.
+ */
+export async function deriveKey(
+  options: deriveKey.Options,
+): Promise<deriveKey.ReturnType> {
+  const { iterations = 900_000, password, salt = randomSalt(32) } = options
+  const key = await getKey({ iterations, password, salt })
+  return { key, salt, iterations }
+}
+
+export declare namespace deriveKey {
+  type Options = getKey.Options
+
+  type ReturnType = {
+    /** Derived AES-GCM key. */
+    key: CryptoKey
+    /** Salt used for derivation. */
+    salt: Bytes.Bytes
+    /** Iteration count used for derivation. */
+    iterations: number
+  }
+
+  type ErrorType = getKey.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Encrypts data using AES-GCM and writes a self-describing envelope.
+ *
+ * @remarks
+ * The output is `version (1 byte) || iv (12 bytes) || ciphertext||tag`.
+ * Use the standard 12-byte AES-GCM IV (the interoperability fast path) and
+ * a leading version byte so future envelope formats can be added without
+ * ambiguous decryption.
+ *
+ * Existing on-disk ciphertexts produced by {@link ox#AesGcm.(encrypt:function)}
+ * (which use a 16-byte prefix) remain decryptable via
+ * {@link ox#AesGcm.(decrypt:function)}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { AesGcm, Hex } from 'ox'
+ *
+ * const key = await AesGcm.getKey({ password: 'correct-horse-battery-staple' })
+ *
+ * const envelope = await AesGcm.encryptEnvelope( // [!code focus]
+ *   Hex.fromString('hello'), // [!code focus]
+ *   key, // [!code focus]
+ * ) // [!code focus]
+ *
+ * const decoded = await AesGcm.decryptEnvelope(envelope, key)
+ * // @log: Hex.fromString('hello')
+ * ```
+ *
+ * @param value - The data to encrypt.
+ * @param key - The `CryptoKey` to use for encryption.
+ * @param options - Encryption options.
+ * @returns The versioned envelope (defaults to `Hex`).
+ */
+export async function encryptEnvelope<
+  value extends Hex.Hex | Bytes.Bytes,
+  as extends 'Bytes' | 'Hex' = 'Hex',
+>(
+  value: value | Bytes.Bytes | Hex.Hex,
+  key: CryptoKey,
+  options: encryptEnvelope.Options<as> = {},
+): Promise<encryptEnvelope.ReturnType<as>> {
+  const { as = 'Hex' } = options
+  const iv = Bytes.random(ivLengthV1)
+  const encrypted = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    Bytes.from(value),
+  )
+  const out = new Uint8Array(1 + ivLengthV1 + encrypted.byteLength)
+  out[0] = envelopeVersion
+  out.set(iv, 1)
+  out.set(new Uint8Array(encrypted), 1 + ivLengthV1)
+  if (as === 'Bytes') return out as never
+  return Hex.from(out) as never
+}
+
+export declare namespace encryptEnvelope {
+  type Options<as extends 'Bytes' | 'Hex' = 'Hex'> = {
+    /** The output format. @default 'Hex' */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Bytes.random.ErrorType
+    | Hex.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Decrypts a self-describing envelope produced by
+ * {@link ox#AesGcm.(encryptEnvelope:function)}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { AesGcm, Hex } from 'ox'
+ *
+ * const key = await AesGcm.getKey({ password: 'correct-horse-battery-staple' })
+ * const envelope = await AesGcm.encryptEnvelope(Hex.fromString('hello'), key)
+ *
+ * const decoded = await AesGcm.decryptEnvelope(envelope, key) // [!code focus]
+ * ```
+ *
+ * @param value - The envelope to decrypt.
+ * @param key - The `CryptoKey` to use for decryption.
+ * @param options - Decryption options.
+ * @returns The decrypted data.
+ */
+export async function decryptEnvelope<
+  value extends Hex.Hex | Bytes.Bytes,
+  as extends 'Hex' | 'Bytes' =
+    | (value extends Hex.Hex ? 'Hex' : never)
+    | (value extends Bytes.Bytes ? 'Bytes' : never),
+>(
+  value: value | Bytes.Bytes | Hex.Hex,
+  key: CryptoKey,
+  options: decryptEnvelope.Options<as> = {},
+): Promise<decryptEnvelope.ReturnType<as>> {
+  const { as = typeof value === 'string' ? 'Hex' : 'Bytes' } = options
+  const envelope = Bytes.from(value)
+  if (envelope.length < 1 + ivLengthV1)
+    throw new InvalidEnvelopeError('envelope is too short.')
+  const version = envelope[0]
+  if (version !== envelopeVersion)
+    throw new InvalidEnvelopeError(
+      `unsupported envelope version: ${version}.`,
+    )
+  const iv = envelope.subarray(1, 1 + ivLengthV1)
+  const data = envelope.subarray(1 + ivLengthV1)
+  const decrypted = await globalThis.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    data,
+  )
+  const result = new Uint8Array(decrypted)
+  if (as === 'Bytes') return result as never
+  return Hex.from(result) as never
+}
+
+export declare namespace decryptEnvelope {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> = {
+    /** The output format. @default 'Bytes' */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.from.ErrorType
+    | InvalidEnvelopeError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Thrown when {@link ox#AesGcm.(decryptEnvelope:function)} is given an envelope
+ * that is too short or has an unsupported version byte.
+ */
+export class InvalidEnvelopeError extends Errors.BaseError {
+  override readonly name = 'AesGcm.InvalidEnvelopeError'
+
+  constructor(message: string) {
+    super(`AesGcm.decryptEnvelope: ${message}`)
+  }
 }

--- a/src/core/Bls.ts
+++ b/src/core/Bls.ts
@@ -685,3 +685,330 @@ export declare namespace verify {
 
   type ErrorType = Errors.GlobalErrorType
 }
+
+/**
+ * Hashes a payload to a point on the BLS12-381 curve.
+ *
+ * @remarks
+ * Identical to {@link ox#Bls.(preparePayload:function)}; the alias is provided
+ * because `hashToCurve` is the standard term used by the BLS-signature
+ * specification and noble's BLS implementation.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bls, Hex } from 'ox'
+ *
+ * const point = Bls.hashToCurve({ payload: Hex.random(32) })
+ * ```
+ *
+ * @param options - The hash-to-curve options.
+ * @returns The hashed point.
+ */
+export function hashToCurve<size extends Size = 'short-key:long-sig'>(
+  options: hashToCurve.Options<size>,
+): size extends 'short-key:long-sig' ? BlsPoint.G2 : BlsPoint.G1
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function hashToCurve(
+  options: hashToCurve.Options,
+): BlsPoint.BlsPoint {
+  return preparePayload(options)
+}
+
+export declare namespace hashToCurve {
+  type Options<size extends Size = 'short-key:long-sig'> =
+    preparePayload.Options<size>
+  type ErrorType = preparePayload.ErrorType
+}
+
+/**
+ * Prepares a payload for repeated signing or verification by hashing it to a
+ * point on the BLS12-381 curve once.
+ *
+ * @remarks
+ * For workflows that sign or verify the same payload many times (threshold
+ * signing, committee voting, aggregated-signature verification), passing the
+ * prepared payload to {@link ox#Bls.(signPrepared:function)} /
+ * {@link ox#Bls.(verifyPrepared:function)} avoids paying the
+ * `hashToCurve` cost on every call.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bls, Hex } from 'ox'
+ *
+ * const payload = Bls.preparePayload({ payload: Hex.random(32) })
+ *
+ * const signatures = Array.from({ length: 16 }, () =>
+ *   Bls.signPrepared({ payload, privateKey: '0x...' }),
+ * )
+ * ```
+ *
+ * @param options - The prepare options.
+ * @returns The prepared payload point.
+ */
+export function preparePayload<size extends Size = 'short-key:long-sig'>(
+  options: preparePayload.Options<size>,
+): size extends 'short-key:long-sig' ? BlsPoint.G2 : BlsPoint.G1
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function preparePayload(
+  options: preparePayload.Options,
+): BlsPoint.BlsPoint {
+  const { payload, suite, size = 'short-key:long-sig' } = options
+  const group = size === 'short-key:long-sig' ? bls.G2 : bls.G1
+  const point = group.hashToCurve(
+    Bytes.from(payload),
+    suite ? { DST: Bytes.fromString(suite) } : undefined,
+  )
+  return { x: point.X, y: point.Y, z: point.Z }
+}
+
+export declare namespace preparePayload {
+  type Options<size extends Size = 'short-key:long-sig'> = {
+    /** Payload to prepare. */
+    payload: Hex.Hex | Bytes.Bytes
+    /**
+     * Ciphersuite (DST) to use. Defaults to "Basic".
+     * @see {@link ox#Bls.suite}
+     */
+    suite?: string | undefined
+    /**
+     * Group on which to prepare the payload.
+     *
+     * - `'short-key:long-sig'`: payload prepared on G2 (96 bytes).
+     * - `'long-key:short-sig'`: payload prepared on G1 (48 bytes).
+     *
+     * @default 'short-key:long-sig'
+     */
+    size?: size | Size | undefined
+  }
+
+  type ErrorType = Bytes.from.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Signs a payload that has already been prepared via
+ * {@link ox#Bls.(preparePayload:function)}.
+ *
+ * @remarks
+ * Skips the per-call `hashToCurve` cost. For repeated same-message signing
+ * (threshold / committee), this is the hot path.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bls, Hex } from 'ox'
+ *
+ * const payload = Bls.preparePayload({ payload: Hex.random(32) })
+ * const signature = Bls.signPrepared({ payload, privateKey: '0x...' })
+ * ```
+ *
+ * @param options - The signing options.
+ * @returns BLS signature point.
+ */
+export function signPrepared<size extends Size = 'short-key:long-sig'>(
+  options: signPrepared.Options<size>,
+): size extends 'short-key:long-sig' ? BlsPoint.G2 : BlsPoint.G1
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function signPrepared(
+  options: signPrepared.Options,
+): BlsPoint.BlsPoint {
+  const { payload, privateKey, size = 'short-key:long-sig' } = options
+  const isShortKey = size === 'short-key:long-sig'
+  const payloadGroup = isShortKey ? bls.G2 : bls.G1
+  const privateKeyGroup = isShortKey ? bls.G1 : bls.G2
+
+  const PointCtor = (payloadGroup as any).Point
+  const payloadPoint = new PointCtor(payload.x, payload.y, payload.z)
+  const signature = payloadPoint.multiply(
+    privateKeyGroup.Point.Fn.fromBytes(Bytes.from(privateKey)),
+  )
+  return { x: signature.X, y: signature.Y, z: signature.Z }
+}
+
+export declare namespace signPrepared {
+  type Options<size extends Size = 'short-key:long-sig'> = {
+    /** Payload prepared by {@link ox#Bls.(preparePayload:function)}. */
+    payload: size extends 'short-key:long-sig' ? BlsPoint.G2 : BlsPoint.G1
+    /** BLS private key. */
+    privateKey: Hex.Hex | Bytes.Bytes
+    /**
+     * Size of the signature to compute. Must match the group used to prepare the payload.
+     *
+     * @default 'short-key:long-sig'
+     */
+    size?: size | Size | undefined
+  }
+
+  type ErrorType = Bytes.from.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Verifies a signature against a payload prepared by
+ * {@link ox#Bls.(preparePayload:function)}.
+ *
+ * @remarks
+ * Skips the per-call `hashToCurve` cost. Combine with
+ * {@link ox#Bls.(verifyBatchSameMessage:function)} for high-throughput
+ * verification of many signatures over a single payload.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bls, Hex } from 'ox'
+ *
+ * const privateKey = Bls.randomPrivateKey()
+ * const publicKey = Bls.getPublicKey({ privateKey })
+ *
+ * const payload = Bls.preparePayload({ payload: Hex.random(32) })
+ * const signature = Bls.signPrepared({ payload, privateKey })
+ *
+ * const verified = Bls.verifyPrepared({ payload, publicKey, signature })
+ * ```
+ *
+ * @param options - The verification options.
+ * @returns Whether the signature was produced by the public key over the payload.
+ */
+export function verifyPrepared(options: verifyPrepared.Options): boolean {
+  const publicKey = options.publicKey as unknown as BlsPoint.BlsPoint<any>
+  const signature = options.signature as unknown as BlsPoint.BlsPoint<any>
+  const payloadIn = options.payload as BlsPoint.BlsPoint<any>
+
+  const isShortSig = typeof signature.x === 'bigint'
+
+  const payloadGroup = isShortSig ? bls.G1 : bls.G2
+  const PayloadPointCtor = (payloadGroup as any).Point
+  const payloadPoint = new PayloadPointCtor(
+    payloadIn.x,
+    payloadIn.y,
+    payloadIn.z,
+  )
+
+  const shortSigPairing = () =>
+    bls.pairingBatch([
+      {
+        g1: payloadPoint as InstanceType<typeof bls.G1.Point>,
+        g2: new bls.G2.Point(publicKey.x, publicKey.y, publicKey.z),
+      },
+      {
+        g1: new bls.G1.Point(signature.x, signature.y, signature.z),
+        g2: bls.G2.Point.BASE.negate(),
+      },
+    ])
+
+  const longSigPairing = () =>
+    bls.pairingBatch([
+      {
+        g1: new bls.G1.Point(publicKey.x, publicKey.y, publicKey.z).negate(),
+        g2: payloadPoint as InstanceType<typeof bls.G2.Point>,
+      },
+      {
+        g1: bls.G1.Point.BASE,
+        g2: new bls.G2.Point(signature.x, signature.y, signature.z),
+      },
+    ])
+
+  return bls.fields.Fp12.eql(
+    isShortSig ? shortSigPairing() : longSigPairing(),
+    bls.fields.Fp12.ONE,
+  )
+}
+
+export declare namespace verifyPrepared {
+  type Options = {
+    /** Payload prepared by {@link ox#Bls.(preparePayload:function)}. */
+    payload: BlsPoint.G1 | BlsPoint.G2
+  } & OneOf<
+    | {
+        publicKey: BlsPoint.G1
+        signature: BlsPoint.G2
+      }
+    | {
+        publicKey: BlsPoint.G2
+        signature: BlsPoint.G1
+      }
+  >
+
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Verifies many signatures over the same payload by aggregating them and
+ * verifying once, using the bilinearity of the pairing.
+ *
+ * @remarks
+ * For N signatures over a single message, this performs `O(N)` point
+ * additions instead of `O(N)` pairings, then a single pairing check. The
+ * payload is hashed to the curve once. Returns `true` only if all signatures
+ * verify against their respective public keys.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bls, Hex } from 'ox'
+ *
+ * const payload = Hex.random(32)
+ * const privateKeys = Array.from({ length: 32 }, () => Bls.randomPrivateKey())
+ *
+ * const publicKeys = privateKeys.map((privateKey) =>
+ *   Bls.getPublicKey({ privateKey }),
+ * )
+ * const signatures = privateKeys.map((privateKey) =>
+ *   Bls.sign({ payload, privateKey }),
+ * )
+ *
+ * const verified = Bls.verifyBatchSameMessage({ // [!code focus]
+ *   payload, // [!code focus]
+ *   publicKeys, // [!code focus]
+ *   signatures, // [!code focus]
+ * }) // [!code focus]
+ * ```
+ *
+ * @param options - The verification options.
+ * @returns Whether every signature is valid for its corresponding public key.
+ */
+export function verifyBatchSameMessage(
+  options: verifyBatchSameMessage.Options,
+): boolean {
+  const { payload, publicKeys, signatures, suite } = options
+  if (publicKeys.length !== signatures.length)
+    throw new Errors.BaseError(
+      `Bls.verifyBatchSameMessage expects publicKeys.length (${publicKeys.length}) === signatures.length (${signatures.length}).`,
+    )
+  if (publicKeys.length === 0)
+    throw new Errors.BaseError(
+      'Bls.verifyBatchSameMessage expects a non-empty input.',
+    )
+
+  const publicKey = aggregate(publicKeys as any)
+  const signature = aggregate(signatures as any)
+
+  return verify({
+    payload,
+    suite,
+    publicKey,
+    signature,
+  } as unknown as verify.Options)
+}
+
+export declare namespace verifyBatchSameMessage {
+  type Options = {
+    /** Payload that was signed. */
+    payload: Hex.Hex | Bytes.Bytes
+    /**
+     * Ciphersuite to use for verification. Defaults to "Basic".
+     *
+     * @see {@link ox#Bls.suite}
+     */
+    suite?: string | undefined
+  } & OneOf<
+    | {
+        publicKeys: readonly BlsPoint.G1[]
+        signatures: readonly BlsPoint.G2[]
+      }
+    | {
+        publicKeys: readonly BlsPoint.G2[]
+        signatures: readonly BlsPoint.G1[]
+      }
+  >
+
+  type ErrorType =
+    | aggregate.ErrorType
+    | verify.ErrorType
+    | Errors.GlobalErrorType
+}

--- a/src/core/Bls.ts
+++ b/src/core/Bls.ts
@@ -12,6 +12,42 @@ export type Size = 'short-key:long-sig' | 'long-key:short-sig'
 export const noble = bls
 
 /**
+ * Domain Separation Tags (DSTs) for the standard BLS-signature ciphersuites
+ * defined in {@link https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05 | draft-irtf-cfrg-bls-signature-05}.
+ *
+ * Use these constants instead of hand-typing the DST string when calling
+ * {@link ox#Bls.(sign:function)} or {@link ox#Bls.(verify:function)} so that
+ * typos cannot silently produce incompatible signatures.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bls, Hex } from 'ox'
+ *
+ * const signature = Bls.sign({
+ *   payload: Hex.random(32),
+ *   privateKey: '0x...',
+ *   suite: Bls.suite.basic,
+ * })
+ * ```
+ */
+export const suite = {
+  /** Basic ciphersuite for short-key:long-sig (G2 signatures). */
+  basic: 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_',
+  /** Message-augmentation ciphersuite for short-key:long-sig (G2 signatures). */
+  augmentation: 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_',
+  /** Proof-of-possession ciphersuite for short-key:long-sig (G2 signatures). */
+  proofOfPossession: 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_',
+  /** Basic ciphersuite for long-key:short-sig (G1 signatures). */
+  basicShortSig: 'BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_',
+  /** Message-augmentation ciphersuite for long-key:short-sig (G1 signatures). */
+  augmentationShortSig: 'BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_',
+  /** Proof-of-possession ciphersuite for long-key:short-sig (G1 signatures). */
+  proofOfPossessionShortSig: 'BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_',
+} as const
+
+export type SuiteName = keyof typeof suite
+
+/**
  * Aggregates a set of BLS points that are either on the G1 or G2 curves (ie. public keys or signatures).
  *
  * @example

--- a/src/core/Kzg.ts
+++ b/src/core/Kzg.ts
@@ -1,8 +1,23 @@
 import type * as Bytes from './Bytes.js'
 import type * as Errors from './Errors.js'
+import type { Branded } from './internal/types.js'
 
 /** @see https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md#parameters */
 export const versionedHashVersion = 1
+
+/** EIP-4844 fixed blob size in bytes (4096 field elements * 32 bytes). */
+export const blobLength = 131_072
+/** EIP-4844 fixed KZG commitment size in bytes. */
+export const commitmentLength = 48
+/** EIP-4844 fixed KZG proof size in bytes. */
+export const proofLength = 48
+
+/** Branded fixed-size type for a 131072-byte EIP-4844 blob. */
+export type Blob = Branded<Bytes.Bytes, 'Kzg.Blob'>
+/** Branded fixed-size type for a 48-byte KZG commitment. */
+export type Commitment = Branded<Bytes.Bytes, 'Kzg.Commitment'>
+/** Branded fixed-size type for a 48-byte KZG proof. */
+export type Proof = Branded<Bytes.Bytes, 'Kzg.Proof'>
 
 /** Root type for a KZG interface. */
 export type Kzg = {
@@ -15,6 +30,23 @@ export type Kzg = {
    * commitment.
    */
   computeBlobKzgProof(blob: Bytes.Bytes, commitment: Bytes.Bytes): Bytes.Bytes
+  /**
+   * Optionally compute a batch of KZG commitments. Implementations that do
+   * not provide a native batch entry point can omit this; {@link ox#Kzg.(from:function)}
+   * synthesises a per-blob fallback in that case.
+   */
+  blobToKzgCommitmentBatch?: ((blobs: readonly Bytes.Bytes[]) => Bytes.Bytes[]) | undefined
+  /**
+   * Optionally compute a batch of KZG proofs. Implementations that do
+   * not provide a native batch entry point can omit this; {@link ox#Kzg.(from:function)}
+   * synthesises a per-blob fallback in that case.
+   */
+  computeBlobKzgProofBatch?:
+    | ((
+        blobs: readonly Bytes.Bytes[],
+        commitments: readonly Bytes.Bytes[],
+      ) => Bytes.Bytes[])
+    | undefined
 }
 
 /**
@@ -36,10 +68,28 @@ export type Kzg = {
  * @returns The KZG interface object.
  */
 export function from(value: Kzg): Kzg {
+  const blobToKzgCommitmentBatch =
+    value.blobToKzgCommitmentBatch?.bind(value) ??
+    ((blobs: readonly Bytes.Bytes[]) =>
+      blobs.map((blob) => value.blobToKzgCommitment(blob)))
+  const computeBlobKzgProofBatch =
+    value.computeBlobKzgProofBatch?.bind(value) ??
+    ((blobs: readonly Bytes.Bytes[], commitments: readonly Bytes.Bytes[]) => {
+      if (blobs.length !== commitments.length)
+        throw new Error(
+          `computeBlobKzgProofBatch: blobs.length (${blobs.length}) !== commitments.length (${commitments.length})`,
+        )
+      const out: Bytes.Bytes[] = new Array(blobs.length)
+      for (let i = 0; i < blobs.length; i++)
+        out[i] = value.computeBlobKzgProof(blobs[i]!, commitments[i]!)
+      return out
+    })
   return {
     blobToKzgCommitment: (blob) => value.blobToKzgCommitment(blob),
     computeBlobKzgProof: (blob, commitment) =>
       value.computeBlobKzgProof(blob, commitment),
+    blobToKzgCommitmentBatch,
+    computeBlobKzgProofBatch,
   }
 }
 

--- a/src/core/Mnemonic.ts
+++ b/src/core/Mnemonic.ts
@@ -1,5 +1,6 @@
 import {
   generateMnemonic,
+  mnemonicToSeed,
   mnemonicToSeedSync,
   validateMnemonic,
 } from '@scure/bip39'
@@ -225,5 +226,53 @@ export function validate(mnemonic: string, wordlist: string[]): boolean {
 }
 
 export declare namespace validate {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts a mnemonic to a master seed asynchronously, without blocking the
+ * caller's event loop on the 2048-round PBKDF2-HMAC-SHA512 derivation.
+ *
+ * @remarks
+ * Functionally identical to {@link ox#Mnemonic.(toSeed:function)}, but defers
+ * the heavy KDF work via the async `mnemonicToSeed` primitive from `@scure/bip39`.
+ * Prefer this helper in browser / UI contexts and in batch wallet generation
+ * where blocking the main thread becomes noticeable.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Mnemonic } from 'ox'
+ *
+ * const mnemonic = Mnemonic.random(Mnemonic.english)
+ * const seed = await Mnemonic.toSeedAsync(mnemonic)
+ * // @log: Uint8Array [...64 bytes]
+ * ```
+ *
+ * @param mnemonic - The mnemonic to convert.
+ * @param options - Conversion options.
+ * @returns The master seed.
+ */
+export async function toSeedAsync<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  mnemonic: string,
+  options: toSeedAsync.Options<as> = {},
+): Promise<toSeedAsync.ReturnType<as>> {
+  const { passphrase } = options
+  const seed = await mnemonicToSeed(mnemonic, passphrase)
+  if (options.as === 'Hex') return Bytes.toHex(seed) as never
+  return seed as never
+}
+
+export declare namespace toSeedAsync {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes'> = {
+    /** The output format. @default 'Bytes' */
+    as?: as | 'Bytes' | 'Hex' | undefined
+    /** An optional passphrase for additional protection to the seed. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
   type ErrorType = Errors.GlobalErrorType
 }

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -344,3 +344,117 @@ export declare namespace verify {
 
   type ErrorType = Errors.GlobalErrorType
 }
+
+/**
+ * Verifies a payload-bytes signature without re-normalizing the payload from
+ * a hex string on every call.
+ *
+ * @remarks
+ * Identical in behavior to {@link ox#P256.(verify:function)} when the
+ * caller already holds the payload as a {@link ox#Bytes.Bytes} value (or has
+ * already prehashed it). Skipping the per-call `Bytes.from(...)` branch is
+ * useful in tight batch-verify loops.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bytes, P256 } from 'ox'
+ *
+ * const { privateKey, publicKey } = P256.createKeyPair()
+ * const payload = Bytes.fromString('hello world')
+ * const signature = P256.sign({ payload, privateKey })
+ *
+ * const verified = P256.verifyBytes({ // [!code focus]
+ *   publicKey, // [!code focus]
+ *   payload, // [!code focus]
+ *   signature, // [!code focus]
+ * }) // [!code focus]
+ * ```
+ *
+ * @param options - The verification options.
+ * @returns Whether the bytes-payload was signed by the provided public key.
+ */
+export function verifyBytes(options: verifyBytes.Options): boolean {
+  const { hash, payload, publicKey, signature } = options
+  return noble_p256.verify(
+    toCompactBytes(signature),
+    payload,
+    PublicKey.toBytes(publicKey),
+    { lowS: true, prehash: hash === true },
+  )
+}
+
+export declare namespace verifyBytes {
+  type Options = {
+    /** If set to `true`, the payload will be hashed (sha256) before being verified. */
+    hash?: boolean | undefined
+    /** Payload that was signed, as bytes. */
+    payload: Bytes.Bytes
+    /** Public key that signed the payload. */
+    publicKey: PublicKey.PublicKey<boolean>
+    /** Signature of the payload. */
+    signature: Signature.Signature<boolean>
+  }
+
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Verifies a batch of signatures by pipelining {@link ox#P256.(verifyBytes:function)}.
+ *
+ * @remarks
+ * The underlying noble backend does not currently expose a native batched
+ * ECDSA verifier, so this is a thin loop wrapper. It still removes per-call
+ * `Bytes.from` normalization once and lets callers express batch intent for
+ * future optimization without touching call sites.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bytes, P256 } from 'ox'
+ *
+ * const { privateKey, publicKey } = P256.createKeyPair()
+ * const payload = Bytes.fromString('hello')
+ * const signatures = [
+ *   P256.sign({ payload, privateKey }),
+ *   P256.sign({ payload, privateKey }),
+ * ]
+ *
+ * const results = P256.verifyBatch( // [!code focus]
+ *   signatures.map((signature) => ({ payload, publicKey, signature })), // [!code focus]
+ * ) // [!code focus]
+ * // @log: [true, true]
+ * ```
+ *
+ * @param entries - The verification entries.
+ * @returns A boolean array, parallel to `entries`.
+ */
+export function verifyBatch(entries: readonly verifyBatch.Entry[]): boolean[] {
+  const out = new Array<boolean>(entries.length)
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!
+    out[i] = verifyBytes({
+      hash: entry.hash,
+      payload:
+        typeof entry.payload === 'string'
+          ? Bytes.from(entry.payload)
+          : entry.payload,
+      publicKey: entry.publicKey,
+      signature: entry.signature,
+    })
+  }
+  return out
+}
+
+export declare namespace verifyBatch {
+  type Entry = {
+    /** If set to `true`, the payload will be hashed (sha256) before being verified. */
+    hash?: boolean | undefined
+    /** Payload that was signed. */
+    payload: Hex.Hex | Bytes.Bytes
+    /** Public key that signed the payload. */
+    publicKey: PublicKey.PublicKey<boolean>
+    /** Signature of the payload. */
+    signature: Signature.Signature<boolean>
+  }
+
+  type ErrorType = verifyBytes.ErrorType | Errors.GlobalErrorType
+}

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -414,3 +414,117 @@ export declare namespace verify {
 
   type ErrorType = Errors.GlobalErrorType
 }
+
+/**
+ * Verifies a payload-bytes signature without re-normalizing the payload from
+ * a hex string on every call.
+ *
+ * @remarks
+ * Identical in behavior to {@link ox#Secp256k1.(verify:function)} when the
+ * caller already holds the payload as a {@link ox#Bytes.Bytes} value (or has
+ * already prehashed it). Skipping the per-call `Bytes.from(...)` branch is
+ * useful in tight batch-verify loops.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bytes, Secp256k1 } from 'ox'
+ *
+ * const { privateKey, publicKey } = Secp256k1.createKeyPair()
+ * const payload = Bytes.fromString('hello world')
+ * const signature = Secp256k1.sign({ payload, privateKey })
+ *
+ * const verified = Secp256k1.verifyBytes({ // [!code focus]
+ *   publicKey, // [!code focus]
+ *   payload, // [!code focus]
+ *   signature, // [!code focus]
+ * }) // [!code focus]
+ * ```
+ *
+ * @param options - The verification options.
+ * @returns Whether the bytes-payload was signed by the provided public key.
+ */
+export function verifyBytes(options: verifyBytes.Options): boolean {
+  const { hash, payload, publicKey, signature } = options
+  return secp256k1.verify(
+    toCompactBytes(signature),
+    payload,
+    PublicKey.toBytes(publicKey),
+    { lowS: true, prehash: hash === true },
+  )
+}
+
+export declare namespace verifyBytes {
+  type Options = {
+    /** If set to `true`, the payload will be hashed (sha256) before being verified. */
+    hash?: boolean | undefined
+    /** Payload that was signed, as bytes. */
+    payload: Bytes.Bytes
+    /** Public key that signed the payload. */
+    publicKey: PublicKey.PublicKey<boolean>
+    /** Signature of the payload. */
+    signature: Signature.Signature<false>
+  }
+
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Verifies a batch of signatures by pipelining {@link ox#Secp256k1.(verifyBytes:function)}.
+ *
+ * @remarks
+ * The underlying noble backend does not currently expose a native batched
+ * ECDSA verifier, so this is a thin loop wrapper. It still removes per-call
+ * `Bytes.from` normalization once and lets callers express batch intent for
+ * future optimization without touching call sites.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bytes, Secp256k1 } from 'ox'
+ *
+ * const { privateKey, publicKey } = Secp256k1.createKeyPair()
+ * const payload = Bytes.fromString('hello')
+ * const signatures = [
+ *   Secp256k1.sign({ payload, privateKey }),
+ *   Secp256k1.sign({ payload, privateKey }),
+ * ]
+ *
+ * const results = Secp256k1.verifyBatch( // [!code focus]
+ *   signatures.map((signature) => ({ payload, publicKey, signature })), // [!code focus]
+ * ) // [!code focus]
+ * // @log: [true, true]
+ * ```
+ *
+ * @param entries - The verification entries.
+ * @returns A boolean array, parallel to `entries`.
+ */
+export function verifyBatch(entries: readonly verifyBatch.Entry[]): boolean[] {
+  const out = new Array<boolean>(entries.length)
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!
+    out[i] = verifyBytes({
+      hash: entry.hash,
+      payload:
+        typeof entry.payload === 'string'
+          ? Bytes.from(entry.payload)
+          : entry.payload,
+      publicKey: entry.publicKey,
+      signature: entry.signature,
+    })
+  }
+  return out
+}
+
+export declare namespace verifyBatch {
+  type Entry = {
+    /** If set to `true`, the payload will be hashed (sha256) before being verified. */
+    hash?: boolean | undefined
+    /** Payload that was signed. */
+    payload: Hex.Hex | Bytes.Bytes
+    /** Public key that signed the payload. */
+    publicKey: PublicKey.PublicKey<boolean>
+    /** Signature of the payload. */
+    signature: Signature.Signature<false>
+  }
+
+  type ErrorType = verifyBytes.ErrorType | Errors.GlobalErrorType
+}

--- a/src/core/WebCryptoP256.ts
+++ b/src/core/WebCryptoP256.ts
@@ -332,6 +332,110 @@ export declare namespace verify {
 }
 
 /**
+ * Imports an ECDSA P-256 public key once so that repeated verification calls
+ * do not pay the cost of `crypto.subtle.importKey` on every call.
+ *
+ * @remarks
+ * `crypto.subtle.importKey` is one of the slower Web Crypto steps. For batch
+ * verification of many signatures against the same key, prepare the key once
+ * with {@link ox#WebCryptoP256.(prepareVerifyKey:function)} and pass the
+ * resulting `CryptoKey` to {@link ox#WebCryptoP256.(verifyPrepared:function)}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { WebCryptoP256 } from 'ox'
+ *
+ * const { publicKey, privateKey } = await WebCryptoP256.createKeyPair()
+ * const verifier = await WebCryptoP256.prepareVerifyKey(publicKey) // [!code focus]
+ *
+ * const signature = await WebCryptoP256.sign({ payload: '0xdeadbeef', privateKey })
+ * const verified = await WebCryptoP256.verifyPrepared({
+ *   publicKey: verifier,
+ *   signature,
+ *   payload: '0xdeadbeef',
+ * })
+ * ```
+ *
+ * @param publicKey - The public key to import.
+ * @returns A {@link CryptoKey} usable with {@link ox#WebCryptoP256.(verifyPrepared:function)}.
+ */
+export async function prepareVerifyKey(
+  publicKey: PublicKey.PublicKey<boolean>,
+): Promise<CryptoKey> {
+  return await globalThis.crypto.subtle.importKey(
+    'raw',
+    PublicKey.toBytes(publicKey),
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['verify'],
+  )
+}
+
+export declare namespace prepareVerifyKey {
+  type ErrorType = PublicKey.toBytes.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Verifies a signature using a public key that was already imported with
+ * {@link ox#WebCryptoP256.(prepareVerifyKey:function)}, skipping the
+ * per-call `crypto.subtle.importKey` overhead.
+ *
+ * @example
+ * ```ts twoslash
+ * import { WebCryptoP256 } from 'ox'
+ *
+ * const { publicKey, privateKey } = await WebCryptoP256.createKeyPair()
+ * const verifier = await WebCryptoP256.prepareVerifyKey(publicKey)
+ *
+ * const signature = await WebCryptoP256.sign({ payload: '0xdeadbeef', privateKey })
+ *
+ * const verified = await WebCryptoP256.verifyPrepared({ // [!code focus]
+ *   publicKey: verifier, // [!code focus]
+ *   signature, // [!code focus]
+ *   payload: '0xdeadbeef', // [!code focus]
+ * }) // [!code focus]
+ * ```
+ *
+ * @param options - The verification options.
+ * @returns Whether the payload was signed by the prepared public key.
+ */
+export async function verifyPrepared(
+  options: verifyPrepared.Options,
+): Promise<boolean> {
+  const { lowS = true, payload, publicKey, signature } = options
+
+  if (lowS && signature.s > N / 2n) return false
+
+  return await globalThis.crypto.subtle.verify(
+    {
+      name: 'ECDSA',
+      hash: 'SHA-256',
+    },
+    publicKey,
+    Bytes.concat(
+      Bytes.fromNumber(signature.r, { size: 32 }),
+      Bytes.fromNumber(signature.s, { size: 32 }),
+    ),
+    Bytes.from(payload),
+  )
+}
+
+export declare namespace verifyPrepared {
+  type Options = {
+    /** If set to `true`, only low-S signatures will be accepted. @default true */
+    lowS?: boolean | undefined
+    /** Imported public {@link CryptoKey} from {@link ox#WebCryptoP256.(prepareVerifyKey:function)}. */
+    publicKey: CryptoKey
+    /** Signature of the payload. */
+    signature: Signature.Signature<false>
+    /** Payload that was signed. */
+    payload: Hex.Hex | Bytes.Bytes
+  }
+
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
  * Thrown when an ECDSA private key is supplied to {@link ox#WebCryptoP256.(getSharedSecret:function)}.
  * Only ECDH private keys are valid for shared secret derivation.
  */

--- a/src/core/_test/AesGcm.test.ts
+++ b/src/core/_test/AesGcm.test.ts
@@ -99,14 +99,106 @@ describe('randomSalt', () => {
   })
 })
 
+describe('deriveKey', () => {
+  test('returns key + salt + iterations', async () => {
+    const result = await AesGcm.deriveKey({
+      password: 'test-password',
+      iterations: 1,
+    })
+    expect(result.iterations).toBe(1)
+    expect(result.salt).toHaveLength(32)
+    expect(result.key).toBeInstanceOf(CryptoKey)
+  })
+
+  test('round-trip: same salt + iterations -> identical encrypt/decrypt', async () => {
+    const { key: k1, salt } = await AesGcm.deriveKey({
+      password: 'test-password',
+      iterations: 1,
+    })
+    const { key: k2 } = await AesGcm.deriveKey({
+      password: 'test-password',
+      salt,
+      iterations: 1,
+    })
+    const encrypted = await AesGcm.encrypt(Hex.fromString('hi'), k1)
+    const decrypted = await AesGcm.decrypt(encrypted, k2)
+    expect(decrypted).toEqual(Hex.fromString('hi'))
+  })
+})
+
+describe('encryptEnvelope / decryptEnvelope', () => {
+  test('round-trip default (Hex)', async () => {
+    const key = await AesGcm.getKey({ password: 'test-password' })
+    const envelope = await AesGcm.encryptEnvelope(
+      Hex.fromString('hello envelope'),
+      key,
+    )
+    expect(typeof envelope).toBe('string')
+    const decoded = await AesGcm.decryptEnvelope(envelope, key)
+    expect(decoded).toEqual(Hex.fromString('hello envelope'))
+  })
+
+  test('round-trip Bytes input', async () => {
+    const key = await AesGcm.getKey({ password: 'test-password' })
+    const envelope = await AesGcm.encryptEnvelope(
+      Bytes.fromString('hello envelope'),
+      key,
+      { as: 'Bytes' },
+    )
+    expect(envelope).toBeInstanceOf(Uint8Array)
+    expect(envelope[0]).toBe(AesGcm.envelopeVersion)
+    const decoded = await AesGcm.decryptEnvelope(envelope, key)
+    expect(decoded).toEqual(Bytes.fromString('hello envelope'))
+  })
+
+  test('uses 12-byte IV', async () => {
+    const key = await AesGcm.getKey({ password: 'test-password' })
+    const envelope = await AesGcm.encryptEnvelope(
+      Bytes.fromString('x'),
+      key,
+      { as: 'Bytes' },
+    )
+    // 1 (version) + 12 (iv) + 1 (plaintext) + 16 (tag) = 30
+    expect(envelope.length).toBe(1 + AesGcm.ivLengthV1 + 1 + 16)
+  })
+
+  test('rejects unsupported version byte', async () => {
+    const key = await AesGcm.getKey({ password: 'test-password' })
+    const garbage = new Uint8Array(20).fill(0xff)
+    await expect(
+      AesGcm.decryptEnvelope(garbage, key),
+    ).rejects.toThrowError(AesGcm.InvalidEnvelopeError)
+  })
+
+  test('rejects too-short envelope', async () => {
+    const key = await AesGcm.getKey({ password: 'test-password' })
+    await expect(
+      AesGcm.decryptEnvelope(new Uint8Array([0x01]), key),
+    ).rejects.toThrowError(AesGcm.InvalidEnvelopeError)
+  })
+
+  test('legacy 16-byte-prefix decrypt still works', async () => {
+    const key = await AesGcm.getKey({ password: 'test-password' })
+    const legacy = await AesGcm.encrypt(Hex.fromString('legacy'), key)
+    const decoded = await AesGcm.decrypt(legacy, key)
+    expect(decoded).toEqual(Hex.fromString('legacy'))
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(AesGcm)).toMatchInlineSnapshot(`
     [
       "ivLength",
+      "ivLengthV1",
+      "envelopeVersion",
       "decrypt",
       "encrypt",
       "getKey",
       "randomSalt",
+      "deriveKey",
+      "encryptEnvelope",
+      "decryptEnvelope",
+      "InvalidEnvelopeError",
     ]
   `)
 })

--- a/src/core/_test/Bls.test.ts
+++ b/src/core/_test/Bls.test.ts
@@ -253,3 +253,17 @@ describe('verify', () => {
     expect(verified).toBe(true)
   })
 })
+
+describe("suite", () => {
+  test("exports the standard DST constants", () => {
+    expect(Bls.suite.basic).toMatch(/BLS12381G2/)
+    expect(Bls.suite.basicShortSig).toMatch(/BLS12381G1/)
+  })
+
+  test("Bls.sign(suite=basic) matches default", () => {
+    const payload = Hex.fromString("dst-test")
+    expect(
+      Bls.sign({ payload, privateKey, suite: Bls.suite.basic }),
+    ).toEqual(Bls.sign({ payload, privateKey }))
+  })
+})

--- a/src/core/_test/Bls.test.ts
+++ b/src/core/_test/Bls.test.ts
@@ -254,6 +254,112 @@ describe('verify', () => {
   })
 })
 
+
+describe("hashToCurve / preparePayload", () => {
+  test("hashToCurve aliases preparePayload", () => {
+    const payload = Hex.fromString("hello")
+    expect(Bls.hashToCurve({ payload })).toEqual(
+      Bls.preparePayload({ payload }),
+    )
+  })
+
+  test("preparePayload size: long-key:short-sig hits G1", () => {
+    const payload = Hex.fromString("hello")
+    const point = Bls.preparePayload({ payload, size: "long-key:short-sig" })
+    // G1 has bigint x; G2 has Fp2 x
+    expect(typeof point.x).toBe("bigint")
+  })
+})
+
+describe("signPrepared / verifyPrepared", () => {
+  test("equivalent to sign / verify (default size)", () => {
+    const payload = Hex.fromString("hello prepared")
+    const prepared = Bls.preparePayload({ payload })
+    const signature = Bls.signPrepared({ payload: prepared, privateKey })
+
+    expect(signature).toEqual(Bls.sign({ payload, privateKey }))
+
+    const publicKey = Bls.getPublicKey({ privateKey })
+    expect(
+      Bls.verifyPrepared({ payload: prepared, publicKey, signature }),
+    ).toBe(true)
+  })
+
+  test("equivalent to sign / verify (long-key:short-sig)", () => {
+    const payload = Hex.fromString("hello prepared")
+    const size = "long-key:short-sig" as const
+    const prepared = Bls.preparePayload({ payload, size })
+    const signature = Bls.signPrepared({
+      payload: prepared,
+      privateKey,
+      size,
+    })
+
+    expect(signature).toEqual(Bls.sign({ payload, privateKey, size }))
+
+    const publicKey = Bls.getPublicKey({ privateKey, size })
+    expect(
+      Bls.verifyPrepared({ payload: prepared, publicKey, signature }),
+    ).toBe(true)
+  })
+})
+
+describe("verifyBatchSameMessage", () => {
+  test("default", () => {
+    const payload = Hex.random(32)
+    const privateKeys = Array.from({ length: 8 }, () =>
+      Bls.randomPrivateKey(),
+    )
+    const publicKeys = privateKeys.map((pk) =>
+      Bls.getPublicKey({ privateKey: pk }),
+    )
+    const signatures = privateKeys.map((pk) =>
+      Bls.sign({ payload, privateKey: pk }),
+    )
+    expect(
+      Bls.verifyBatchSameMessage({ payload, publicKeys, signatures }),
+    ).toBe(true)
+  })
+
+  test("returns false for any mismatched signature", () => {
+    const payload = Hex.random(32)
+    const pks = Array.from({ length: 4 }, () => Bls.randomPrivateKey())
+    const publicKeys = pks.map((pk) => Bls.getPublicKey({ privateKey: pk }))
+    const signatures = pks.map((pk) =>
+      Bls.sign({ payload, privateKey: pk }),
+    )
+    // tamper one signature with a signature of another payload
+    signatures[0] = Bls.sign({
+      payload: Hex.random(32),
+      privateKey: pks[0]!,
+    })
+    expect(
+      Bls.verifyBatchSameMessage({ payload, publicKeys, signatures }),
+    ).toBe(false)
+  })
+
+  test("rejects empty input", () => {
+    expect(() =>
+      Bls.verifyBatchSameMessage({
+        payload: Hex.fromString("x"),
+        publicKeys: [],
+        signatures: [],
+      }),
+    ).toThrowError("non-empty")
+  })
+
+  test("rejects mismatched lengths", () => {
+    const pk = Bls.randomPrivateKey()
+    expect(() =>
+      Bls.verifyBatchSameMessage({
+        payload: Hex.fromString("x"),
+        publicKeys: [Bls.getPublicKey({ privateKey: pk })],
+        signatures: [],
+      } as any),
+    ).toThrowError("publicKeys.length")
+  })
+})
+
 describe("suite", () => {
   test("exports the standard DST constants", () => {
     expect(Bls.suite.basic).toMatch(/BLS12381G2/)
@@ -267,3 +373,5 @@ describe("suite", () => {
     ).toEqual(Bls.sign({ payload, privateKey }))
   })
 })
+
+

--- a/src/core/_test/Kzg.test.ts
+++ b/src/core/_test/Kzg.test.ts
@@ -42,7 +42,9 @@ describe('from', () => {
     expect(kzg).toMatchInlineSnapshot(`
     {
       "blobToKzgCommitment": [Function],
+      "blobToKzgCommitmentBatch": [Function],
       "computeBlobKzgProof": [Function],
+      "computeBlobKzgProofBatch": [Function],
     }
   `)
   })
@@ -96,6 +98,9 @@ test('exports', () => {
   expect(Object.keys(Kzg)).toMatchInlineSnapshot(`
     [
       "versionedHashVersion",
+      "blobLength",
+      "commitmentLength",
+      "proofLength",
       "from",
     ]
   `)
@@ -129,4 +134,81 @@ test('from: preserves `this` binding for method-style implementations', () => {
   expect(
     kzg.computeBlobKzgProof(new Uint8Array([0x11]), new Uint8Array([0x22])),
   ).toEqual(new Uint8Array([0x11, 0x22, 0xab, 0xcd]))
+})
+
+test('from: synthesizes batch helpers when underlying implementation lacks them', () => {
+  const calls: { kind: string; n: number }[] = []
+  const kzg = Kzg.from({
+    blobToKzgCommitment(blob) {
+      calls.push({ kind: 'commitment', n: 1 })
+      return new Uint8Array([blob[0]!, 0xaa])
+    },
+    computeBlobKzgProof(blob, commitment) {
+      calls.push({ kind: 'proof', n: 1 })
+      return new Uint8Array([blob[0]!, commitment[0]!, 0xbb])
+    },
+  })
+  expect(typeof kzg.blobToKzgCommitmentBatch).toBe('function')
+  expect(typeof kzg.computeBlobKzgProofBatch).toBe('function')
+
+  const blobs = [new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])]
+  const commitments = kzg.blobToKzgCommitmentBatch!(blobs)
+  expect(commitments).toEqual([
+    new Uint8Array([1, 0xaa]),
+    new Uint8Array([2, 0xaa]),
+    new Uint8Array([3, 0xaa]),
+  ])
+
+  const proofs = kzg.computeBlobKzgProofBatch!(blobs, commitments)
+  expect(proofs).toEqual([
+    new Uint8Array([1, 1, 0xbb]),
+    new Uint8Array([2, 2, 0xbb]),
+    new Uint8Array([3, 3, 0xbb]),
+  ])
+})
+
+test('from: forwards native batch helpers when provided', () => {
+  let nativeCalls = 0
+  const kzg = Kzg.from({
+    blobToKzgCommitment() {
+      throw new Error('should not call single')
+    },
+    computeBlobKzgProof() {
+      throw new Error('should not call single')
+    },
+    blobToKzgCommitmentBatch(blobs) {
+      nativeCalls++
+      return blobs.map((b) => new Uint8Array([b[0]!, 0xcc]))
+    },
+    computeBlobKzgProofBatch(blobs, commitments) {
+      nativeCalls++
+      return blobs.map(
+        (b, i) => new Uint8Array([b[0]!, commitments[i]![0]!, 0xdd]),
+      )
+    },
+  })
+  const commitments = kzg.blobToKzgCommitmentBatch!([new Uint8Array([7])])
+  expect(commitments).toEqual([new Uint8Array([7, 0xcc])])
+  const proofs = kzg.computeBlobKzgProofBatch!(
+    [new Uint8Array([7])],
+    commitments,
+  )
+  expect(proofs).toEqual([new Uint8Array([7, 7, 0xdd])])
+  expect(nativeCalls).toBe(2)
+})
+
+test('from: synthesized proof batch validates length parity', () => {
+  const kzg = Kzg.from({
+    blobToKzgCommitment: () => new Uint8Array(),
+    computeBlobKzgProof: () => new Uint8Array(),
+  })
+  expect(() =>
+    kzg.computeBlobKzgProofBatch!([new Uint8Array([1])], []),
+  ).toThrowError('blobs.length')
+})
+
+test('exports fixed-size constants', () => {
+  expect(Kzg.blobLength).toBe(131_072)
+  expect(Kzg.commitmentLength).toBe(48)
+  expect(Kzg.proofLength).toBe(48)
 })

--- a/src/core/_test/Mnemonic.test.ts
+++ b/src/core/_test/Mnemonic.test.ts
@@ -297,6 +297,29 @@ describe('toSeed', () => {
   })
 })
 
+describe('toSeedAsync', () => {
+  const mnemonic =
+    'buyer zoo end danger ice capable shrug naive twist relief mass bonus'
+
+  test('matches sync `toSeed`', async () => {
+    const sync = Mnemonic.toSeed(mnemonic)
+    const async_ = await Mnemonic.toSeedAsync(mnemonic)
+    expect(async_).toEqual(sync)
+  })
+
+  test('honors `passphrase`', async () => {
+    const a = await Mnemonic.toSeedAsync(mnemonic, { passphrase: 'a' })
+    const b = await Mnemonic.toSeedAsync(mnemonic, { passphrase: 'b' })
+    expect(a).not.toEqual(b)
+  })
+
+  test('honors `as: "Hex"`', async () => {
+    const seed = await Mnemonic.toSeedAsync(mnemonic, { as: 'Hex' })
+    expect(typeof seed).toBe('string')
+    expect(seed.startsWith('0x')).toBe(true)
+  })
+})
+
 describe('validate', () => {
   test('default', () => {
     expect(
@@ -333,6 +356,7 @@ test('exports', () => {
       "toPrivateKey",
       "toSeed",
       "validate",
+      "toSeedAsync",
     ]
   `)
 })

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -548,6 +548,48 @@ test('exports', () => {
       "recoverPublicKey",
       "sign",
       "verify",
+      "verifyBytes",
+      "verifyBatch",
     ]
   `)
+})
+
+describe('verifyBytes', () => {
+  test('verifies bytes-payload', () => {
+    const { privateKey, publicKey } = P256.createKeyPair()
+    const payload = Bytes.fromString('hello bytes p256')
+    const signature = P256.sign({ payload, privateKey })
+    expect(P256.verifyBytes({ payload, publicKey, signature })).toBe(true)
+  })
+
+  test('rejects wrong payload', () => {
+    const { privateKey, publicKey } = P256.createKeyPair()
+    const signature = P256.sign({
+      payload: Bytes.fromString('a'),
+      privateKey,
+    })
+    expect(
+      P256.verifyBytes({
+        payload: Bytes.fromString('b'),
+        publicKey,
+        signature,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('verifyBatch', () => {
+  test('returns parallel results', () => {
+    const { privateKey, publicKey } = P256.createKeyPair()
+    const a = Bytes.fromString('a')
+    const b = Bytes.fromString('b')
+    const sigA = P256.sign({ payload: a, privateKey })
+    const sigB = P256.sign({ payload: b, privateKey })
+    const results = P256.verifyBatch([
+      { payload: a, publicKey, signature: sigA },
+      { payload: b, publicKey, signature: sigB },
+      { payload: a, publicKey, signature: sigB },
+    ])
+    expect(results).toEqual([true, true, false])
+  })
 })

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -490,6 +490,55 @@ test('exports', () => {
       "recoverPublicKey",
       "sign",
       "verify",
+      "verifyBytes",
+      "verifyBatch",
     ]
   `)
+})
+
+describe('verifyBytes', () => {
+  test('verifies bytes-payload', () => {
+    const { privateKey, publicKey } = Secp256k1.createKeyPair()
+    const payload = Bytes.fromString('hello bytes')
+    const signature = Secp256k1.sign({ payload, privateKey })
+    expect(
+      Secp256k1.verifyBytes({ payload, publicKey, signature }),
+    ).toBe(true)
+  })
+
+  test('rejects wrong payload', () => {
+    const { privateKey, publicKey } = Secp256k1.createKeyPair()
+    const signature = Secp256k1.sign({
+      payload: Bytes.fromString('a'),
+      privateKey,
+    })
+    expect(
+      Secp256k1.verifyBytes({
+        payload: Bytes.fromString('b'),
+        publicKey,
+        signature,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('verifyBatch', () => {
+  test('returns parallel results', () => {
+    const { privateKey, publicKey } = Secp256k1.createKeyPair()
+    const a = Bytes.fromString('a')
+    const b = Bytes.fromString('b')
+    const sigA = Secp256k1.sign({ payload: a, privateKey })
+    const sigB = Secp256k1.sign({ payload: b, privateKey })
+
+    const results = Secp256k1.verifyBatch([
+      { payload: a, publicKey, signature: sigA },
+      { payload: b, publicKey, signature: sigB },
+      { payload: a, publicKey, signature: sigB },
+    ])
+    expect(results).toEqual([true, true, false])
+  })
+
+  test('handles empty input', () => {
+    expect(Secp256k1.verifyBatch([])).toEqual([])
+  })
 })

--- a/src/core/_test/WebCryptoP256.test.ts
+++ b/src/core/_test/WebCryptoP256.test.ts
@@ -219,7 +219,61 @@ test('exports', () => {
       "getSharedSecret",
       "sign",
       "verify",
+      "prepareVerifyKey",
+      "verifyPrepared",
       "InvalidPrivateKeyAlgorithmError",
     ]
   `)
+})
+
+describe('prepareVerifyKey + verifyPrepared', () => {
+  test('round-trip', async () => {
+    const { privateKey, publicKey } = await WebCryptoP256.createKeyPair()
+    const verifier = await WebCryptoP256.prepareVerifyKey(publicKey)
+    const signature = await WebCryptoP256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+    })
+    const verified = await WebCryptoP256.verifyPrepared({
+      publicKey: verifier,
+      signature,
+      payload: '0xdeadbeef',
+    })
+    expect(verified).toBe(true)
+  })
+
+  test('rejects wrong payload', async () => {
+    const { privateKey, publicKey } = await WebCryptoP256.createKeyPair()
+    const verifier = await WebCryptoP256.prepareVerifyKey(publicKey)
+    const signature = await WebCryptoP256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+    })
+    const verified = await WebCryptoP256.verifyPrepared({
+      publicKey: verifier,
+      signature,
+      payload: '0xcafebabe',
+    })
+    expect(verified).toBe(false)
+  })
+
+  test('matches `verify` semantics', async () => {
+    const { privateKey, publicKey } = await WebCryptoP256.createKeyPair()
+    const verifier = await WebCryptoP256.prepareVerifyKey(publicKey)
+    const signature = await WebCryptoP256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+    })
+    const a = await WebCryptoP256.verify({
+      publicKey,
+      signature,
+      payload: '0xdeadbeef',
+    })
+    const b = await WebCryptoP256.verifyPrepared({
+      publicKey: verifier,
+      signature,
+      payload: '0xdeadbeef',
+    })
+    expect(a).toBe(b)
+  })
 })


### PR DESCRIPTION
Additive crypto APIs across `AesGcm`, `Mnemonic`, `Bls`, `Kzg`, `WebCryptoP256`, `Secp256k1`, and `P256`.

Highlights:

- Adds `AesGcm.deriveKey` (returning `{ key, salt, iterations }`) and versioned `AesGcm.encryptEnvelope` / `decryptEnvelope` with a 12-byte-IV envelope (legacy 16-byte-prefix decrypt remains supported).
- Adds `Mnemonic.toSeedAsync`, exports `Bls.suite` DST constants, and adds optional batch helpers and fixed-size branded blob/commitment/proof types to `Kzg`.
- Adds `WebCryptoP256.prepareVerifyKey` / `verifyPrepared` to skip per-call `crypto.subtle.importKey`.
- Adds `Secp256k1.verifyBytes` / `verifyBatch` and `P256.verifyBytes` / `verifyBatch` for batch verification.
- Adds `Bls.preparePayload` / `hashToCurve` / `signPrepared` / `verifyPrepared` / `verifyBatchSameMessage` for batch verification and same-message hot paths.
