### PR TITLE
feat(v1): `Attribution` / `Execute` aliases and versioned `UserOperation` helpers

### DIFF
--- a/.changeset/erc-additive-aliases.md
+++ b/.changeset/erc-additive-aliases.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `encode` / `decode` aliases on `Attribution` and `Execute`, plus versioned `hashV06` / `hashV07` / `hashV08` and `fromRpcV06` / `fromRpcV07` / `fromRpcV08` / `toRpcV06` / `toRpcV07` / `toRpcV08` helpers on `UserOperation`.

--- a/src/erc4337/UserOperation.ts
+++ b/src/erc4337/UserOperation.ts
@@ -408,6 +408,108 @@ export declare namespace fromRpc {
 }
 
 /**
+ * Converts a v0.6 {@link ox#UserOperation.Rpc} to a v0.6
+ * {@link ox#UserOperation.UserOperation}. Versioned variant of
+ * {@link ox#UserOperation.fromRpc} that disambiguates the EntryPoint version
+ * at the type level.
+ *
+ * @example
+ * ```ts twoslash
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const userOperation = UserOperation.fromRpcV06({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: '0x69420',
+ *   maxFeePerGas: '0x2ca6ae494',
+ *   maxPriorityFeePerGas: '0x41cc3c0',
+ *   nonce: '0x357',
+ *   preVerificationGas: '0x69420',
+ *   signature: '0x',
+ *   sender: '0x1234567890123456789012345678901234567890',
+ *   verificationGasLimit: '0x69420',
+ * })
+ * ```
+ *
+ * @param rpc - The v0.6 RPC user operation to convert.
+ * @returns A v0.6 {@link ox#UserOperation.UserOperation}.
+ */
+export function fromRpcV06(rpc: RpcV06): UserOperation<'0.6', true> {
+  return fromRpc(rpc as Rpc) as UserOperation<'0.6', true>
+}
+
+export declare namespace fromRpcV06 {
+  type ErrorType = fromRpc.ErrorType
+}
+
+/**
+ * Converts a v0.7 {@link ox#UserOperation.Rpc} to a v0.7
+ * {@link ox#UserOperation.UserOperation}. Versioned variant of
+ * {@link ox#UserOperation.fromRpc} that disambiguates the EntryPoint version
+ * at the type level.
+ *
+ * @example
+ * ```ts twoslash
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const userOperation = UserOperation.fromRpcV07({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: '0x69420',
+ *   maxFeePerGas: '0x2ca6ae494',
+ *   maxPriorityFeePerGas: '0x41cc3c0',
+ *   nonce: '0x357',
+ *   preVerificationGas: '0x69420',
+ *   signature: '0x',
+ *   sender: '0x1234567890123456789012345678901234567890',
+ *   verificationGasLimit: '0x69420',
+ * })
+ * ```
+ *
+ * @param rpc - The v0.7 RPC user operation to convert.
+ * @returns A v0.7 {@link ox#UserOperation.UserOperation}.
+ */
+export function fromRpcV07(rpc: RpcV07): UserOperation<'0.7', true> {
+  return fromRpc(rpc as Rpc) as UserOperation<'0.7', true>
+}
+
+export declare namespace fromRpcV07 {
+  type ErrorType = fromRpc.ErrorType
+}
+
+/**
+ * Converts a v0.8 {@link ox#UserOperation.Rpc} to a v0.8
+ * {@link ox#UserOperation.UserOperation}. Versioned variant of
+ * {@link ox#UserOperation.fromRpc} that disambiguates the EntryPoint version
+ * at the type level (notably for the `authorization` field).
+ *
+ * @example
+ * ```ts twoslash
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const userOperation = UserOperation.fromRpcV08({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: '0x69420',
+ *   maxFeePerGas: '0x2ca6ae494',
+ *   maxPriorityFeePerGas: '0x41cc3c0',
+ *   nonce: '0x357',
+ *   preVerificationGas: '0x69420',
+ *   signature: '0x',
+ *   sender: '0x1234567890123456789012345678901234567890',
+ *   verificationGasLimit: '0x69420',
+ * })
+ * ```
+ *
+ * @param rpc - The v0.8 RPC user operation to convert.
+ * @returns A v0.8 {@link ox#UserOperation.UserOperation}.
+ */
+export function fromRpcV08(rpc: RpcV08): UserOperation<'0.8', true> {
+  return fromRpc(rpc as Rpc) as UserOperation<'0.8', true>
+}
+
+export declare namespace fromRpcV08 {
+  type ErrorType = fromRpc.ErrorType
+}
+
+/**
  * Obtains the signing payload for a {@link ox#UserOperation.UserOperation}.
  *
  * @example
@@ -488,103 +590,14 @@ export function hash<
   userOperation: UserOperation<entrypointVersion>,
   options: hash.Options<entrypointVersion>,
 ): Hex.Hex {
-  const { chainId, entryPointAddress, entryPointVersion } = options
-  const {
-    callData,
-    callGasLimit,
-    initCode,
-    factory,
-    factoryData,
-    maxFeePerGas,
-    maxPriorityFeePerGas,
-    nonce,
-    paymaster,
-    paymasterAndData,
-    paymasterData,
-    paymasterPostOpGasLimit,
-    paymasterVerificationGasLimit,
-    preVerificationGas,
-    sender,
-    verificationGasLimit,
-  } = userOperation as UserOperation
-
-  if (entryPointVersion === '0.8') {
-    const typedData = toTypedData(userOperation as UserOperation<'0.8', true>, {
-      chainId,
-      entryPointAddress,
-    })
-    return TypedData.getSignPayload(typedData)
-  }
-
-  const packedUserOp = (() => {
-    if (entryPointVersion === '0.6') {
-      const initCodeHash =
-        !initCode || initCode === '0x' ? EMPTY_KECCAK : Hash.keccak256(initCode)
-      const paymasterAndDataHash =
-        !paymasterAndData || paymasterAndData === '0x'
-          ? EMPTY_KECCAK
-          : Hash.keccak256(paymasterAndData)
-
-      return AbiParameters.encode(v06HashParameters, [
-        sender,
-        nonce,
-        initCodeHash,
-        Hash.keccak256(callData),
-        callGasLimit,
-        verificationGasLimit,
-        preVerificationGas,
-        maxFeePerGas,
-        maxPriorityFeePerGas,
-        paymasterAndDataHash,
-      ])
-    }
-
-    if (entryPointVersion === '0.7') {
-      const accountGasLimits = packUint128Pair(
-        verificationGasLimit,
-        callGasLimit,
-      )
-      const gasFees = packUint128Pair(maxPriorityFeePerGas, maxFeePerGas)
-      const initCode_hashed =
-        factory && factoryData
-          ? Hash.keccak256(Hex.concat(factory, factoryData))
-          : EMPTY_KECCAK
-      const paymasterAndData_hashed = paymaster
-        ? Hash.keccak256(
-            Hex.concat(
-              paymaster,
-              Hex.padLeft(
-                Hex.fromNumber(paymasterVerificationGasLimit || 0),
-                16,
-              ),
-              Hex.padLeft(Hex.fromNumber(paymasterPostOpGasLimit || 0), 16),
-              paymasterData || '0x',
-            ),
-          )
-        : EMPTY_KECCAK
-
-      return AbiParameters.encode(v07HashParameters, [
-        sender,
-        nonce,
-        initCode_hashed,
-        Hash.keccak256(callData),
-        accountGasLimits,
-        preVerificationGas,
-        gasFees,
-        paymasterAndData_hashed,
-      ])
-    }
-
-    throw new Error(`entryPointVersion "${entryPointVersion}" not supported.`)
-  })()
-
-  return Hash.keccak256(
-    AbiParameters.encode(hashEnvelopeParameters, [
-      Hash.keccak256(packedUserOp),
-      entryPointAddress,
-      BigInt(chainId),
-    ]),
-  )
+  const { entryPointVersion } = options
+  if (entryPointVersion === '0.6')
+    return hashV06(userOperation as UserOperation<'0.6'>, options)
+  if (entryPointVersion === '0.7')
+    return hashV07(userOperation as UserOperation<'0.7'>, options)
+  if (entryPointVersion === '0.8')
+    return hashV08(userOperation as UserOperation<'0.8', true>, options)
+  throw new Error(`entryPointVersion "${entryPointVersion}" not supported.`)
 }
 
 export declare namespace hash {
@@ -603,6 +616,237 @@ export declare namespace hash {
     | Hex.fromNumber.ErrorType
     | Hex.padLeft.ErrorType
     | Errors.GlobalErrorType
+}
+
+/**
+ * Hashes a v0.6 {@link ox#UserOperation.UserOperation}. Versioned variant of
+ * {@link ox#UserOperation.hash} for EntryPoint v0.6.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Value } from 'ox'
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const userOpHash = UserOperation.hashV06({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: 300_000n,
+ *   maxFeePerGas: Value.fromGwei('20'),
+ *   maxPriorityFeePerGas: Value.fromGwei('2'),
+ *   nonce: 69n,
+ *   preVerificationGas: 100_000n,
+ *   sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+ *   verificationGasLimit: 100_000n,
+ * }, {
+ *   chainId: 1,
+ *   entryPointAddress: '0x1234567890123456789012345678901234567890',
+ * })
+ * ```
+ *
+ * @param userOperation - The v0.6 user operation to hash.
+ * @param options - The hashing options.
+ * @returns The hash of the user operation.
+ */
+export function hashV06(
+  userOperation: UserOperation<'0.6'>,
+  options: hashV06.Options,
+): Hex.Hex {
+  const { chainId, entryPointAddress } = options
+  const {
+    callData,
+    callGasLimit,
+    initCode,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    nonce,
+    paymasterAndData,
+    preVerificationGas,
+    sender,
+    verificationGasLimit,
+  } = userOperation
+
+  const initCodeHash =
+    !initCode || initCode === '0x' ? EMPTY_KECCAK : Hash.keccak256(initCode)
+  const paymasterAndDataHash =
+    !paymasterAndData || paymasterAndData === '0x'
+      ? EMPTY_KECCAK
+      : Hash.keccak256(paymasterAndData)
+
+  const packedUserOp = AbiParameters.encode(v06HashParameters, [
+    sender,
+    nonce,
+    initCodeHash,
+    Hash.keccak256(callData),
+    callGasLimit,
+    verificationGasLimit,
+    preVerificationGas,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    paymasterAndDataHash,
+  ])
+
+  return Hash.keccak256(
+    AbiParameters.encode(hashEnvelopeParameters, [
+      Hash.keccak256(packedUserOp),
+      entryPointAddress,
+      BigInt(chainId),
+    ]),
+  )
+}
+
+export declare namespace hashV06 {
+  type Options = {
+    chainId: number
+    entryPointAddress: Address.Address
+  }
+
+  type ErrorType = hash.ErrorType
+}
+
+/**
+ * Hashes a v0.7 {@link ox#UserOperation.UserOperation}. Versioned variant of
+ * {@link ox#UserOperation.hash} for EntryPoint v0.7.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Value } from 'ox'
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const userOpHash = UserOperation.hashV07({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: 300_000n,
+ *   maxFeePerGas: Value.fromGwei('20'),
+ *   maxPriorityFeePerGas: Value.fromGwei('2'),
+ *   nonce: 69n,
+ *   preVerificationGas: 100_000n,
+ *   sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+ *   verificationGasLimit: 100_000n,
+ * }, {
+ *   chainId: 1,
+ *   entryPointAddress: '0x1234567890123456789012345678901234567890',
+ * })
+ * ```
+ *
+ * @param userOperation - The v0.7 user operation to hash.
+ * @param options - The hashing options.
+ * @returns The hash of the user operation.
+ */
+export function hashV07(
+  userOperation: UserOperation<'0.7'>,
+  options: hashV07.Options,
+): Hex.Hex {
+  const { chainId, entryPointAddress } = options
+  const {
+    callData,
+    callGasLimit,
+    factory,
+    factoryData,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    nonce,
+    paymaster,
+    paymasterData,
+    paymasterPostOpGasLimit,
+    paymasterVerificationGasLimit,
+    preVerificationGas,
+    sender,
+    verificationGasLimit,
+  } = userOperation
+
+  const accountGasLimits = packUint128Pair(verificationGasLimit, callGasLimit)
+  const gasFees = packUint128Pair(maxPriorityFeePerGas, maxFeePerGas)
+  const initCode_hashed =
+    factory && factoryData
+      ? Hash.keccak256(Hex.concat(factory, factoryData))
+      : EMPTY_KECCAK
+  const paymasterAndData_hashed = paymaster
+    ? Hash.keccak256(
+        Hex.concat(
+          paymaster,
+          Hex.padLeft(Hex.fromNumber(paymasterVerificationGasLimit || 0), 16),
+          Hex.padLeft(Hex.fromNumber(paymasterPostOpGasLimit || 0), 16),
+          paymasterData || '0x',
+        ),
+      )
+    : EMPTY_KECCAK
+
+  const packedUserOp = AbiParameters.encode(v07HashParameters, [
+    sender,
+    nonce,
+    initCode_hashed,
+    Hash.keccak256(callData),
+    accountGasLimits,
+    preVerificationGas,
+    gasFees,
+    paymasterAndData_hashed,
+  ])
+
+  return Hash.keccak256(
+    AbiParameters.encode(hashEnvelopeParameters, [
+      Hash.keccak256(packedUserOp),
+      entryPointAddress,
+      BigInt(chainId),
+    ]),
+  )
+}
+
+export declare namespace hashV07 {
+  type Options = {
+    chainId: number
+    entryPointAddress: Address.Address
+  }
+
+  type ErrorType = hash.ErrorType
+}
+
+/**
+ * Hashes a v0.8 {@link ox#UserOperation.UserOperation}. Versioned variant of
+ * {@link ox#UserOperation.hash} for EntryPoint v0.8 (delegates to
+ * {@link ox#UserOperation.toTypedData} + {@link ox#TypedData.getSignPayload}).
+ *
+ * @example
+ * ```ts twoslash
+ * import { Value } from 'ox'
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const userOpHash = UserOperation.hashV08({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: 300_000n,
+ *   maxFeePerGas: Value.fromGwei('20'),
+ *   maxPriorityFeePerGas: Value.fromGwei('2'),
+ *   nonce: 69n,
+ *   preVerificationGas: 100_000n,
+ *   sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+ *   signature: '0x...',
+ *   verificationGasLimit: 100_000n,
+ * }, {
+ *   chainId: 1,
+ *   entryPointAddress: '0x1234567890123456789012345678901234567890',
+ * })
+ * ```
+ *
+ * @param userOperation - The v0.8 user operation to hash.
+ * @param options - The hashing options.
+ * @returns The hash of the user operation.
+ */
+export function hashV08(
+  userOperation: UserOperation<'0.8', true>,
+  options: hashV08.Options,
+): Hex.Hex {
+  const { chainId, entryPointAddress } = options
+  const typedData = toTypedData(userOperation, {
+    chainId,
+    entryPointAddress,
+  })
+  return TypedData.getSignPayload(typedData)
+}
+
+export declare namespace hashV08 {
+  type Options = {
+    chainId: number
+    entryPointAddress: Address.Address
+  }
+
+  type ErrorType = hash.ErrorType
 }
 
 /**
@@ -905,6 +1149,108 @@ export function toRpc(userOperation: UserOperation): Rpc {
 
 export declare namespace toRpc {
   export type ErrorType = Hex.fromNumber.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Converts a v0.6 {@link ox#UserOperation.UserOperation} to a v0.6
+ * {@link ox#UserOperation.Rpc}. Versioned variant of
+ * {@link ox#UserOperation.toRpc} that disambiguates the EntryPoint version
+ * at the type level.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Value } from 'ox'
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const rpc = UserOperation.toRpcV06({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: 300_000n,
+ *   maxFeePerGas: Value.fromGwei('20'),
+ *   maxPriorityFeePerGas: Value.fromGwei('2'),
+ *   nonce: 69n,
+ *   preVerificationGas: 100_000n,
+ *   sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+ *   verificationGasLimit: 100_000n,
+ * })
+ * ```
+ *
+ * @param userOperation - The v0.6 user operation to convert.
+ * @returns A v0.6 RPC-formatted user operation.
+ */
+export function toRpcV06(userOperation: UserOperation<'0.6'>): RpcV06 {
+  return toRpc(userOperation as UserOperation) as RpcV06
+}
+
+export declare namespace toRpcV06 {
+  type ErrorType = toRpc.ErrorType
+}
+
+/**
+ * Converts a v0.7 {@link ox#UserOperation.UserOperation} to a v0.7
+ * {@link ox#UserOperation.Rpc}. Versioned variant of
+ * {@link ox#UserOperation.toRpc} that disambiguates the EntryPoint version
+ * at the type level.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Value } from 'ox'
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const rpc = UserOperation.toRpcV07({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: 300_000n,
+ *   maxFeePerGas: Value.fromGwei('20'),
+ *   maxPriorityFeePerGas: Value.fromGwei('2'),
+ *   nonce: 69n,
+ *   preVerificationGas: 100_000n,
+ *   sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+ *   verificationGasLimit: 100_000n,
+ * })
+ * ```
+ *
+ * @param userOperation - The v0.7 user operation to convert.
+ * @returns A v0.7 RPC-formatted user operation.
+ */
+export function toRpcV07(userOperation: UserOperation<'0.7'>): RpcV07 {
+  return toRpc(userOperation as UserOperation) as RpcV07
+}
+
+export declare namespace toRpcV07 {
+  type ErrorType = toRpc.ErrorType
+}
+
+/**
+ * Converts a v0.8 {@link ox#UserOperation.UserOperation} to a v0.8
+ * {@link ox#UserOperation.Rpc}. Versioned variant of
+ * {@link ox#UserOperation.toRpc} that disambiguates the EntryPoint version
+ * at the type level (notably for the `authorization` field).
+ *
+ * @example
+ * ```ts twoslash
+ * import { Value } from 'ox'
+ * import { UserOperation } from 'ox/erc4337'
+ *
+ * const rpc = UserOperation.toRpcV08({
+ *   callData: '0xdeadbeef',
+ *   callGasLimit: 300_000n,
+ *   maxFeePerGas: Value.fromGwei('20'),
+ *   maxPriorityFeePerGas: Value.fromGwei('2'),
+ *   nonce: 69n,
+ *   preVerificationGas: 100_000n,
+ *   sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+ *   verificationGasLimit: 100_000n,
+ * })
+ * ```
+ *
+ * @param userOperation - The v0.8 user operation to convert.
+ * @returns A v0.8 RPC-formatted user operation.
+ */
+export function toRpcV08(userOperation: UserOperation<'0.8'>): RpcV08 {
+  return toRpc(userOperation as UserOperation) as RpcV08
+}
+
+export declare namespace toRpcV08 {
+  type ErrorType = toRpc.ErrorType
 }
 
 /**

--- a/src/erc4337/_test/UserOperation.test.ts
+++ b/src/erc4337/_test/UserOperation.test.ts
@@ -1500,3 +1500,121 @@ describe('v0.8 authorization round-trip', () => {
     expect('authorization' in rpc).toBe(false)
   })
 })
+
+describe('versioned hash helpers', () => {
+  const v06UserOp = {
+    callData: '0x',
+    callGasLimit: 6942069n,
+    maxFeePerGas: 69420n,
+    maxPriorityFeePerGas: 69n,
+    nonce: 0n,
+    preVerificationGas: 6942069n,
+    sender: '0x1234567890123456789012345678901234567890',
+    signature: '0x',
+    verificationGasLimit: 6942069n,
+  } as const
+
+  const v07UserOp = {
+    callData: '0x',
+    callGasLimit: 6942069n,
+    maxFeePerGas: 69420n,
+    maxPriorityFeePerGas: 69n,
+    nonce: 0n,
+    preVerificationGas: 6942069n,
+    sender: '0x1234567890123456789012345678901234567890',
+    signature: '0x',
+    verificationGasLimit: 6942069n,
+  } as const
+
+  const v08UserOp = {
+    callData: '0x',
+    callGasLimit: 6942069n,
+    maxFeePerGas: 69420n,
+    maxPriorityFeePerGas: 69n,
+    nonce: 0n,
+    preVerificationGas: 6942069n,
+    sender: '0x1234567890123456789012345678901234567890',
+    signature: '0x',
+    verificationGasLimit: 6942069n,
+  } as const
+
+  const opts = {
+    chainId: 1,
+    entryPointAddress: '0x1234567890123456789012345678901234567890',
+  } as const
+
+  test('hashV06 matches hash with entryPointVersion 0.6', () => {
+    expect(UserOperation.hashV06(v06UserOp, opts)).toEqual(
+      UserOperation.hash(v06UserOp, { ...opts, entryPointVersion: '0.6' }),
+    )
+  })
+
+  test('hashV07 matches hash with entryPointVersion 0.7', () => {
+    expect(UserOperation.hashV07(v07UserOp, opts)).toEqual(
+      UserOperation.hash(v07UserOp, { ...opts, entryPointVersion: '0.7' }),
+    )
+  })
+
+  test('hashV08 matches hash with entryPointVersion 0.8', () => {
+    const opts8 = {
+      chainId: 1,
+      entryPointAddress: '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108',
+    } as const
+    expect(UserOperation.hashV08(v08UserOp, opts8)).toEqual(
+      UserOperation.hash(v08UserOp, { ...opts8, entryPointVersion: '0.8' }),
+    )
+  })
+})
+
+describe('versioned RPC helpers', () => {
+  const v06 = {
+    callData: '0xdeadbeef',
+    callGasLimit: 300_000n,
+    maxFeePerGas: 1_000_000_000n,
+    maxPriorityFeePerGas: 100_000_000n,
+    nonce: 69n,
+    preVerificationGas: 100_000n,
+    sender: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+    signature: '0x',
+    verificationGasLimit: 100_000n,
+  } as const
+
+  const v07 = {
+    ...v06,
+    factory: '0x1234567890123456789012345678901234567890',
+    factoryData: '0xdeadbeef',
+  } as const
+
+  const v08 = {
+    ...v07,
+    authorization: {
+      address: '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357',
+      chainId: 1,
+      nonce: 69n,
+      yParity: 0,
+      r: 1n,
+      s: 2n,
+    },
+  } as const
+
+  test('toRpcV06 / fromRpcV06 round-trip matches generic helpers', () => {
+    const rpc = UserOperation.toRpcV06(v06)
+    expect(rpc).toEqual(UserOperation.toRpc(v06))
+    expect(UserOperation.fromRpcV06(rpc)).toEqual(UserOperation.fromRpc(rpc))
+  })
+
+  test('toRpcV07 / fromRpcV07 round-trip matches generic helpers', () => {
+    const rpc = UserOperation.toRpcV07(v07)
+    expect(rpc).toEqual(UserOperation.toRpc(v07))
+    expect(UserOperation.fromRpcV07(rpc)).toEqual(UserOperation.fromRpc(rpc))
+  })
+
+  test('toRpcV08 / fromRpcV08 round-trip preserves authorization', () => {
+    const rpc = UserOperation.toRpcV08(v08)
+    expect(rpc).toEqual(UserOperation.toRpc(v08))
+    expect(UserOperation.fromRpcV08(rpc)).toEqual(UserOperation.fromRpc(rpc))
+    expect(UserOperation.fromRpcV08(rpc).authorization).toEqual(
+      v08.authorization,
+    )
+  })
+})

--- a/src/erc7821/Execute.ts
+++ b/src/erc7821/Execute.ts
@@ -195,3 +195,57 @@ export declare namespace encodeData {
     opData?: Hex.Hex | undefined
   }
 }
+
+/**
+ * Canonical alias for {@link ox#Execute.encodeData}. Encodes calls for the
+ * ERC-7821 `execute` function.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Execute } from 'ox/erc7821'
+ *
+ * const data = Execute.encode([
+ *   {
+ *     data: '0xcafebabe',
+ *     to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+ *     value: 1n,
+ *   }
+ * ])
+ * ```
+ *
+ * @param calls - The calls to encode.
+ * @param options - The options.
+ * @returns The encoded data.
+ */
+export function encode(
+  calls: readonly Call[],
+  options: encodeData.Options = {},
+) {
+  return encodeData(calls, options)
+}
+
+export declare namespace encode {
+  type Options = encodeData.Options
+}
+
+/**
+ * Canonical alias for {@link ox#Execute.decodeData}. Decodes calls from
+ * ERC-7821 `execute` function data.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Execute } from 'ox/erc7821'
+ *
+ * const { calls } = Execute.decode('0x...')
+ * ```
+ *
+ * @param data - The encoded data.
+ * @returns The decoded calls and optional opData.
+ */
+export function decode(data: Hex.Hex): decodeData.ReturnType {
+  return decodeData(data)
+}
+
+export declare namespace decode {
+  type ReturnType = decodeData.ReturnType
+}

