### PR TITLE
feat(v1): canonical `encode` / `decode` aliases for encoding modules

### DIFF
--- a/.changeset/encoding-encode-decode-aliases.md
+++ b/.changeset/encoding-encode-decode-aliases.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added canonical `encode` / `decode` aliases on `Base32`, `Base58`, `Base64`, `CompactSize`, and `Rlp` with an `as` option for decoders.

--- a/src/core/Base32.ts
+++ b/src/core/Base32.ts
@@ -10,6 +10,8 @@ import {
 /**
  * Encodes a {@link ox#Bytes.Bytes} value to a Base32-encoded string (using the BIP-173 bech32 alphabet).
  *
+ * @deprecated Use {@link Base32#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base32, Bytes } from 'ox'
@@ -35,6 +37,8 @@ export declare namespace fromBytes {
 /**
  * Encodes a {@link ox#Hex.Hex} value to a Base32-encoded string (using the BIP-173 bech32 alphabet).
  *
+ * @deprecated Use {@link Base32#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base32 } from 'ox'
@@ -54,7 +58,40 @@ export declare namespace fromHex {
 }
 
 /**
+ * Encodes a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value to a Base32-encoded string (using the BIP-173 bech32 alphabet).
+ *
+ * Canonical alias for {@link Base32#fromBytes} / {@link Base32#fromHex}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Base32, Bytes } from 'ox'
+ *
+ * Base32.encode(new Uint8Array([0x00, 0xff, 0x00]))
+ * // @log: 'qrlsq'
+ *
+ * Base32.encode('0x00ff00')
+ * // @log: 'qrlsq'
+ * ```
+ *
+ * @param value - The byte array or hex value to encode.
+ * @returns The Base32 encoded string.
+ */
+export function encode(value: Bytes.Bytes | Hex.Hex): string {
+  if (value instanceof Uint8Array) return fromBytes(value)
+  return fromBytes(Bytes.fromHex(value))
+}
+
+export declare namespace encode {
+  type ErrorType =
+    | fromBytes.ErrorType
+    | Bytes.fromHex.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Decodes a Base32-encoded string (using the BIP-173 bech32 alphabet) to {@link ox#Bytes.Bytes}.
+ *
+ * @deprecated Use {@link Base32#decode} instead. Will be removed in a future major.
  *
  * @example
  * ```ts twoslash
@@ -99,6 +136,8 @@ export declare namespace toBytes {
 /**
  * Decodes a Base32-encoded string (using the BIP-173 bech32 alphabet) to {@link ox#Hex.Hex}.
  *
+ * @deprecated Use {@link Base32#decode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base32 } from 'ox'
@@ -114,6 +153,49 @@ export function toHex(value: string): Hex.Hex {
 }
 
 export declare namespace toHex {
+  type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Decodes a Base32-encoded string (using the BIP-173 bech32 alphabet) to a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
+ *
+ * Canonical alias for {@link Base32#toBytes} / {@link Base32#toHex}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Base32 } from 'ox'
+ *
+ * Base32.decode('qrlsq')
+ * // @log: Uint8Array [ 0, 255, 0 ]
+ *
+ * Base32.decode('qrlsq', { as: 'Hex' })
+ * // @log: '0x00ff00'
+ * ```
+ *
+ * @param value - The Base32 encoded string.
+ * @param options - Decoding options.
+ * @returns The decoded value.
+ */
+export function decode<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  value: string,
+  options: decode.Options<as> = {},
+): decode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  const bytes = toBytes(value)
+  if (as === 'Hex') return Hex.fromBytes(bytes) as decode.ReturnType<as>
+  return bytes as decode.ReturnType<as>
+}
+
+export declare namespace decode {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> = {
+    /** The format to return the decoded value in. */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
   type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
 }
 

--- a/src/core/Base58.ts
+++ b/src/core/Base58.ts
@@ -6,6 +6,8 @@ import * as internal from './internal/base58.js'
 /**
  * Encodes a {@link ox#Bytes.Bytes} to a Base58-encoded string.
  *
+ * @deprecated Use {@link Base58#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base58, Bytes } from 'ox'
@@ -27,6 +29,8 @@ export declare namespace fromBytes {
 
 /**
  * Encodes a {@link ox#Hex.Hex} to a Base58-encoded string.
+ *
+ * @deprecated Use {@link Base58#encode} instead. Will be removed in a future major.
  *
  * @example
  * ```ts twoslash
@@ -50,6 +54,8 @@ export declare namespace fromHex {
 /**
  * Encodes a string to a Base58-encoded string.
  *
+ * @deprecated Use {@link Base58#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base58 } from 'ox'
@@ -70,7 +76,44 @@ export declare namespace fromString {
 }
 
 /**
+ * Encodes a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or string value to a Base58-encoded string.
+ *
+ * Canonical alias for {@link Base58#fromBytes} / {@link Base58#fromHex} / {@link Base58#fromString}.
+ *
+ * Strings prefixed with `0x` are decoded as hex; other strings are decoded as UTF-8.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Base58, Bytes } from 'ox'
+ *
+ * Base58.encode(Bytes.fromString('Hello World!'))
+ * // @log: '2NEpo7TZRRrLZSi2U'
+ *
+ * Base58.encode('0x48656c6c6f20576f726c6421')
+ * // @log: '2NEpo7TZRRrLZSi2U'
+ *
+ * Base58.encode('Hello World!')
+ * // @log: '2NEpo7TZRRrLZSi2U'
+ * ```
+ *
+ * @param value - The byte array, hex value, or UTF-8 string to encode.
+ * @returns The Base58 encoded string.
+ */
+export function encode(value: Bytes.Bytes | Hex.Hex | string): string {
+  if (value instanceof Uint8Array) return internal.from(value)
+  if (typeof value === 'string' && value.startsWith('0x'))
+    return internal.from(value as Hex.Hex)
+  return internal.from(Bytes.fromString(value))
+}
+
+export declare namespace encode {
+  type ErrorType = internal.from.ErrorType | Errors.GlobalErrorType
+}
+
+/**
  * Decodes a Base58-encoded string to a {@link ox#Bytes.Bytes}.
+ *
+ * @deprecated Use {@link Base58#decode} instead. Will be removed in a future major.
  *
  * @example
  * ```ts twoslash
@@ -93,6 +136,8 @@ export declare namespace toBytes {
 
 /**
  * Decodes a Base58-encoded string to {@link ox#Hex.Hex}.
+ *
+ * @deprecated Use {@link Base58#decode} instead. Will be removed in a future major.
  *
  * @example
  * ```ts twoslash
@@ -139,6 +184,8 @@ export declare namespace toHex {
 /**
  * Decodes a Base58-encoded string to a string.
  *
+ * @deprecated Use {@link Base58#decode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base58 } from 'ox'
@@ -156,6 +203,62 @@ export function toString(value: string): string {
 
 export declare namespace toString {
   type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Decodes a Base58-encoded string to a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or UTF-8 string value.
+ *
+ * Canonical alias for {@link Base58#toBytes} / {@link Base58#toHex} / {@link Base58#toString}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Base58 } from 'ox'
+ *
+ * Base58.decode('2NEpo7TZRRrLZSi2U')
+ * // @log: Uint8Array [ 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33 ]
+ *
+ * Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'Hex' })
+ * // @log: '0x48656c6c6f20576f726c6421'
+ *
+ * Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'String' })
+ * // @log: 'Hello World!'
+ * ```
+ *
+ * @param value - The Base58 encoded string.
+ * @param options - Decoding options.
+ * @returns The decoded value.
+ */
+export function decode<as extends 'Bytes' | 'Hex' | 'String' = 'Bytes'>(
+  value: string,
+  options: decode.Options<as> = {},
+): decode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  if (as === 'String')
+    return Hex.toString(toHex(value)) as decode.ReturnType<as>
+  if (as === 'Hex') return toHex(value) as decode.ReturnType<as>
+  return toBytes(value) as decode.ReturnType<as>
+}
+
+export declare namespace decode {
+  type Options<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > = {
+    /** The format to return the decoded value in. */
+    as?: as | 'Bytes' | 'Hex' | 'String' | undefined
+  }
+
+  type ReturnType<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'String' ? string : never)
+
+  type ErrorType =
+    | toBytes.ErrorType
+    | toHex.ErrorType
+    | toString.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /** Thrown when a Base58 string contains an invalid character. */

--- a/src/core/Base64.ts
+++ b/src/core/Base64.ts
@@ -65,6 +65,8 @@ const nativeFromBase64:
 /**
  * Encodes a {@link ox#Bytes.Bytes} to a Base64-encoded string (with optional padding and/or URL-safe characters).
  *
+ * @deprecated Use {@link Base64#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base64, Bytes } from 'ox'
@@ -158,6 +160,8 @@ export declare namespace fromBytes {
 /**
  * Encodes a {@link ox#Hex.Hex} to a Base64-encoded string (with optional padding and/or URL-safe characters).
  *
+ * @deprecated Use {@link Base64#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base64, Hex } from 'ox'
@@ -219,6 +223,8 @@ export declare namespace fromHex {
 /**
  * Encodes a string to a Base64-encoded string (with optional padding and/or URL-safe characters).
  *
+ * @deprecated Use {@link Base64#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base64 } from 'ox'
@@ -278,7 +284,54 @@ export declare namespace fromString {
 }
 
 /**
+ * Encodes a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or string value to a Base64-encoded string (with optional padding and/or URL-safe characters).
+ *
+ * Canonical alias for {@link Base64#fromBytes} / {@link Base64#fromHex} / {@link Base64#fromString}.
+ *
+ * Strings prefixed with `0x` are decoded as hex; other strings are decoded as UTF-8.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Base64, Bytes } from 'ox'
+ *
+ * Base64.encode(Bytes.fromString('hello world'))
+ * // @log: 'aGVsbG8gd29ybGQ='
+ *
+ * Base64.encode('hello world')
+ * // @log: 'aGVsbG8gd29ybGQ='
+ *
+ * Base64.encode('0x68656c6c6f20776f726c64')
+ * // @log: 'aGVsbG8gd29ybGQ='
+ * ```
+ *
+ * @param value - The byte array, hex value, or UTF-8 string to encode.
+ * @param options - Encoding options.
+ * @returns The Base64 encoded string.
+ */
+export function encode(
+  value: Bytes.Bytes | Hex.Hex | string,
+  options: encode.Options = {},
+): string {
+  if (value instanceof Uint8Array) return fromBytes(value, options)
+  if (typeof value === 'string' && value.startsWith('0x'))
+    return fromHex(value as Hex.Hex, options)
+  return fromString(value, options)
+}
+
+export declare namespace encode {
+  type Options = fromBytes.Options
+
+  type ErrorType =
+    | fromBytes.ErrorType
+    | fromHex.ErrorType
+    | fromString.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to {@link ox#Bytes.Bytes}.
+ *
+ * @deprecated Use {@link Base64#decode} instead. Will be removed in a future major.
  *
  * @example
  * ```ts twoslash
@@ -353,6 +406,8 @@ export declare namespace toBytes {
 /**
  * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to {@link ox#Hex.Hex}.
  *
+ * @deprecated Use {@link Base64#decode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base64, Hex } from 'ox'
@@ -375,6 +430,8 @@ export declare namespace toHex {
 /**
  * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to a string.
  *
+ * @deprecated Use {@link Base64#decode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Base64 } from 'ox'
@@ -391,6 +448,58 @@ export function toString(value: string): string {
 }
 
 export declare namespace toString {
+  type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or UTF-8 string value.
+ *
+ * Canonical alias for {@link Base64#toBytes} / {@link Base64#toHex} / {@link Base64#toString}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Base64 } from 'ox'
+ *
+ * Base64.decode('aGVsbG8gd29ybGQ=')
+ * // @log: Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+ *
+ * Base64.decode('aGVsbG8gd29ybGQ=', { as: 'Hex' })
+ * // @log: '0x68656c6c6f20776f726c64'
+ *
+ * Base64.decode('aGVsbG8gd29ybGQ=', { as: 'String' })
+ * // @log: 'hello world'
+ * ```
+ *
+ * @param value - The Base64 encoded string.
+ * @param options - Decoding options.
+ * @returns The decoded value.
+ */
+export function decode<as extends 'Bytes' | 'Hex' | 'String' = 'Bytes'>(
+  value: string,
+  options: decode.Options<as> = {},
+): decode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  const bytes = toBytes(value)
+  if (as === 'String') return Bytes.toString(bytes) as decode.ReturnType<as>
+  if (as === 'Hex') return Hex.fromBytes(bytes) as decode.ReturnType<as>
+  return bytes as decode.ReturnType<as>
+}
+
+export declare namespace decode {
+  type Options<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > = {
+    /** The format to return the decoded value in. */
+    as?: as | 'Bytes' | 'Hex' | 'String' | undefined
+  }
+
+  type ReturnType<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'String' ? string : never)
+
   type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
 }
 

--- a/src/core/CompactSize.ts
+++ b/src/core/CompactSize.ts
@@ -12,6 +12,8 @@ import * as Hex from './Hex.js'
  * | 65,536–4,294,967,295 | `0xFE` + 4 bytes LE | 5 |
  * | \> 4,294,967,295 | `0xFF` + 8 bytes LE | 9 |
  *
+ * @deprecated Use {@link CompactSize#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { CompactSize } from 'ox'
@@ -63,6 +65,8 @@ export declare namespace toBytes {
 /**
  * Encodes an integer using Bitcoin's CompactSize variable-length encoding and returns it as {@link ox#Hex.Hex}.
  *
+ * @deprecated Use {@link CompactSize#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { CompactSize } from 'ox'
@@ -83,7 +87,59 @@ export declare namespace toHex {
 }
 
 /**
+ * Encodes an integer using Bitcoin's CompactSize variable-length encoding.
+ *
+ * Canonical alias for {@link CompactSize#toBytes} / {@link CompactSize#toHex}.
+ *
+ * | Range | Encoding | Bytes |
+ * |---|---|---|
+ * | 0–252 | Direct value | 1 |
+ * | 253–65,535 | `0xFD` + 2 bytes LE | 3 |
+ * | 65,536–4,294,967,295 | `0xFE` + 4 bytes LE | 5 |
+ * | \> 4,294,967,295 | `0xFF` + 8 bytes LE | 9 |
+ *
+ * @example
+ * ```ts twoslash
+ * import { CompactSize } from 'ox'
+ *
+ * CompactSize.encode(253n)
+ * // @log: Uint8Array [ 253, 253, 0 ]
+ *
+ * CompactSize.encode(253n, { as: 'Hex' })
+ * // @log: '0xfdfd00'
+ * ```
+ *
+ * @param value - The integer to encode.
+ * @param options - Encoding options.
+ * @returns The CompactSize-encoded value.
+ */
+export function encode<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  value: bigint | number,
+  options: encode.Options<as> = {},
+): encode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  const bytes = toBytes(value)
+  if (as === 'Hex') return Hex.fromBytes(bytes) as encode.ReturnType<as>
+  return bytes as encode.ReturnType<as>
+}
+
+export declare namespace encode {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> = {
+    /** The format to return the encoded value in. */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
+}
+
+/**
  * Decodes a CompactSize-encoded value from {@link ox#Bytes.Bytes}.
+ *
+ * @deprecated Use {@link CompactSize#decode} instead. Will be removed in a future major.
  *
  * @example
  * ```ts twoslash
@@ -143,6 +199,8 @@ export declare namespace fromBytes {
 /**
  * Decodes a CompactSize-encoded value from {@link ox#Hex.Hex}.
  *
+ * @deprecated Use {@link CompactSize#decode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { CompactSize } from 'ox'
@@ -160,6 +218,39 @@ export function fromHex(data: Hex.Hex): fromBytes.ReturnType {
 
 export declare namespace fromHex {
   type ErrorType = fromBytes.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Decodes a CompactSize-encoded value from {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex}.
+ *
+ * Canonical alias for {@link CompactSize#fromBytes} / {@link CompactSize#fromHex}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { CompactSize } from 'ox'
+ *
+ * CompactSize.decode(new Uint8Array([0xfd, 0x00, 0x01]))
+ * // @log: { value: 256n, size: 3 }
+ *
+ * CompactSize.decode('0xfd0001')
+ * // @log: { value: 256n, size: 3 }
+ * ```
+ *
+ * @param value - The CompactSize-encoded bytes or hex string to decode.
+ * @returns The decoded value and number of bytes consumed.
+ */
+export function decode(value: Bytes.Bytes | Hex.Hex): fromBytes.ReturnType {
+  if (value instanceof Uint8Array) return fromBytes(value)
+  return fromBytes(Bytes.fromHex(value))
+}
+
+export declare namespace decode {
+  type ReturnType = fromBytes.ReturnType
+
+  type ErrorType =
+    | fromBytes.ErrorType
+    | Bytes.fromHex.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /** Thrown when a CompactSize value is negative. */

--- a/src/core/Rlp.ts
+++ b/src/core/Rlp.ts
@@ -8,6 +8,8 @@ import type { ExactPartial, RecursiveArray } from './internal/types.js'
 /**
  * Decodes a Recursive-Length Prefix (RLP) value into a {@link ox#Bytes.Bytes} value.
  *
+ * @deprecated Use {@link Rlp#decode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Rlp } from 'ox'
@@ -31,6 +33,8 @@ export declare namespace toBytes {
 /**
  * Decodes a Recursive-Length Prefix (RLP) value into a {@link ox#Hex.Hex} value.
  *
+ * @deprecated Use {@link Rlp#decode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Rlp } from 'ox'
@@ -46,6 +50,47 @@ export function toHex(value: Bytes.Bytes | Hex.Hex): RecursiveArray<Hex.Hex> {
 }
 
 export declare namespace toHex {
+  type ErrorType = to.ErrorType
+}
+
+/**
+ * Decodes a Recursive-Length Prefix (RLP) value into a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
+ *
+ * Canonical alias for {@link Rlp#toBytes} / {@link Rlp#toHex}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Rlp } from 'ox'
+ *
+ * Rlp.decode('0x8b68656c6c6f20776f726c64')
+ * // @log: Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+ *
+ * Rlp.decode('0x8b68656c6c6f20776f726c64', { as: 'Hex' })
+ * // @log: '0x68656c6c6f20776f726c64'
+ * ```
+ *
+ * @param value - The value to decode.
+ * @param options - Decoding options.
+ * @returns The decoded value.
+ */
+export function decode<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  value: Bytes.Bytes | Hex.Hex,
+  options: decode.Options<as> = {},
+): decode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  return to(value, as) as decode.ReturnType<as>
+}
+
+export declare namespace decode {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> = {
+    /** The format to return the decoded value in. */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    | (as extends 'Bytes' ? RecursiveArray<Bytes.Bytes> : never)
+    | (as extends 'Hex' ? RecursiveArray<Hex.Hex> : never)
+
   type ErrorType = to.ErrorType
 }
 
@@ -165,6 +210,8 @@ export declare namespace readList {
 /**
  * Encodes a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value into a Recursive-Length Prefix (RLP) value.
  *
+ * @deprecated Use {@link Rlp#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Bytes, Rlp } from 'ox'
@@ -237,6 +284,8 @@ export declare namespace from {
 /**
  * Encodes a {@link ox#Bytes.Bytes} value into a Recursive-Length Prefix (RLP) value.
  *
+ * @deprecated Use {@link Rlp#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Bytes, Rlp } from 'ox'
@@ -270,6 +319,8 @@ export declare namespace fromBytes {
 /**
  * Encodes a {@link ox#Hex.Hex} value into a Recursive-Length Prefix (RLP) value.
  *
+ * @deprecated Use {@link Rlp#encode} instead. Will be removed in a future major.
+ *
  * @example
  * ```ts twoslash
  * import { Rlp } from 'ox'
@@ -296,6 +347,46 @@ export declare namespace fromHex {
   >
 
   type ReturnType<as extends 'Hex' | 'Bytes' = 'Hex'> = from.ReturnType<as>
+
+  type ErrorType = from.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Encodes a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value into a Recursive-Length Prefix (RLP) value.
+ *
+ * Canonical alias for {@link Rlp#from} / {@link Rlp#fromBytes} / {@link Rlp#fromHex}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bytes, Rlp } from 'ox'
+ *
+ * Rlp.encode('0x68656c6c6f20776f726c64', { as: 'Hex' })
+ * // @log: '0x8b68656c6c6f20776f726c64'
+ *
+ * Rlp.encode(Bytes.from([139, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]))
+ * // @log: Uint8Array([139, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+ * ```
+ *
+ * @param value - The {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value to encode.
+ * @param options - Encoding options.
+ * @returns The RLP-encoded value.
+ */
+export function encode<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  value: RecursiveArray<Bytes.Bytes> | RecursiveArray<Hex.Hex>,
+  options: encode.Options<as> = {},
+): encode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  return from(value, { as }) as never
+}
+
+export declare namespace encode {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> = {
+    /** The format to return the encoded value in. */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    from.ReturnType<as>
 
   type ErrorType = from.ErrorType | Errors.GlobalErrorType
 }

--- a/src/core/_test/Base32.test.ts
+++ b/src/core/_test/Base32.test.ts
@@ -53,13 +53,44 @@ describe('toHex', () => {
   })
 })
 
+describe('encode', () => {
+  test('bytes input', () => {
+    expect(Base32.encode(new Uint8Array([0x00, 0xff, 0x00]))).toBe('qrlsq')
+  })
+
+  test('hex input', () => {
+    expect(Base32.encode('0x00ff00')).toBe('qrlsq')
+  })
+})
+
+describe('decode', () => {
+  test('default (Bytes)', () => {
+    const out = Base32.decode('qrlsq')
+    expect(out).toBeInstanceOf(Uint8Array)
+    expect(out.slice(0, 3)).toEqual(new Uint8Array([0x00, 0xff, 0x00]))
+  })
+
+  test('as: Bytes', () => {
+    const out = Base32.decode('qrlsq', { as: 'Bytes' })
+    expect(out).toBeInstanceOf(Uint8Array)
+  })
+
+  test('as: Hex', () => {
+    const out = Base32.decode('qrlsq', { as: 'Hex' })
+    expect(out.startsWith('0x')).toBe(true)
+    expect(out.slice(0, 8)).toBe('0x00ff00')
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(Base32)).toMatchInlineSnapshot(`
     [
       "fromBytes",
       "fromHex",
+      "encode",
       "toBytes",
       "toHex",
+      "decode",
       "InvalidCharacterError",
       "InvalidPaddingError",
     ]

--- a/src/core/_test/Base58.test.ts
+++ b/src/core/_test/Base58.test.ts
@@ -70,15 +70,56 @@ describe('toString', () => {
   })
 })
 
+describe('encode', () => {
+  test('bytes input', () => {
+    const bytes = new Uint8Array([
+      72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+    ])
+    expect(Base58.encode(bytes)).toBe('2NEpo7TZRRrLZSi2U')
+  })
+
+  test('hex input', () => {
+    expect(Base58.encode('0x48656c6c6f20576f726c6421')).toBe(
+      '2NEpo7TZRRrLZSi2U',
+    )
+  })
+
+  test('utf-8 string input', () => {
+    expect(Base58.encode('Hello World!')).toBe('2NEpo7TZRRrLZSi2U')
+  })
+})
+
+describe('decode', () => {
+  test('default (Bytes)', () => {
+    expect(Base58.decode('2NEpo7TZRRrLZSi2U')).toEqual(
+      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
+    )
+  })
+
+  test('as: Hex', () => {
+    expect(Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'Hex' })).toBe(
+      '0x48656c6c6f20576f726c6421',
+    )
+  })
+
+  test('as: String', () => {
+    expect(Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'String' })).toBe(
+      'Hello World!',
+    )
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(Base58)).toMatchInlineSnapshot(`
     [
       "fromBytes",
       "fromHex",
       "fromString",
+      "encode",
       "toBytes",
       "toHex",
       "toString",
+      "decode",
       "InvalidCharacterError",
     ]
   `)

--- a/src/core/_test/Base64.test.ts
+++ b/src/core/_test/Base64.test.ts
@@ -89,15 +89,58 @@ describe('toString', () => {
   })
 })
 
+describe('encode', () => {
+  test('bytes input', () => {
+    const bytes = new Uint8Array([
+      104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100,
+    ])
+    expect(Base64.encode(bytes)).toBe('aGVsbG8gd29ybGQ=')
+  })
+
+  test('hex input', () => {
+    expect(Base64.encode('0x68656c6c6f20776f726c64')).toBe('aGVsbG8gd29ybGQ=')
+  })
+
+  test('utf-8 string input', () => {
+    expect(Base64.encode('hello world')).toBe('aGVsbG8gd29ybGQ=')
+  })
+
+  test('forwards options', () => {
+    expect(Base64.encode('hello world', { pad: false })).toBe('aGVsbG8gd29ybGQ')
+  })
+})
+
+describe('decode', () => {
+  test('default (Bytes)', () => {
+    expect(Base64.decode('aGVsbG8gd29ybGQ=')).toEqual(
+      new Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]),
+    )
+  })
+
+  test('as: Hex', () => {
+    expect(Base64.decode('aGVsbG8gd29ybGQ=', { as: 'Hex' })).toBe(
+      '0x68656c6c6f20776f726c64',
+    )
+  })
+
+  test('as: String', () => {
+    expect(Base64.decode('aGVsbG8gd29ybGQ=', { as: 'String' })).toBe(
+      'hello world',
+    )
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(Base64)).toMatchInlineSnapshot(`
     [
       "fromBytes",
       "fromHex",
       "fromString",
+      "encode",
       "toBytes",
       "toHex",
       "toString",
+      "decode",
       "InvalidCharacterError",
       "InvalidLengthError",
       "InvalidPaddingError",

--- a/src/core/_test/CompactSize.test.ts
+++ b/src/core/_test/CompactSize.test.ts
@@ -160,13 +160,47 @@ describe('fromHex', () => {
   })
 })
 
+describe('encode', () => {
+  test('default (Bytes)', () => {
+    expect(CompactSize.encode(253n)).toEqual(new Uint8Array([253, 253, 0]))
+  })
+
+  test('as: Bytes', () => {
+    expect(CompactSize.encode(252n, { as: 'Bytes' })).toEqual(
+      new Uint8Array([252]),
+    )
+  })
+
+  test('as: Hex', () => {
+    expect(CompactSize.encode(253n, { as: 'Hex' })).toBe('0xfdfd00')
+  })
+})
+
+describe('decode', () => {
+  test('bytes input', () => {
+    expect(CompactSize.decode(new Uint8Array([0xfd, 0x00, 0x01]))).toEqual({
+      value: 256n,
+      size: 3,
+    })
+  })
+
+  test('hex input', () => {
+    expect(CompactSize.decode('0xfd0001')).toEqual({
+      value: 256n,
+      size: 3,
+    })
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(CompactSize)).toMatchInlineSnapshot(`
     [
       "toBytes",
       "toHex",
+      "encode",
       "fromBytes",
       "fromHex",
+      "decode",
       "NegativeValueError",
       "InsufficientBytesError",
       "InvalidValueError",

--- a/src/core/_test/Rlp.test.ts
+++ b/src/core/_test/Rlp.test.ts
@@ -6,6 +6,7 @@ test('exports', () => {
     [
       "toBytes",
       "toHex",
+      "decode",
       "to",
       "decodeRlpCursor",
       "readLength",
@@ -13,6 +14,7 @@ test('exports', () => {
       "from",
       "fromBytes",
       "fromHex",
+      "encode",
     ]
   `)
 })
@@ -335,5 +337,45 @@ describe('Rlp.to', () => {
     It must be an even length.]
   `,
     )
+  })
+})
+
+describe('Rlp.encode', () => {
+  test('default (Bytes)', () => {
+    const value = '0x68656c6c6f20776f726c64'
+    expect(Rlp.encode(value)).toEqual(
+      Bytes.fromHex('0x8b68656c6c6f20776f726c64'),
+    )
+  })
+
+  test('as: Hex', () => {
+    expect(Rlp.encode('0x68656c6c6f20776f726c64', { as: 'Hex' })).toBe(
+      '0x8b68656c6c6f20776f726c64',
+    )
+  })
+
+  test('as: Bytes', () => {
+    expect(
+      Rlp.encode(Bytes.fromHex('0x68656c6c6f20776f726c64'), { as: 'Bytes' }),
+    ).toEqual(Bytes.fromHex('0x8b68656c6c6f20776f726c64'))
+  })
+})
+
+describe('Rlp.decode', () => {
+  test('default (Bytes)', () => {
+    expect(Rlp.decode('0x8b68656c6c6f20776f726c64')).toEqual(
+      Bytes.fromHex('0x68656c6c6f20776f726c64'),
+    )
+  })
+
+  test('as: Hex', () => {
+    expect(Rlp.decode('0x8b68656c6c6f20776f726c64', { as: 'Hex' })).toBe(
+      '0x68656c6c6f20776f726c64',
+    )
+  })
+
+  test('list', () => {
+    const encoded = Rlp.encode(['0x00', '0x80'], { as: 'Hex' })
+    expect(Rlp.decode(encoded, { as: 'Hex' })).toEqual(['0x00', '0x80'])
   })
 })


### PR DESCRIPTION
Canonical aliases for the encoding modules.

Highlights:

- Adds canonical `encode` / `decode` aliases on `Base32`, `Base58`, `Base64`, `CompactSize`, and `Rlp`.
- Decoders accept an `as` option to pick the output representation.