--- a/src/erc7821/_test/Execute.test.ts
+++ b/src/erc7821/_test/Execute.test.ts
@@ -546,3 +546,55 @@ describe('decodeBatchOfBatchesData', () => {
     expect(result).toEqual(batches)
   })
 })
+
+describe('encode / decode', () => {
+  test('encode matches encodeData', () => {
+    const calls = [
+      {
+        data: '0xcafebabe',
+        to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        value: 1n,
+      },
+    ] as const
+    expect(Execute.encode(calls)).toEqual(Execute.encodeData(calls))
+  })
+
+  test('encode matches encodeData (with opData)', () => {
+    const calls = [
+      {
+        data: '0xcafebabe',
+        to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        value: 1n,
+      },
+    ] as const
+    const opData = '0xdeadbeef' as const
+    expect(Execute.encode(calls, { opData })).toEqual(
+      Execute.encodeData(calls, { opData }),
+    )
+  })
+
+  test('decode matches decodeData', () => {
+    const calls = [
+      {
+        data: '0xcafebabe',
+        to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        value: 1n,
+      },
+    ] as const
+    const data = Execute.encode(calls)
+    expect(Execute.decode(data)).toEqual(Execute.decodeData(data))
+  })
+
+  test('encode / decode roundtrip', () => {
+    const calls = [
+      {
+        data: '0xcafebabe',
+        to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        value: 1n,
+      },
+    ] as const
+    const data = Execute.encode(calls)
+    const decoded = Execute.decode(data)
+    expect(decoded.calls).toEqual(calls)
+  })
+})

--- a/src/erc8021/Attribution.ts
+++ b/src/erc8021/Attribution.ts
@@ -414,6 +414,57 @@ export declare namespace fromData {
     | Errors.GlobalErrorType
 }
 
+/**
+ * Canonical alias for {@link ox#Attribution.toDataSuffix}. Encodes an
+ * {@link ox#Attribution.Attribution} as the trailing data suffix that gets
+ * appended to transaction calldata.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Attribution } from 'ox/erc8021'
+ *
+ * const suffix = Attribution.encode({
+ *   codes: ['baseapp', 'morpho'],
+ * })
+ * ```
+ *
+ * @param attribution - The attribution to encode.
+ * @returns The encoded data suffix as a {@link ox#Hex.Hex} value.
+ */
+export function encode(attribution: Attribution): Hex.Hex {
+  return toDataSuffix(attribution)
+}
+
+export declare namespace encode {
+  type ErrorType = toDataSuffix.ErrorType
+}
+
+/**
+ * Canonical alias for {@link ox#Attribution.fromData}. Decodes an
+ * {@link ox#Attribution.Attribution} from the trailing data suffix on
+ * transaction calldata.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Attribution } from 'ox/erc8021'
+ *
+ * const attribution = Attribution.decode(
+ *   '0xdddddddd62617365617070070080218021802180218021802180218021'
+ * )
+ * // @log: { codes: ['baseapp'], id: 0 }
+ * ```
+ *
+ * @param data - The transaction calldata containing the attribution suffix.
+ * @returns The decoded attribution, or `undefined` if no valid attribution is found.
+ */
+export function decode(data: Hex.Hex): Attribution | undefined {
+  return fromData(data)
+}
+
+export declare namespace decode {
+  type ErrorType = fromData.ErrorType
+}
+
 // ---- Schema 2 helpers ----
 
 /** Internal CBOR map shape matching the ERC-8021 spec. */

--- a/src/erc8021/_test/Attribution.test.ts
+++ b/src/erc8021/_test/Attribution.test.ts
@@ -770,3 +770,29 @@ describe('schema 2 (CBOR-encoded)', () => {
     )
   })
 })
+
+describe('encode / decode', () => {
+  test('encode matches toDataSuffix', () => {
+    const attribution = { codes: ['baseapp', 'morpho'] } as const
+    expect(Attribution.encode(attribution)).toEqual(
+      Attribution.toDataSuffix(attribution),
+    )
+  })
+
+  test('decode matches fromData', () => {
+    const attribution = { codes: ['baseapp', 'morpho'] } as const
+    const suffix = Attribution.encode(attribution)
+    const data = `0xabcdef${suffix.slice(2)}` as const
+    expect(Attribution.decode(data)).toEqual(Attribution.fromData(data))
+  })
+
+  test('encode / decode roundtrip', () => {
+    const attribution = { codes: ['baseapp', 'morpho'] } as const
+    const suffix = Attribution.encode(attribution)
+    const data = `0xabcdef${suffix.slice(2)}` as const
+    expect(Attribution.decode(data)).toEqual({
+      codes: ['baseapp', 'morpho'],
+      id: 0,
+    })
+  })
+})


### PR DESCRIPTION
Additive aliases and versioned helpers for ERC modules.

Highlights:

- Adds `encode` / `decode` aliases on `Attribution` and `Execute`.
- Adds versioned `UserOperation.hashV06` / `hashV07` / `hashV08` helpers.
- Adds versioned `UserOperation.fromRpcV06` / `fromRpcV07` / `fromRpcV08` and `toRpcV06` / `toRpcV07` / `toRpcV08` helpers.
