### PR TITLE
feat(v1): `Parts` codecs and serialized-input `as` option for crypto modules

### DIFF
--- a/.changeset/crypto-serialized-inputs-and-as-option.md
+++ b/.changeset/crypto-serialized-inputs-and-as-option.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `as: 'Hex' | 'Bytes' | 'Object'` option to `Secp256k1.sign` / `getPublicKey` / `recoverPublicKey`, `P256.sign` / `getPublicKey` / `recoverPublicKey`, `WebCryptoP256.sign`, and `Bls.sign` / `getPublicKey` (default `'Object'` keeps existing behavior); plus accept `Hex.Hex | Bytes.Bytes | Signature.Signature` for `signature` params and `Hex.Hex | Bytes.Bytes | PublicKey.PublicKey` for `publicKey` params on `verify`, `recoverAddress`, `recoverPublicKey`, `getSharedSecret` across the same modules.

--- a/.changeset/parts-types-and-codecs.md
+++ b/.changeset/parts-types-and-codecs.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `Signature.SignatureParts`, `PublicKey.PublicKeyParts`, and `BlsPoint.G1Parts` / `G2Parts` types with matching `toParts` / `fromParts` codecs.

--- a/.changeset/parts-types-and-codecs.md
+++ b/.changeset/parts-types-and-codecs.md
@@ -2,4 +2,4 @@
 "ox": minor
 ---
 
-Added `Signature.SignatureParts`, `PublicKey.PublicKeyParts`, and `BlsPoint.G1Parts` / `G2Parts` types with matching `toParts` / `fromParts` codecs.
+Added `Signature.Parts`, `PublicKey.Parts`, and `BlsPoint.G1Parts` / `G2Parts` types with matching `toParts` / `fromParts` codecs.

--- a/src/core/Bls.ts
+++ b/src/core/Bls.ts
@@ -1,10 +1,51 @@
 import { bls12_381 as bls } from '@noble/curves/bls12-381.js'
 
-import type * as BlsPoint from './BlsPoint.js'
+import * as BlsPoint from './BlsPoint.js'
 import * as Bytes from './Bytes.js'
 import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 import type { OneOf } from './internal/types.js'
+
+/**
+ * Coerces a serialized or structured BLS point into a structured
+ * {@link ox#BlsPoint.BlsPoint}.
+ *
+ * @internal
+ */
+function normalizeBlsPoint<group extends 'G1' | 'G2'>(
+  value: Hex.Hex | Bytes.Bytes | BlsPoint.BlsPoint,
+  group: group,
+): BlsPoint.BlsPoint {
+  if (typeof value === 'string') return BlsPoint.fromHex(value, group)
+  if (value instanceof Uint8Array) return BlsPoint.fromBytes(value, group)
+  return value
+}
+
+/**
+ * Formats a structured BLS point as the requested representation.
+ *
+ * @internal
+ */
+function formatBlsPoint<point extends BlsPoint.BlsPoint>(
+  point: point,
+  as: 'Hex' | 'Bytes' | 'Object',
+): unknown {
+  if (as === 'Hex') return BlsPoint.toHex(point as BlsPoint.G1 | BlsPoint.G2)
+  if (as === 'Bytes')
+    return BlsPoint.toBytes(point as BlsPoint.G1 | BlsPoint.G2)
+  return point
+}
+
+/**
+ * Returns the byte length of a serialized BLS point. Hex strings are measured
+ * minus the `0x` prefix, divided by two; `Uint8Array`s use `byteLength`.
+ *
+ * @internal
+ */
+function signatureByteLength(value: Hex.Hex | Bytes.Bytes): number {
+  if (typeof value === 'string') return (value.length - 2) / 2
+  return value.byteLength
+}
 
 export type Size = 'short-key:long-sig' | 'long-key:short-sig'
 
@@ -48,23 +89,41 @@ export const noble = bls
 export function aggregate<const points extends readonly BlsPoint.BlsPoint[]>(
   points: points,
 ): points extends readonly BlsPoint.G1[] ? BlsPoint.G1 : BlsPoint.G2
+export function aggregate(
+  points: readonly (Hex.Hex | Bytes.Bytes | BlsPoint.BlsPoint)[],
+  options?: aggregate.Options,
+): BlsPoint.BlsPoint
 // eslint-disable-next-line jsdoc/require-jsdoc
 export function aggregate(
-  points: readonly BlsPoint.BlsPoint[],
+  points: readonly (Hex.Hex | Bytes.Bytes | BlsPoint.BlsPoint)[],
+  options: aggregate.Options = {},
 ): BlsPoint.BlsPoint {
   if (points.length === 0)
     throw new Errors.BaseError(
       'Bls.aggregate expects a non-empty array of points.',
     )
 
-  const first = points[0]!
+  // Normalize once -- accept structured points, hex strings, or `Uint8Array`s.
+  const groupHint = options.group
+  const normalized: BlsPoint.BlsPoint[] = points.map((point) => {
+    if (typeof point === 'string' || point instanceof Uint8Array) {
+      if (!groupHint)
+        throw new Errors.BaseError(
+          'Bls.aggregate requires `options.group` (`"G1"` or `"G2"`) when passing serialized points.',
+        )
+      return normalizeBlsPoint(point, groupHint)
+    }
+    return point
+  })
+
+  const first = normalized[0]!
 
   // Fast path: a single point aggregates to itself.
-  if (points.length === 1) return first
+  if (normalized.length === 1) return first
 
   const isG1 = typeof first.x === 'bigint'
-  for (let i = 1; i < points.length; i++) {
-    if ((typeof points[i]!.x === 'bigint') !== isG1)
+  for (let i = 1; i < normalized.length; i++) {
+    if ((typeof normalized[i]!.x === 'bigint') !== isG1)
       throw new Errors.BaseError(
         'Bls.aggregate expects all points to be from the same group (G1 or G2).',
       )
@@ -75,8 +134,8 @@ export function aggregate(
   // (avoids the per-iteration callback overhead from `Array.reduce`).
   const PointCtor = (group as any).Point
   let acc = group.Point.ZERO
-  for (let i = 0; i < points.length; i++) {
-    const p = points[i]!
+  for (let i = 0; i < normalized.length; i++) {
+    const p = normalized[i]!
     acc = acc.add(new PointCtor(p.x, p.y, p.z))
   }
   return {
@@ -87,6 +146,15 @@ export function aggregate(
 }
 
 export declare namespace aggregate {
+  type Options = {
+    /**
+     * Curve group of the input points. Required when any input is serialized
+     * (`Hex.Hex` or `Uint8Array`); ignored when all inputs are structured
+     * {@link ox#BlsPoint.BlsPoint}.
+     */
+    group?: 'G1' | 'G2' | undefined
+  }
+
   type ErrorType = Errors.GlobalErrorType
 }
 
@@ -343,21 +411,35 @@ export declare namespace createKeyPair {
  * @param options - The options to compute the public key.
  * @returns The computed public key.
  */
-export function getPublicKey<size extends Size = 'short-key:long-sig'>(
-  options: getPublicKey.Options<size>,
-): size extends 'short-key:long-sig' ? BlsPoint.G1 : BlsPoint.G2
+export function getPublicKey<
+  as extends 'Hex' | 'Bytes' | 'Object' = 'Object',
+  size extends Size = 'short-key:long-sig',
+>(options: getPublicKey.Options<as, size>): getPublicKey.ReturnType<as, size>
 // eslint-disable-next-line jsdoc/require-jsdoc
-export function getPublicKey(options: getPublicKey.Options): BlsPoint.BlsPoint {
-  const { privateKey, size = 'short-key:long-sig' } = options
+export function getPublicKey(options: getPublicKey.Options): unknown {
+  const { as = 'Object', privateKey, size = 'short-key:long-sig' } = options
   const group = size === 'short-key:long-sig' ? bls.G1 : bls.G2
   const point = group.Point.BASE.multiply(
     group.Point.Fn.fromBytes(Bytes.from(privateKey)),
   )
-  return { x: point.X, y: point.Y, z: point.Z }
+  const publicKey: BlsPoint.BlsPoint = {
+    x: point.X,
+    y: point.Y,
+    z: point.Z,
+  }
+  return formatBlsPoint(publicKey, as)
 }
 
 export declare namespace getPublicKey {
-  type Options<size extends Size = 'short-key:long-sig'> = {
+  type Options<
+    as extends 'Hex' | 'Bytes' | 'Object' = 'Object',
+    size extends Size = 'short-key:long-sig',
+  > = {
+    /**
+     * Format of the returned public key.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /**
      * Private key to compute the public key from.
      */
@@ -372,6 +454,23 @@ export declare namespace getPublicKey {
      */
     size?: size | Size | undefined
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object', size extends Size> =
+    | (as extends 'Bytes'
+        ? size extends 'short-key:long-sig'
+          ? BlsPoint.G1Bytes
+          : BlsPoint.G2Bytes
+        : never)
+    | (as extends 'Hex'
+        ? size extends 'short-key:long-sig'
+          ? BlsPoint.G1Hex
+          : BlsPoint.G2Hex
+        : never)
+    | (as extends 'Object'
+        ? size extends 'short-key:long-sig'
+          ? BlsPoint.G1
+          : BlsPoint.G2
+        : never)
 
   type ErrorType = Hex.from.ErrorType | Errors.GlobalErrorType
 }
@@ -475,12 +574,19 @@ export declare namespace randomPrivateKey {
  * @param options - The signing options.
  * @returns BLS Point.
  */
-export function sign<size extends Size = 'short-key:long-sig'>(
-  options: sign.Options<size>,
-): size extends 'short-key:long-sig' ? BlsPoint.G2 : BlsPoint.G1
+export function sign<
+  as extends 'Hex' | 'Bytes' | 'Object' = 'Object',
+  size extends Size = 'short-key:long-sig',
+>(options: sign.Options<as, size>): sign.ReturnType<as, size>
 // eslint-disable-next-line jsdoc/require-jsdoc
-export function sign(options: sign.Options): BlsPoint.BlsPoint {
-  const { payload, privateKey, suite, size = 'short-key:long-sig' } = options
+export function sign(options: sign.Options): unknown {
+  const {
+    as = 'Object',
+    payload,
+    privateKey,
+    suite,
+    size = 'short-key:long-sig',
+  } = options
 
   const payloadGroup = size === 'short-key:long-sig' ? bls.G2 : bls.G1
   const payloadPoint = payloadGroup.hashToCurve(
@@ -493,15 +599,24 @@ export function sign(options: sign.Options): BlsPoint.BlsPoint {
     privateKeyGroup.Point.Fn.fromBytes(Bytes.from(privateKey)),
   )
 
-  return {
+  const result: BlsPoint.BlsPoint = {
     x: signature.X,
     y: signature.Y,
     z: signature.Z,
   }
+  return formatBlsPoint(result, as)
 }
 
 export declare namespace sign {
-  type Options<size extends Size = 'short-key:long-sig'> = {
+  type Options<
+    as extends 'Hex' | 'Bytes' | 'Object' = 'Object',
+    size extends Size = 'short-key:long-sig',
+  > = {
+    /**
+     * Format of the returned signature.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /**
      * Payload to sign.
      */
@@ -527,6 +642,23 @@ export declare namespace sign {
      */
     size?: size | Size | undefined
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object', size extends Size> =
+    | (as extends 'Bytes'
+        ? size extends 'short-key:long-sig'
+          ? BlsPoint.G2Bytes
+          : BlsPoint.G1Bytes
+        : never)
+    | (as extends 'Hex'
+        ? size extends 'short-key:long-sig'
+          ? BlsPoint.G2Hex
+          : BlsPoint.G1Hex
+        : never)
+    | (as extends 'Object'
+        ? size extends 'short-key:long-sig'
+          ? BlsPoint.G2
+          : BlsPoint.G1
+        : never)
 
   type ErrorType = Bytes.from.ErrorType | Errors.GlobalErrorType
 }
@@ -582,8 +714,43 @@ export declare namespace sign {
 export function verify(options: verify.Options): boolean {
   const { payload, suite } = options
 
-  const publicKey = options.publicKey as unknown as BlsPoint.BlsPoint<any>
-  const signature = options.signature as unknown as BlsPoint.BlsPoint<any>
+  // Accept structured / hex / bytes inputs. Inspect the *signature* group
+  // first when structured, otherwise fall back to the explicit `group` /
+  // pair-shape hint to know how to deserialize.
+  const signatureRaw = options.signature
+  const publicKeyRaw = options.publicKey
+
+  // If signature is structured, infer signature group via field shape.
+  const signatureIsStructured =
+    typeof signatureRaw === 'object' &&
+    !(signatureRaw instanceof Uint8Array) &&
+    'z' in signatureRaw
+  const publicKeyIsStructured =
+    typeof publicKeyRaw === 'object' &&
+    !(publicKeyRaw instanceof Uint8Array) &&
+    'z' in publicKeyRaw
+
+  // Determine signature group: G1 (short sig, x is bigint) or G2 (long sig).
+  // For serialized signatures, infer from the byte/hex length.
+  const signatureGroup: 'G1' | 'G2' = signatureIsStructured
+    ? typeof (signatureRaw as BlsPoint.BlsPoint).x === 'bigint'
+      ? 'G1'
+      : 'G2'
+    : signatureByteLength(signatureRaw as Hex.Hex | Bytes.Bytes) === 48
+      ? 'G1'
+      : 'G2'
+  const publicKeyGroup: 'G1' | 'G2' = signatureGroup === 'G1' ? 'G2' : 'G1'
+
+  const signature = (
+    signatureIsStructured
+      ? (signatureRaw as BlsPoint.BlsPoint)
+      : normalizeBlsPoint(signatureRaw as Hex.Hex | Bytes.Bytes, signatureGroup)
+  ) as BlsPoint.BlsPoint<any>
+  const publicKey = (
+    publicKeyIsStructured
+      ? (publicKeyRaw as BlsPoint.BlsPoint)
+      : normalizeBlsPoint(publicKeyRaw as Hex.Hex | Bytes.Bytes, publicKeyGroup)
+  ) as BlsPoint.BlsPoint<any>
 
   const isShortSig = typeof signature.x === 'bigint'
 
@@ -638,12 +805,28 @@ export declare namespace verify {
     suite?: string | undefined
   } & OneOf<
     | {
-        publicKey: BlsPoint.G1
-        signature: BlsPoint.G2
+        /**
+         * Public key (G1). Accepts a structured {@link ox#BlsPoint.G1}, a hex
+         * string, or a `Uint8Array`.
+         */
+        publicKey: Hex.Hex | Bytes.Bytes | BlsPoint.G1
+        /**
+         * Signature (G2). Accepts a structured {@link ox#BlsPoint.G2}, a hex
+         * string, or a `Uint8Array`.
+         */
+        signature: Hex.Hex | Bytes.Bytes | BlsPoint.G2
       }
     | {
-        publicKey: BlsPoint.G2
-        signature: BlsPoint.G1
+        /**
+         * Public key (G2). Accepts a structured {@link ox#BlsPoint.G2}, a hex
+         * string, or a `Uint8Array`.
+         */
+        publicKey: Hex.Hex | Bytes.Bytes | BlsPoint.G2
+        /**
+         * Signature (G1). Accepts a structured {@link ox#BlsPoint.G1}, a hex
+         * string, or a `Uint8Array`.
+         */
+        signature: Hex.Hex | Bytes.Bytes | BlsPoint.G1
       }
   >
 

--- a/src/core/BlsPoint.ts
+++ b/src/core/BlsPoint.ts
@@ -31,26 +31,16 @@ export type G2Bytes = Branded<Bytes.Bytes, 'G2'>
 /** Branded type for a hex representation of a G2 point. */
 export type G2Hex = Branded<Hex.Hex, 'G2'>
 
-/**
- * Structured projective parts of a BLS point on the G1 curve.
- *
- * @remarks
- * In a future major (`1.0`), {@link ox#BlsPoint.G1} will be flipped to a
- * branded {@link ox#BlsPoint.G1Hex} string and this `Parts` type will represent
- * the structured projective form. Today, `G1Parts` is structurally equivalent
- * to `G1` -- prefer it in new code so the upgrade path is a no-op.
- */
+// TODO(v1): flip `G1` to a branded `G1Hex` string and let `G1Parts` represent
+// the structured projective form. Today `G1Parts` is structurally equivalent
+// to `G1`.
+/** Structured projective parts of a BLS point on the G1 curve. */
 export type G1Parts = BlsPoint<Fp>
 
-/**
- * Structured projective parts of a BLS point on the G2 curve.
- *
- * @remarks
- * In a future major (`1.0`), {@link ox#BlsPoint.G2} will be flipped to a
- * branded {@link ox#BlsPoint.G2Hex} string and this `Parts` type will represent
- * the structured projective form. Today, `G2Parts` is structurally equivalent
- * to `G2` -- prefer it in new code so the upgrade path is a no-op.
- */
+// TODO(v1): flip `G2` to a branded `G2Hex` string and let `G2Parts` represent
+// the structured projective form. Today `G2Parts` is structurally equivalent
+// to `G2`.
+/** Structured projective parts of a BLS point on the G2 curve. */
 export type G2Parts = BlsPoint<Fp2>
 
 /**
@@ -245,17 +235,12 @@ export declare namespace fromHex {
   type ErrorType = Errors.GlobalErrorType
 }
 
+// TODO(v1): once `G1` / `G2` are branded `Hex.Hex` strings, decode into the
+// parts form here by delegating through `toBytes` / `fromBytes` instead of
+// returning the projective object directly.
 /**
  * Converts a BLS point to its structured projective {@link ox#BlsPoint.G1Parts}
  * / {@link ox#BlsPoint.G2Parts} form.
- *
- * @remarks
- * Today this is a structural pass-through (the root `BlsPoint` is already the
- * projective object). In a future major, `G1` / `G2` will be branded
- * `Hex.Hex` strings and this codec will decode into the parts form by
- * delegating through {@link ox#BlsPoint.(toBytes:function)} /
- * {@link ox#BlsPoint.(fromBytes:function)}. Migrating call sites to `toParts`
- * / `fromParts` now keeps that upgrade a no-op.
  *
  * @example
  * ### Public Key to Parts
@@ -284,15 +269,12 @@ export declare namespace toParts {
   type ErrorType = Errors.GlobalErrorType
 }
 
+// TODO(v1): once `G1` / `G2` are branded `Hex.Hex` strings, encode the parts
+// via `toBytes` here instead of returning the projective object directly.
 /**
  * Converts structured projective parts ({@link ox#BlsPoint.G1Parts} or
  * {@link ox#BlsPoint.G2Parts}) into a {@link ox#BlsPoint.G1} or
  * {@link ox#BlsPoint.G2} BLS point.
- *
- * @remarks
- * Today this is a structural pass-through. In a future major, the BLS point
- * root types will be branded `Hex.Hex` strings; this codec will then encode
- * the parts via {@link ox#BlsPoint.(toBytes:function)}.
  *
  * @example
  * ### Parts to Public Key

--- a/src/core/BlsPoint.ts
+++ b/src/core/BlsPoint.ts
@@ -32,6 +32,28 @@ export type G2Bytes = Branded<Bytes.Bytes, 'G2'>
 export type G2Hex = Branded<Hex.Hex, 'G2'>
 
 /**
+ * Structured projective parts of a BLS point on the G1 curve.
+ *
+ * @remarks
+ * In a future major (`1.0`), {@link ox#BlsPoint.G1} will be flipped to a
+ * branded {@link ox#BlsPoint.G1Hex} string and this `Parts` type will represent
+ * the structured projective form. Today, `G1Parts` is structurally equivalent
+ * to `G1` -- prefer it in new code so the upgrade path is a no-op.
+ */
+export type G1Parts = BlsPoint<Fp>
+
+/**
+ * Structured projective parts of a BLS point on the G2 curve.
+ *
+ * @remarks
+ * In a future major (`1.0`), {@link ox#BlsPoint.G2} will be flipped to a
+ * branded {@link ox#BlsPoint.G2Hex} string and this `Parts` type will represent
+ * the structured projective form. Today, `G2Parts` is structurally equivalent
+ * to `G2` -- prefer it in new code so the upgrade path is a no-op.
+ */
+export type G2Parts = BlsPoint<Fp2>
+
+/**
  * Converts a BLS point to {@link ox#Bytes.Bytes}.
  *
  * @example
@@ -220,5 +242,91 @@ export function fromHex(hex: Hex.Hex, group: 'G1' | 'G2'): BlsPoint<any> {
 }
 
 export declare namespace fromHex {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts a BLS point to its structured projective {@link ox#BlsPoint.G1Parts}
+ * / {@link ox#BlsPoint.G2Parts} form.
+ *
+ * @remarks
+ * Today this is a structural pass-through (the root `BlsPoint` is already the
+ * projective object). In a future major, `G1` / `G2` will be branded
+ * `Hex.Hex` strings and this codec will decode into the parts form by
+ * delegating through {@link ox#BlsPoint.(toBytes:function)} /
+ * {@link ox#BlsPoint.(fromBytes:function)}. Migrating call sites to `toParts`
+ * / `fromParts` now keeps that upgrade a no-op.
+ *
+ * @example
+ * ### Public Key to Parts
+ *
+ * ```ts twoslash
+ * import { Bls, BlsPoint } from 'ox'
+ *
+ * const publicKey = Bls.getPublicKey({ privateKey: '0x...' })
+ * const parts = BlsPoint.toParts(publicKey)
+ * // @log: { x: 172...n, y: 175...n, z: 1n }
+ * ```
+ *
+ * @param point - The BLS point to convert.
+ * @returns The structured projective parts.
+ */
+export function toParts<point extends G1 | G2>(
+  point: point,
+): point extends G1 ? G1Parts : G2Parts {
+  // Today the root `BlsPoint` is already the projective object form -- copy
+  // the fields so callers don't accidentally mutate the input. In the future
+  // major, this becomes `fromBytes(toBytes(point))`.
+  return { x: point.x, y: point.y, z: point.z } as never
+}
+
+export declare namespace toParts {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts structured projective parts ({@link ox#BlsPoint.G1Parts} or
+ * {@link ox#BlsPoint.G2Parts}) into a {@link ox#BlsPoint.G1} or
+ * {@link ox#BlsPoint.G2} BLS point.
+ *
+ * @remarks
+ * Today this is a structural pass-through. In a future major, the BLS point
+ * root types will be branded `Hex.Hex` strings; this codec will then encode
+ * the parts via {@link ox#BlsPoint.(toBytes:function)}.
+ *
+ * @example
+ * ### Parts to Public Key
+ *
+ * ```ts twoslash
+ * // @noErrors
+ * import { BlsPoint } from 'ox'
+ *
+ * const publicKey = BlsPoint.fromParts(
+ *   { x: 172n, y: 175n, z: 1n },
+ *   'G1',
+ * )
+ * // @log: { x: 172n, y: 175n, z: 1n }
+ * ```
+ *
+ * @param parts - The structured projective parts to convert.
+ * @param group - The BLS curve group (`'G1'` or `'G2'`).
+ * @returns The BLS point.
+ */
+export function fromParts<group extends 'G1' | 'G2'>(
+  parts: group extends 'G1' ? G1Parts : G2Parts,
+  group: group,
+): group extends 'G1' ? G1 : G2
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function fromParts(
+  parts: G1Parts | G2Parts,
+  _group: 'G1' | 'G2',
+): BlsPoint<any> {
+  // Today the root `BlsPoint` is already the projective object form. In the
+  // future major, this becomes `fromBytes(<bytes encoded from parts>, group)`
+  // -- the `group` argument is kept now so call sites match the future shape.
+  return { x: parts.x, y: parts.y, z: parts.z }
+}
+
+export declare namespace fromParts {
   type ErrorType = Errors.GlobalErrorType
 }

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -2,6 +2,12 @@ import { p256 as noble_p256 } from '@noble/curves/nist.js'
 import * as Bytes from './Bytes.js'
 import type * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
+import {
+  formatPublicKey,
+  formatSignature,
+  normalizePublicKey,
+  normalizeSignature,
+} from './internal/cryptoIo.js'
 import * as Entropy from './internal/entropy.js'
 import {
   fromRecoveredBytes,
@@ -75,21 +81,32 @@ export declare namespace createKeyPair {
  * @param options - The options to compute the public key.
  * @returns The computed public key.
  */
-export function getPublicKey(
-  options: getPublicKey.Options,
-): PublicKey.PublicKey {
-  const { privateKey } = options
+export function getPublicKey<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'>(
+  options: getPublicKey.Options<as>,
+): getPublicKey.ReturnType<as> {
+  const { as = 'Object', privateKey } = options
   const bytes = noble_p256.getPublicKey(Bytes.from(privateKey), false)
-  return PublicKey.fromBytes(bytes)
+  const publicKey = PublicKey.fromBytes(bytes)
+  return formatPublicKey(publicKey, as) as never
 }
 
 export declare namespace getPublicKey {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'> = {
+    /**
+     * Format of the returned public key.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /**
      * Private key to compute the public key from.
      */
     privateKey: Hex.Hex | Bytes.Bytes
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'Object' ? PublicKey.PublicKey : never)
 
   type ErrorType = Errors.GlobalErrorType
 }
@@ -119,7 +136,7 @@ export function getSharedSecret<as extends 'Hex' | 'Bytes' = 'Hex'>(
   const { as = 'Hex', privateKey, publicKey } = options
   const sharedSecret = noble_p256.getSharedSecret(
     Bytes.from(privateKey),
-    PublicKey.toBytes(publicKey),
+    PublicKey.toBytes(normalizePublicKey(publicKey)),
     true, // compressed
   )
   if (as === 'Hex') return Hex.fromBytes(sharedSecret) as never
@@ -139,8 +156,11 @@ export declare namespace getSharedSecret {
     privateKey: Hex.Hex | Bytes.Bytes
     /**
      * Public key to use for the shared secret computation.
+     *
+     * Accepts a structured {@link ox#PublicKey.PublicKey}, a serialized hex
+     * string, or a `Uint8Array` (SEC1 encoding).
      */
-    publicKey: PublicKey.PublicKey<boolean>
+    publicKey: Hex.Hex | Bytes.Bytes | PublicKey.PublicKey<boolean>
   }
 
   type ReturnType<as extends 'Hex' | 'Bytes'> =
@@ -209,25 +229,41 @@ export declare namespace randomPrivateKey {
  * @param options - The recovery options.
  * @returns The recovered public key.
  */
-export function recoverPublicKey(
-  options: recoverPublicKey.Options,
-): PublicKey.PublicKey {
-  const { payload, signature } = options
-  const sigBytes = toRecoveredBytes(signature)
+export function recoverPublicKey<
+  as extends 'Hex' | 'Bytes' | 'Object' = 'Object',
+>(options: recoverPublicKey.Options<as>): recoverPublicKey.ReturnType<as> {
+  const { as = 'Object', payload, signature } = options
+  const sigBytes = toRecoveredBytes(normalizeSignature<true>(signature))
   const point = noble_p256.Signature.fromBytes(
     sigBytes,
     'recovered',
   ).recoverPublicKey(Bytes.from(payload))
-  return PublicKey.fromBytes(point.toBytes(false))
+  const publicKey = PublicKey.fromBytes(point.toBytes(false))
+  return formatPublicKey(publicKey, as) as never
 }
 
 export declare namespace recoverPublicKey {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'> = {
+    /**
+     * Format of the returned public key.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /** Payload that was signed. */
     payload: Hex.Hex | Bytes.Bytes
-    /** Signature of the payload. */
-    signature: Signature.Signature
+    /**
+     * Signature of the payload.
+     *
+     * Accepts a structured {@link ox#Signature.Signature}, a serialized hex
+     * string, or a `Uint8Array` (65-byte recovered).
+     */
+    signature: Hex.Hex | Bytes.Bytes | Signature.Signature
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'Object' ? PublicKey.PublicKey : never)
 
   type ErrorType =
     | PublicKey.from.ErrorType
@@ -251,8 +287,11 @@ export declare namespace recoverPublicKey {
  * @param options - The signing options.
  * @returns The ECDSA {@link ox#Signature.Signature}.
  */
-export function sign(options: sign.Options): Signature.Signature {
+export function sign<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'>(
+  options: sign.Options<as>,
+): sign.ReturnType<as> {
   const {
+    as = 'Object',
     extraEntropy = Entropy.extraEntropy,
     hash,
     payload,
@@ -271,11 +310,17 @@ export function sign(options: sign.Options): Signature.Signature {
       format: 'recovered',
     },
   )
-  return fromRecoveredBytes(sigBytes)
+  const signature = fromRecoveredBytes(sigBytes)
+  return formatSignature(signature, as) as never
 }
 
 export declare namespace sign {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'> = {
+    /**
+     * Format of the returned signature.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /**
      * Extra entropy to add to the signing process. Setting to `true` enables hedged
      * (RFC 6979 + extra randomness) signing.
@@ -295,6 +340,11 @@ export declare namespace sign {
      */
     privateKey: Hex.Hex | Bytes.Bytes
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'Object' ? Signature.Signature : never)
 
   type ErrorType = Bytes.fromHex.ErrorType | Errors.GlobalErrorType
 }
@@ -323,9 +373,9 @@ export declare namespace sign {
 export function verify(options: verify.Options): boolean {
   const { hash, payload, publicKey, signature } = options
   return noble_p256.verify(
-    toCompactBytes(signature),
+    toCompactBytes(normalizeSignature(signature)),
     Bytes.from(payload),
-    PublicKey.toBytes(publicKey),
+    PublicKey.toBytes(normalizePublicKey(publicKey)),
     { lowS: true, prehash: hash === true },
   )
 }
@@ -336,10 +386,20 @@ export declare namespace verify {
     hash?: boolean | undefined
     /** Payload that was signed. */
     payload: Hex.Hex | Bytes.Bytes
-    /** Public key that signed the payload. */
-    publicKey: PublicKey.PublicKey<boolean>
-    /** Signature of the payload. */
-    signature: Signature.Signature<boolean>
+    /**
+     * Public key that signed the payload.
+     *
+     * Accepts a structured {@link ox#PublicKey.PublicKey}, a serialized hex
+     * string, or a `Uint8Array` (SEC1 encoding).
+     */
+    publicKey: Hex.Hex | Bytes.Bytes | PublicKey.PublicKey<boolean>
+    /**
+     * Signature of the payload.
+     *
+     * Accepts a structured {@link ox#Signature.Signature}, a serialized hex
+     * string, or a `Uint8Array`.
+     */
+    signature: Hex.Hex | Bytes.Bytes | Signature.Signature<boolean>
   }
 
   type ErrorType = Errors.GlobalErrorType

--- a/src/core/PublicKey.ts
+++ b/src/core/PublicKey.ts
@@ -24,6 +24,30 @@ export type PublicKey<
 >
 
 /**
+ * Structured parts of an ECDSA public key.
+ *
+ * @remarks
+ * In a future major (`1.0`), {@link ox#PublicKey.PublicKey} will be flipped to
+ * a serialized {@link ox#Hex.Hex} string and this `Parts` type will represent
+ * the structured object form. Today, `PublicKeyParts<compressed>` is
+ * structurally equivalent to `PublicKey<compressed>` -- prefer it in new code
+ * so the upgrade path is a no-op.
+ */
+export type PublicKeyParts<compressed extends boolean = false> = Compute<
+  compressed extends true
+    ? {
+        prefix: number
+        x: bigint
+        y?: undefined
+      }
+    : {
+        prefix: number
+        x: bigint
+        y: bigint
+      }
+>
+
+/**
  * Asserts that a {@link ox#PublicKey.PublicKey} is valid.
  *
  * @example
@@ -384,6 +408,87 @@ export declare namespace toBytes {
     | Hex.fromNumber.ErrorType
     | Bytes.fromHex.ErrorType
     | Errors.GlobalErrorType
+}
+
+/**
+ * Converts a {@link ox#PublicKey.PublicKey} to its structured
+ * {@link ox#PublicKey.PublicKeyParts} form.
+ *
+ * @remarks
+ * Today this is a structural pass-through (the root `PublicKey` type is
+ * already the structured object). In a future major, `PublicKey` will be a
+ * serialized `Hex.Hex` string and this codec will decode into the parts form.
+ * Migrating call sites to `toParts` / `fromParts` now keeps that upgrade a
+ * no-op.
+ *
+ * @example
+ * ```ts twoslash
+ * import { PublicKey } from 'ox'
+ *
+ * const parts = PublicKey.toParts({
+ *   prefix: 4,
+ *   x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+ *   y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+ * })
+ * // @log: { prefix: 4, x: 59295...n, y: 24099...n }
+ * ```
+ *
+ * @param publicKey - The public key to convert.
+ * @returns The structured {@link ox#PublicKey.PublicKeyParts}.
+ */
+export function toParts<compressed extends boolean = false>(
+  publicKey: PublicKey<compressed>,
+): PublicKeyParts<compressed> {
+  if (typeof publicKey.y === 'bigint')
+    return {
+      prefix: publicKey.prefix,
+      x: publicKey.x,
+      y: publicKey.y,
+    } as never
+  return { prefix: publicKey.prefix, x: publicKey.x } as never
+}
+
+export declare namespace toParts {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts a {@link ox#PublicKey.PublicKeyParts} into a structured
+ * {@link ox#PublicKey.PublicKey}.
+ *
+ * @remarks
+ * Today this is a structural pass-through. In a future major, `PublicKey` will
+ * be a serialized `Hex.Hex` string and this codec will encode into that form.
+ *
+ * @example
+ * ```ts twoslash
+ * import { PublicKey } from 'ox'
+ *
+ * const publicKey = PublicKey.fromParts({
+ *   prefix: 4,
+ *   x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+ *   y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+ * })
+ * // @log: { prefix: 4, x: 59295...n, y: 24099...n }
+ * ```
+ *
+ * @param parts - The structured parts to convert.
+ * @returns The {@link ox#PublicKey.PublicKey}.
+ */
+export function fromParts<compressed extends boolean = false>(
+  parts: PublicKeyParts<compressed>,
+): PublicKey<compressed> {
+  if (typeof parts.y === 'bigint')
+    return {
+      prefix: parts.prefix,
+      x: parts.x,
+      y: parts.y,
+    } as never
+  return { prefix: parts.prefix, x: parts.x } as never
+}
+
+export declare namespace fromParts {
+  type ErrorType = Errors.GlobalErrorType
 }
 
 /**

--- a/src/core/PublicKey.ts
+++ b/src/core/PublicKey.ts
@@ -29,11 +29,11 @@ export type PublicKey<
  * @remarks
  * In a future major (`1.0`), {@link ox#PublicKey.PublicKey} will be flipped to
  * a serialized {@link ox#Hex.Hex} string and this `Parts` type will represent
- * the structured object form. Today, `PublicKeyParts<compressed>` is
+ * the structured object form. Today, `Parts<compressed>` is
  * structurally equivalent to `PublicKey<compressed>` -- prefer it in new code
  * so the upgrade path is a no-op.
  */
-export type PublicKeyParts<compressed extends boolean = false> = Compute<
+export type Parts<compressed extends boolean = false> = Compute<
   compressed extends true
     ? {
         prefix: number
@@ -412,7 +412,7 @@ export declare namespace toBytes {
 
 /**
  * Converts a {@link ox#PublicKey.PublicKey} to its structured
- * {@link ox#PublicKey.PublicKeyParts} form.
+ * {@link ox#PublicKey.Parts} form.
  *
  * @remarks
  * Today this is a structural pass-through (the root `PublicKey` type is
@@ -434,11 +434,11 @@ export declare namespace toBytes {
  * ```
  *
  * @param publicKey - The public key to convert.
- * @returns The structured {@link ox#PublicKey.PublicKeyParts}.
+ * @returns The structured {@link ox#PublicKey.Parts}.
  */
 export function toParts<compressed extends boolean = false>(
   publicKey: PublicKey<compressed>,
-): PublicKeyParts<compressed> {
+): Parts<compressed> {
   if (typeof publicKey.y === 'bigint')
     return {
       prefix: publicKey.prefix,
@@ -453,7 +453,7 @@ export declare namespace toParts {
 }
 
 /**
- * Converts a {@link ox#PublicKey.PublicKeyParts} into a structured
+ * Converts a {@link ox#PublicKey.Parts} into a structured
  * {@link ox#PublicKey.PublicKey}.
  *
  * @remarks
@@ -476,7 +476,7 @@ export declare namespace toParts {
  * @returns The {@link ox#PublicKey.PublicKey}.
  */
 export function fromParts<compressed extends boolean = false>(
-  parts: PublicKeyParts<compressed>,
+  parts: Parts<compressed>,
 ): PublicKey<compressed> {
   if (typeof parts.y === 'bigint')
     return {

--- a/src/core/PublicKey.ts
+++ b/src/core/PublicKey.ts
@@ -23,16 +23,10 @@ export type PublicKey<
       }
 >
 
-/**
- * Structured parts of an ECDSA public key.
- *
- * @remarks
- * In a future major (`1.0`), {@link ox#PublicKey.PublicKey} will be flipped to
- * a serialized {@link ox#Hex.Hex} string and this `Parts` type will represent
- * the structured object form. Today, `Parts<compressed>` is
- * structurally equivalent to `PublicKey<compressed>` -- prefer it in new code
- * so the upgrade path is a no-op.
- */
+// TODO(v1): flip `PublicKey` to a serialized `Hex.Hex` string and let `Parts`
+// represent the structured object form. Today `Parts<compressed>` is
+// structurally equivalent to `PublicKey<compressed>`.
+/** Structured parts of an ECDSA public key. */
 export type Parts<compressed extends boolean = false> = Compute<
   compressed extends true
     ? {
@@ -410,16 +404,11 @@ export declare namespace toBytes {
     | Errors.GlobalErrorType
 }
 
+// TODO(v1): once `PublicKey` is a serialized `Hex.Hex` string, decode it into
+// the parts form here instead of returning the input directly.
 /**
  * Converts a {@link ox#PublicKey.PublicKey} to its structured
  * {@link ox#PublicKey.Parts} form.
- *
- * @remarks
- * Today this is a structural pass-through (the root `PublicKey` type is
- * already the structured object). In a future major, `PublicKey` will be a
- * serialized `Hex.Hex` string and this codec will decode into the parts form.
- * Migrating call sites to `toParts` / `fromParts` now keeps that upgrade a
- * no-op.
  *
  * @example
  * ```ts twoslash
@@ -452,13 +441,11 @@ export declare namespace toParts {
   type ErrorType = Errors.GlobalErrorType
 }
 
+// TODO(v1): once `PublicKey` is a serialized `Hex.Hex` string, encode the
+// parts into that form here instead of returning the input directly.
 /**
  * Converts a {@link ox#PublicKey.Parts} into a structured
  * {@link ox#PublicKey.PublicKey}.
- *
- * @remarks
- * Today this is a structural pass-through. In a future major, `PublicKey` will
- * be a serialized `Hex.Hex` string and this codec will encode into that form.
  *
  * @example
  * ```ts twoslash

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -3,6 +3,12 @@ import * as Address from './Address.js'
 import * as Bytes from './Bytes.js'
 import type * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
+import {
+  formatPublicKey,
+  formatSignature,
+  normalizePublicKey,
+  normalizeSignature,
+} from './internal/cryptoIo.js'
 import * as Entropy from './internal/entropy.js'
 import {
   fromRecoveredBytes,
@@ -77,21 +83,32 @@ export declare namespace createKeyPair {
  * @param options - The options to compute the public key.
  * @returns The computed public key.
  */
-export function getPublicKey(
-  options: getPublicKey.Options,
-): PublicKey.PublicKey {
-  const { privateKey } = options
+export function getPublicKey<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'>(
+  options: getPublicKey.Options<as>,
+): getPublicKey.ReturnType<as> {
+  const { as = 'Object', privateKey } = options
   const bytes = secp256k1.getPublicKey(Bytes.from(privateKey), false)
-  return PublicKey.fromBytes(bytes)
+  const publicKey = PublicKey.fromBytes(bytes)
+  return formatPublicKey(publicKey, as) as never
 }
 
 export declare namespace getPublicKey {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'> = {
+    /**
+     * Format of the returned public key.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /**
      * Private key to compute the public key from.
      */
     privateKey: Hex.Hex | Bytes.Bytes
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'Object' ? PublicKey.PublicKey : never)
 
   type ErrorType =
     | Hex.from.ErrorType
@@ -124,7 +141,7 @@ export function getSharedSecret<as extends 'Hex' | 'Bytes' = 'Hex'>(
   const { as = 'Hex', privateKey, publicKey } = options
   const sharedSecret = secp256k1.getSharedSecret(
     Bytes.from(privateKey),
-    PublicKey.toBytes(publicKey),
+    PublicKey.toBytes(normalizePublicKey(publicKey)),
     true, // compressed
   )
   if (as === 'Hex') return Hex.fromBytes(sharedSecret) as never
@@ -144,8 +161,11 @@ export declare namespace getSharedSecret {
     privateKey: Hex.Hex | Bytes.Bytes
     /**
      * Public key to use for the shared secret computation.
+     *
+     * Accepts a structured {@link ox#PublicKey.PublicKey}, a serialized hex
+     * string, or a `Uint8Array` (SEC1 encoding).
      */
-    publicKey: PublicKey.PublicKey<boolean>
+    publicKey: Hex.Hex | Bytes.Bytes | PublicKey.PublicKey<boolean>
   }
 
   type ReturnType<as extends 'Hex' | 'Bytes'> =
@@ -225,8 +245,13 @@ export declare namespace recoverAddress {
   type Options = {
     /** Payload that was signed. */
     payload: Hex.Hex | Bytes.Bytes
-    /** Signature of the payload. */
-    signature: Signature.Signature
+    /**
+     * Signature of the payload.
+     *
+     * Accepts a structured {@link ox#Signature.Signature}, a serialized hex
+     * string, or a `Uint8Array` (65-byte recovered).
+     */
+    signature: Hex.Hex | Bytes.Bytes | Signature.Signature
   }
 
   type ReturnType = Address.Address
@@ -255,25 +280,41 @@ export declare namespace recoverAddress {
  * @param options - The recovery options.
  * @returns The recovered public key.
  */
-export function recoverPublicKey(
-  options: recoverPublicKey.Options,
-): PublicKey.PublicKey {
-  const { payload, signature } = options
-  const sigBytes = toRecoveredBytes(signature)
+export function recoverPublicKey<
+  as extends 'Hex' | 'Bytes' | 'Object' = 'Object',
+>(options: recoverPublicKey.Options<as>): recoverPublicKey.ReturnType<as> {
+  const { as = 'Object', payload, signature } = options
+  const sigBytes = toRecoveredBytes(normalizeSignature<true>(signature))
   const point = secp256k1.Signature.fromBytes(
     sigBytes,
     'recovered',
   ).recoverPublicKey(Bytes.from(payload))
-  return PublicKey.fromBytes(point.toBytes(false))
+  const publicKey = PublicKey.fromBytes(point.toBytes(false))
+  return formatPublicKey(publicKey, as) as never
 }
 
 export declare namespace recoverPublicKey {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'> = {
+    /**
+     * Format of the returned public key.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /** Payload that was signed. */
     payload: Hex.Hex | Bytes.Bytes
-    /** Signature of the payload. */
-    signature: Signature.Signature
+    /**
+     * Signature of the payload.
+     *
+     * Accepts a structured {@link ox#Signature.Signature}, a serialized hex
+     * string, or a `Uint8Array` (65-byte recovered).
+     */
+    signature: Hex.Hex | Bytes.Bytes | Signature.Signature
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'Object' ? PublicKey.PublicKey : never)
 
   type ErrorType =
     | PublicKey.from.ErrorType
@@ -297,8 +338,11 @@ export declare namespace recoverPublicKey {
  * @param options - The signing options.
  * @returns The ECDSA {@link ox#Signature.Signature}.
  */
-export function sign(options: sign.Options): Signature.Signature {
+export function sign<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'>(
+  options: sign.Options<as>,
+): sign.ReturnType<as> {
   const {
+    as = 'Object',
     extraEntropy = Entropy.extraEntropy,
     hash,
     payload,
@@ -313,11 +357,17 @@ export function sign(options: sign.Options): Signature.Signature {
     prehash: hash === true,
     format: 'recovered',
   })
-  return fromRecoveredBytes(sigBytes)
+  const signature = fromRecoveredBytes(sigBytes)
+  return formatSignature(signature, as) as never
 }
 
 export declare namespace sign {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'> = {
+    /**
+     * Format of the returned signature.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /**
      * Extra entropy to add to the signing process. Setting to `true` enables hedged
      * (RFC 6979 + extra randomness) signing.
@@ -337,6 +387,11 @@ export declare namespace sign {
      */
     privateKey: Hex.Hex | Bytes.Bytes
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'Object' ? Signature.Signature : never)
 
   type ErrorType = Bytes.from.ErrorType | Errors.GlobalErrorType
 }
@@ -383,10 +438,11 @@ export function verify(options: verify.Options): boolean {
   const { address, hash, payload, publicKey, signature } = options
   if (address)
     return Address.isEqual(address, recoverAddress({ payload, signature }))
+  const sig = normalizeSignature(signature)
   return secp256k1.verify(
-    toCompactBytes(signature),
+    toCompactBytes(sig),
     Bytes.from(payload),
-    PublicKey.toBytes(publicKey),
+    PublicKey.toBytes(normalizePublicKey(publicKey)),
     { lowS: true, prehash: hash === true },
   )
 }
@@ -401,14 +457,29 @@ export declare namespace verify {
     | {
         /** Address that signed the payload. */
         address: Address.Address
-        /** Signature of the payload. */
-        signature: Signature.Signature
+        /**
+         * Signature of the payload.
+         *
+         * Accepts a structured {@link ox#Signature.Signature}, a serialized
+         * hex string, or a `Uint8Array`.
+         */
+        signature: Hex.Hex | Bytes.Bytes | Signature.Signature
       }
     | {
-        /** Public key that signed the payload. */
-        publicKey: PublicKey.PublicKey<boolean>
-        /** Signature of the payload. */
-        signature: Signature.Signature<false>
+        /**
+         * Public key that signed the payload.
+         *
+         * Accepts a structured {@link ox#PublicKey.PublicKey}, a serialized
+         * hex string, or a `Uint8Array` (SEC1 encoding).
+         */
+        publicKey: Hex.Hex | Bytes.Bytes | PublicKey.PublicKey<boolean>
+        /**
+         * Signature of the payload.
+         *
+         * Accepts a structured {@link ox#Signature.Signature}, a serialized
+         * hex string, or a `Uint8Array`.
+         */
+        signature: Hex.Hex | Bytes.Bytes | Signature.Signature<boolean>
       }
   >
 

--- a/src/core/Signature.ts
+++ b/src/core/Signature.ts
@@ -25,16 +25,10 @@ export type Signature<
       }
 >
 
-/**
- * Structured parts of an ECDSA signature.
- *
- * @remarks
- * In a future major (`1.0`), {@link ox#Signature.Signature} will be flipped to a
- * serialized {@link ox#Hex.Hex} string and this `Parts` type will represent the
- * structured object form. Today, `Parts<recovered>` is structurally
- * equivalent to `Signature<recovered>` -- prefer it in new code so the upgrade
- * path is a no-op.
- */
+// TODO(v1): flip `Signature` to a serialized `Hex.Hex` string and let `Parts`
+// represent the structured object form. Today `Parts<recovered>` is
+// structurally equivalent to `Signature<recovered>`.
+/** Structured parts of an ECDSA signature. */
 export type Parts<recovered extends boolean = true> = Compute<
   recovered extends true
     ? {
@@ -646,15 +640,11 @@ export declare namespace fromRecoveredBytes {
   type ErrorType = Bytes.toBigInt.ErrorType | Errors.GlobalErrorType
 }
 
+// TODO(v1): once `Signature` is a serialized `Hex.Hex` string, decode it into
+// the parts form here instead of returning the input directly.
 /**
  * Converts a {@link ox#Signature.Signature} to its structured
  * {@link ox#Signature.Parts} form.
- *
- * @remarks
- * Today this is a structural pass-through (the root `Signature` type is already
- * the structured object). In a future major, `Signature` will be a serialized
- * `Hex.Hex` string and this codec will decode into the parts form. Migrating
- * call sites to `toParts` / `fromParts` now keeps that upgrade a no-op.
  *
  * @example
  * ```ts twoslash
@@ -687,13 +677,11 @@ export declare namespace toParts {
   type ErrorType = Errors.GlobalErrorType
 }
 
+// TODO(v1): once `Signature` is a serialized `Hex.Hex` string, encode the
+// parts into that form here instead of returning the input directly.
 /**
  * Converts a {@link ox#Signature.Parts} into a structured
  * {@link ox#Signature.Signature}.
- *
- * @remarks
- * Today this is a structural pass-through. In a future major, `Signature` will
- * be a serialized `Hex.Hex` string and this codec will encode into that form.
  *
  * @example
  * ```ts twoslash

--- a/src/core/Signature.ts
+++ b/src/core/Signature.ts
@@ -31,11 +31,11 @@ export type Signature<
  * @remarks
  * In a future major (`1.0`), {@link ox#Signature.Signature} will be flipped to a
  * serialized {@link ox#Hex.Hex} string and this `Parts` type will represent the
- * structured object form. Today, `SignatureParts<recovered>` is structurally
+ * structured object form. Today, `Parts<recovered>` is structurally
  * equivalent to `Signature<recovered>` -- prefer it in new code so the upgrade
  * path is a no-op.
  */
-export type SignatureParts<recovered extends boolean = true> = Compute<
+export type Parts<recovered extends boolean = true> = Compute<
   recovered extends true
     ? {
         r: bigint
@@ -648,7 +648,7 @@ export declare namespace fromRecoveredBytes {
 
 /**
  * Converts a {@link ox#Signature.Signature} to its structured
- * {@link ox#Signature.SignatureParts} form.
+ * {@link ox#Signature.Parts} form.
  *
  * @remarks
  * Today this is a structural pass-through (the root `Signature` type is already
@@ -669,11 +669,11 @@ export declare namespace fromRecoveredBytes {
  * ```
  *
  * @param signature - The signature to convert.
- * @returns The structured {@link ox#Signature.SignatureParts}.
+ * @returns The structured {@link ox#Signature.Parts}.
  */
 export function toParts<recovered extends boolean = true>(
   signature: Signature<recovered>,
-): SignatureParts<recovered> {
+): Parts<recovered> {
   if (typeof signature.yParity === 'number')
     return {
       r: signature.r,
@@ -688,7 +688,7 @@ export declare namespace toParts {
 }
 
 /**
- * Converts a {@link ox#Signature.SignatureParts} into a structured
+ * Converts a {@link ox#Signature.Parts} into a structured
  * {@link ox#Signature.Signature}.
  *
  * @remarks
@@ -711,7 +711,7 @@ export declare namespace toParts {
  * @returns The {@link ox#Signature.Signature}.
  */
 export function fromParts<recovered extends boolean = true>(
-  parts: SignatureParts<recovered>,
+  parts: Parts<recovered>,
 ): Signature<recovered> {
   if (typeof parts.yParity === 'number')
     return {

--- a/src/core/Signature.ts
+++ b/src/core/Signature.ts
@@ -25,6 +25,30 @@ export type Signature<
       }
 >
 
+/**
+ * Structured parts of an ECDSA signature.
+ *
+ * @remarks
+ * In a future major (`1.0`), {@link ox#Signature.Signature} will be flipped to a
+ * serialized {@link ox#Hex.Hex} string and this `Parts` type will represent the
+ * structured object form. Today, `SignatureParts<recovered>` is structurally
+ * equivalent to `Signature<recovered>` -- prefer it in new code so the upgrade
+ * path is a no-op.
+ */
+export type SignatureParts<recovered extends boolean = true> = Compute<
+  recovered extends true
+    ? {
+        r: bigint
+        s: bigint
+        yParity: number
+      }
+    : {
+        r: bigint
+        s: bigint
+        yParity?: number | undefined
+      }
+>
+
 /** RPC-formatted ECDSA signature. */
 export type Rpc<recovered extends boolean = true> = Signature<
   recovered,
@@ -620,6 +644,86 @@ export function fromRecoveredBytes(bytes: Bytes.Bytes): Signature {
 
 export declare namespace fromRecoveredBytes {
   type ErrorType = Bytes.toBigInt.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Converts a {@link ox#Signature.Signature} to its structured
+ * {@link ox#Signature.SignatureParts} form.
+ *
+ * @remarks
+ * Today this is a structural pass-through (the root `Signature` type is already
+ * the structured object). In a future major, `Signature` will be a serialized
+ * `Hex.Hex` string and this codec will decode into the parts form. Migrating
+ * call sites to `toParts` / `fromParts` now keeps that upgrade a no-op.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Signature } from 'ox'
+ *
+ * const parts = Signature.toParts({
+ *   r: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
+ *   s: 33726695977844476214676913201140481102225469284307016937915595756355928419768n,
+ *   yParity: 1,
+ * })
+ * // @log: { r: 49782...n, s: 33726...n, yParity: 1 }
+ * ```
+ *
+ * @param signature - The signature to convert.
+ * @returns The structured {@link ox#Signature.SignatureParts}.
+ */
+export function toParts<recovered extends boolean = true>(
+  signature: Signature<recovered>,
+): SignatureParts<recovered> {
+  if (typeof signature.yParity === 'number')
+    return {
+      r: signature.r,
+      s: signature.s,
+      yParity: signature.yParity,
+    } as never
+  return { r: signature.r, s: signature.s } as never
+}
+
+export declare namespace toParts {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts a {@link ox#Signature.SignatureParts} into a structured
+ * {@link ox#Signature.Signature}.
+ *
+ * @remarks
+ * Today this is a structural pass-through. In a future major, `Signature` will
+ * be a serialized `Hex.Hex` string and this codec will encode into that form.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Signature } from 'ox'
+ *
+ * const signature = Signature.fromParts({
+ *   r: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
+ *   s: 33726695977844476214676913201140481102225469284307016937915595756355928419768n,
+ *   yParity: 1,
+ * })
+ * // @log: { r: 49782...n, s: 33726...n, yParity: 1 }
+ * ```
+ *
+ * @param parts - The structured parts to convert.
+ * @returns The {@link ox#Signature.Signature}.
+ */
+export function fromParts<recovered extends boolean = true>(
+  parts: SignatureParts<recovered>,
+): Signature<recovered> {
+  if (typeof parts.yParity === 'number')
+    return {
+      r: parts.r,
+      s: parts.s,
+      yParity: parts.yParity,
+    } as never
+  return { r: parts.r, s: parts.s } as never
+}
+
+export declare namespace fromParts {
+  type ErrorType = Errors.GlobalErrorType
 }
 
 /**

--- a/src/core/WebCryptoP256.ts
+++ b/src/core/WebCryptoP256.ts
@@ -2,6 +2,11 @@ import { p256 } from '@noble/curves/nist.js'
 import * as Bytes from './Bytes.js'
 import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
+import {
+  formatSignature,
+  normalizePublicKey,
+  normalizeSignature,
+} from './internal/cryptoIo.js'
 import type { Compute } from './internal/types.js'
 import * as PublicKey from './PublicKey.js'
 import type * as Signature from './Signature.js'
@@ -162,7 +167,7 @@ export async function getSharedSecret<as extends 'Hex' | 'Bytes' = 'Hex'>(
 
   const publicKeyCrypto = await globalThis.crypto.subtle.importKey(
     'raw',
-    PublicKey.toBytes(publicKey),
+    PublicKey.toBytes(normalizePublicKey(publicKey)),
     { name: 'ECDH', namedCurve: 'P-256' },
     false,
     [],
@@ -236,10 +241,10 @@ export declare namespace getSharedSecret {
  * @param options - Options for signing the payload.
  * @returns The P256 ECDSA {@link ox#Signature.Signature} (always low-S normalized).
  */
-export async function sign(
-  options: sign.Options,
-): Promise<Signature.Signature<false>> {
-  const { payload, privateKey } = options
+export async function sign<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'>(
+  options: sign.Options<as>,
+): Promise<sign.ReturnType<as>> {
+  const { as = 'Object', payload, privateKey } = options
   const signature = await globalThis.crypto.subtle.sign(
     {
       name: 'ECDSA',
@@ -252,16 +257,26 @@ export async function sign(
   const r = Bytes.toBigInt(Bytes.slice(signature_bytes, 0, 32))
   let s = Bytes.toBigInt(Bytes.slice(signature_bytes, 32, 64))
   if (s > N / 2n) s = N - s
-  return { r, s }
+  return formatSignature({ r, s }, as) as never
 }
 
 export declare namespace sign {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' | 'Object' = 'Object'> = {
+    /**
+     * Format of the returned signature.
+     * @default 'Object'
+     */
+    as?: as | 'Hex' | 'Bytes' | 'Object' | undefined
     /** Payload to sign. */
     payload: Hex.Hex | Bytes.Bytes
     /** ECDSA private key. */
     privateKey: CryptoKey
   }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' | 'Object'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'Object' ? Signature.Signature<false> : never)
 
   type ErrorType = Bytes.fromArray.ErrorType | Errors.GlobalErrorType
 }
@@ -289,14 +304,15 @@ export declare namespace sign {
  * @returns Whether the payload was signed by the provided public key.
  */
 export async function verify(options: verify.Options): Promise<boolean> {
-  const { lowS = true, payload, signature } = options
+  const { lowS = true, payload } = options
+  const signature = normalizeSignature<false>(options.signature)
 
   // Reject high-S signatures if lowS is enabled.
   if (lowS && signature.s > N / 2n) return false
 
   const publicKey = await globalThis.crypto.subtle.importKey(
     'raw',
-    PublicKey.toBytes(options.publicKey),
+    PublicKey.toBytes(normalizePublicKey(options.publicKey)),
     { name: 'ECDSA', namedCurve: 'P-256' },
     true,
     ['verify'],
@@ -320,10 +336,20 @@ export declare namespace verify {
   type Options = {
     /** If set to `true`, only low-S signatures will be accepted. @default true */
     lowS?: boolean | undefined
-    /** Public key that signed the payload. */
-    publicKey: PublicKey.PublicKey<boolean>
-    /** Signature of the payload. */
-    signature: Signature.Signature<false>
+    /**
+     * Public key that signed the payload.
+     *
+     * Accepts a structured {@link ox#PublicKey.PublicKey}, a serialized hex
+     * string, or a `Uint8Array` (SEC1 encoding).
+     */
+    publicKey: Hex.Hex | Bytes.Bytes | PublicKey.PublicKey<boolean>
+    /**
+     * Signature of the payload.
+     *
+     * Accepts a structured {@link ox#Signature.Signature}, a serialized hex
+     * string, or a `Uint8Array`.
+     */
+    signature: Hex.Hex | Bytes.Bytes | Signature.Signature<false>
     /** Payload that was signed. */
     payload: Hex.Hex | Bytes.Bytes
   }

--- a/src/core/_test/Bls.test.ts
+++ b/src/core/_test/Bls.test.ts
@@ -253,3 +253,98 @@ describe('verify', () => {
     expect(verified).toBe(true)
   })
 })
+
+describe('as option / serialized inputs', () => {
+  const privateKey =
+    '0x527f85c60ed7402247da21f1835cea651d0954fc15b7288f096d3608400cb6ac'
+
+  test("getPublicKey: as 'Hex' returns hex string", () => {
+    const pkHex = Bls.getPublicKey({ privateKey, as: 'Hex' })
+    expect(typeof pkHex).toBe('string')
+    expect((pkHex as Hex.Hex).startsWith('0x')).toBe(true)
+  })
+
+  test("getPublicKey: as 'Bytes' returns Uint8Array", () => {
+    const pkBytes = Bls.getPublicKey({ privateKey, as: 'Bytes' })
+    expect(pkBytes).toBeInstanceOf(Uint8Array)
+  })
+
+  test('getPublicKey default as remains Object', () => {
+    const pk = Bls.getPublicKey({ privateKey })
+    expect(typeof pk).toBe('object')
+    expect('z' in pk).toBe(true)
+  })
+
+  test("sign: as 'Hex' returns hex string", () => {
+    const sigHex = Bls.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    expect(typeof sigHex).toBe('string')
+  })
+
+  test("sign: as 'Bytes' returns Uint8Array", () => {
+    const sigBytes = Bls.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Bytes',
+    })
+    expect(sigBytes).toBeInstanceOf(Uint8Array)
+  })
+
+  test('verify accepts Hex publicKey + Hex signature', () => {
+    const pkHex = Bls.getPublicKey({ privateKey, as: 'Hex' })
+    const sigHex = Bls.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    expect(
+      Bls.verify({
+        payload: '0xdeadbeef',
+        publicKey: pkHex,
+        signature: sigHex,
+      }),
+    ).toBe(true)
+  })
+
+  test('verify accepts Bytes publicKey + Bytes signature', () => {
+    const pkBytes = Bls.getPublicKey({ privateKey, as: 'Bytes' })
+    const sigBytes = Bls.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Bytes',
+    })
+    expect(
+      Bls.verify({
+        payload: '0xdeadbeef',
+        publicKey: pkBytes,
+        signature: sigBytes,
+      }),
+    ).toBe(true)
+  })
+
+  test('aggregate accepts hex inputs with group hint', () => {
+    const a = Bls.getPublicKey({ privateKey, as: 'Hex' })
+    const b = Bls.getPublicKey({
+      privateKey:
+        '0x68f9b6c6e0a1f9e7a02e5a6eaae8aa5c4b6b9e1a8f5d8c7b6a5f4e3d2c1b0a9f',
+      as: 'Hex',
+    })
+    const aggregated = Bls.aggregate([a, b], { group: 'G1' })
+    // Should match aggregating from structured inputs.
+    const aObj = Bls.getPublicKey({ privateKey })
+    const bObj = Bls.getPublicKey({
+      privateKey:
+        '0x68f9b6c6e0a1f9e7a02e5a6eaae8aa5c4b6b9e1a8f5d8c7b6a5f4e3d2c1b0a9f',
+    })
+    const aggregatedObj = Bls.aggregate([aObj, bObj])
+    expect(aggregated).toEqual(aggregatedObj)
+  })
+
+  test('aggregate throws if serialized inputs without group hint', () => {
+    const a = Bls.getPublicKey({ privateKey, as: 'Hex' })
+    expect(() => Bls.aggregate([a])).toThrow()
+  })
+})

--- a/src/core/_test/BlsPoint.parts.test-d.ts
+++ b/src/core/_test/BlsPoint.parts.test-d.ts
@@ -1,0 +1,30 @@
+import type { BlsPoint } from 'ox'
+import { expectTypeOf, test } from 'vitest'
+
+test('G1Parts matches G1 structurally', () => {
+  expectTypeOf<BlsPoint.G1Parts>().toEqualTypeOf<BlsPoint.G1>()
+})
+
+test('G2Parts matches G2 structurally', () => {
+  expectTypeOf<BlsPoint.G2Parts>().toEqualTypeOf<BlsPoint.G2>()
+})
+
+test('toParts narrows G1 to G1Parts', () => {
+  type Result = ReturnType<typeof BlsPoint.toParts<BlsPoint.G1>>
+  expectTypeOf<Result>().toEqualTypeOf<BlsPoint.G1Parts>()
+})
+
+test('toParts narrows G2 to G2Parts', () => {
+  type Result = ReturnType<typeof BlsPoint.toParts<BlsPoint.G2>>
+  expectTypeOf<Result>().toEqualTypeOf<BlsPoint.G2Parts>()
+})
+
+test("fromParts(parts, 'G1') returns G1", () => {
+  type Result = ReturnType<typeof BlsPoint.fromParts<'G1'>>
+  expectTypeOf<Result>().toEqualTypeOf<BlsPoint.G1>()
+})
+
+test("fromParts(parts, 'G2') returns G2", () => {
+  type Result = ReturnType<typeof BlsPoint.fromParts<'G2'>>
+  expectTypeOf<Result>().toEqualTypeOf<BlsPoint.G2>()
+})

--- a/src/core/_test/BlsPoint.test.ts
+++ b/src/core/_test/BlsPoint.test.ts
@@ -249,3 +249,53 @@ describe('toBytes', () => {
     )
   })
 })
+
+describe('BlsPoint.toParts', () => {
+  test('default: G1 public key', () => {
+    const publicKey = Bls.getPublicKey({ privateKey })
+    const parts = BlsPoint.toParts(publicKey)
+    expect(parts).toEqual({
+      x: publicKey.x,
+      y: publicKey.y,
+      z: publicKey.z,
+    })
+  })
+
+  test('default: G2 signature', () => {
+    const signature = Bls.sign({ payload: '0xdeadbeef', privateKey })
+    const parts = BlsPoint.toParts(signature)
+    expect(parts).toEqual({
+      x: signature.x,
+      y: signature.y,
+      z: signature.z,
+    })
+  })
+
+  test('behavior: returns a fresh object (no aliasing)', () => {
+    const publicKey = Bls.getPublicKey({ privateKey })
+    const parts = BlsPoint.toParts(publicKey)
+    expect(parts).not.toBe(publicKey)
+  })
+})
+
+describe('BlsPoint.fromParts', () => {
+  test('default: G1', () => {
+    const publicKey = Bls.getPublicKey({ privateKey })
+    const parts = BlsPoint.toParts(publicKey)
+    const reconstructed = BlsPoint.fromParts(parts, 'G1')
+    expect(reconstructed).toEqual(publicKey)
+  })
+
+  test('default: G2', () => {
+    const signature = Bls.sign({ payload: '0xdeadbeef', privateKey })
+    const parts = BlsPoint.toParts(signature)
+    const reconstructed = BlsPoint.fromParts(parts, 'G2')
+    expect(reconstructed).toEqual(signature)
+  })
+
+  test('behavior: roundtrip via bytes still matches', () => {
+    const publicKey = Bls.getPublicKey({ privateKey })
+    const reconstructed = BlsPoint.fromParts(BlsPoint.toParts(publicKey), 'G1')
+    expect(BlsPoint.toBytes(reconstructed)).toEqual(BlsPoint.toBytes(publicKey))
+  })
+})

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -551,3 +551,58 @@ test('exports', () => {
     ]
   `)
 })
+
+describe('as option', () => {
+  test("sign + getPublicKey + recoverPublicKey: as 'Hex'", () => {
+    const { privateKey, publicKey } = P256.createKeyPair()
+    const sigHex = P256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    expect(typeof sigHex).toBe('string')
+
+    const pkHex = P256.getPublicKey({ privateKey, as: 'Hex' })
+    expect(typeof pkHex).toBe('string')
+
+    const recoveredHex = P256.recoverPublicKey({
+      payload: '0xdeadbeef',
+      signature: sigHex,
+      as: 'Hex',
+    })
+    expect(recoveredHex).toBe(pkHex)
+    expect(
+      P256.verify({ payload: '0xdeadbeef', publicKey, signature: sigHex }),
+    ).toBe(true)
+  })
+
+  test("sign + getPublicKey: as 'Bytes'", () => {
+    const { privateKey } = P256.createKeyPair()
+    const sigBytes = P256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Bytes',
+    })
+    expect(sigBytes).toBeInstanceOf(Uint8Array)
+
+    const pkBytes = P256.getPublicKey({ privateKey, as: 'Bytes' })
+    expect(pkBytes).toBeInstanceOf(Uint8Array)
+  })
+
+  test('verify accepts Hex signature + Hex publicKey', () => {
+    const { privateKey } = P256.createKeyPair()
+    const pkHex = P256.getPublicKey({ privateKey, as: 'Hex' })
+    const sigHex = P256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    expect(
+      P256.verify({
+        payload: '0xdeadbeef',
+        publicKey: pkHex,
+        signature: sigHex,
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/core/_test/PublicKey.test-d.ts
+++ b/src/core/_test/PublicKey.test-d.ts
@@ -1,6 +1,6 @@
 import { attest } from '@ark/attest'
 import { PublicKey } from 'ox'
-import { describe, test } from 'vitest'
+import { describe, expectTypeOf, test } from 'vitest'
 
 describe('PublicKey.from', () => {
   test('default', () => {
@@ -48,5 +48,35 @@ describe('PublicKey.from', () => {
     } as PublicKey.PublicKey<true>)
 
     attest(publicKey).type.toString.snap()
+  })
+})
+
+describe('PublicKeyParts type-equivalence', () => {
+  test('PublicKeyParts<false> matches PublicKey<false> structurally', () => {
+    expectTypeOf<PublicKey.PublicKeyParts<false>>().toEqualTypeOf<
+      PublicKey.PublicKey<false>
+    >()
+  })
+
+  test('PublicKeyParts<true> matches PublicKey<true> structurally', () => {
+    expectTypeOf<PublicKey.PublicKeyParts<true>>().toEqualTypeOf<
+      PublicKey.PublicKey<true>
+    >()
+  })
+
+  test('default PublicKeyParts matches default PublicKey', () => {
+    expectTypeOf<PublicKey.PublicKeyParts>().toEqualTypeOf<PublicKey.PublicKey>()
+  })
+
+  test('toParts return is PublicKeyParts', () => {
+    type Result = ReturnType<typeof PublicKey.toParts<false>>
+    expectTypeOf<Result>().toEqualTypeOf<PublicKey.PublicKeyParts<false>>()
+  })
+
+  test('fromParts accepts PublicKeyParts and returns PublicKey', () => {
+    type Param = Parameters<typeof PublicKey.fromParts<false>>[0]
+    type Result = ReturnType<typeof PublicKey.fromParts<false>>
+    expectTypeOf<Param>().toEqualTypeOf<PublicKey.PublicKeyParts<false>>()
+    expectTypeOf<Result>().toEqualTypeOf<PublicKey.PublicKey<false>>()
   })
 })

--- a/src/core/_test/PublicKey.test-d.ts
+++ b/src/core/_test/PublicKey.test-d.ts
@@ -51,32 +51,32 @@ describe('PublicKey.from', () => {
   })
 })
 
-describe('PublicKeyParts type-equivalence', () => {
-  test('PublicKeyParts<false> matches PublicKey<false> structurally', () => {
-    expectTypeOf<PublicKey.PublicKeyParts<false>>().toEqualTypeOf<
+describe('Parts type-equivalence', () => {
+  test('Parts<false> matches PublicKey<false> structurally', () => {
+    expectTypeOf<PublicKey.Parts<false>>().toEqualTypeOf<
       PublicKey.PublicKey<false>
     >()
   })
 
-  test('PublicKeyParts<true> matches PublicKey<true> structurally', () => {
-    expectTypeOf<PublicKey.PublicKeyParts<true>>().toEqualTypeOf<
+  test('Parts<true> matches PublicKey<true> structurally', () => {
+    expectTypeOf<PublicKey.Parts<true>>().toEqualTypeOf<
       PublicKey.PublicKey<true>
     >()
   })
 
-  test('default PublicKeyParts matches default PublicKey', () => {
-    expectTypeOf<PublicKey.PublicKeyParts>().toEqualTypeOf<PublicKey.PublicKey>()
+  test('default Parts matches default PublicKey', () => {
+    expectTypeOf<PublicKey.Parts>().toEqualTypeOf<PublicKey.PublicKey>()
   })
 
-  test('toParts return is PublicKeyParts', () => {
+  test('toParts return is Parts', () => {
     type Result = ReturnType<typeof PublicKey.toParts<false>>
-    expectTypeOf<Result>().toEqualTypeOf<PublicKey.PublicKeyParts<false>>()
+    expectTypeOf<Result>().toEqualTypeOf<PublicKey.Parts<false>>()
   })
 
-  test('fromParts accepts PublicKeyParts and returns PublicKey', () => {
+  test('fromParts accepts Parts and returns PublicKey', () => {
     type Param = Parameters<typeof PublicKey.fromParts<false>>[0]
     type Result = ReturnType<typeof PublicKey.fromParts<false>>
-    expectTypeOf<Param>().toEqualTypeOf<PublicKey.PublicKeyParts<false>>()
+    expectTypeOf<Param>().toEqualTypeOf<PublicKey.Parts<false>>()
     expectTypeOf<Result>().toEqualTypeOf<PublicKey.PublicKey<false>>()
   })
 })

--- a/src/core/_test/PublicKey.test.ts
+++ b/src/core/_test/PublicKey.test.ts
@@ -10,6 +10,8 @@ test('exports', () => {
       "fromBytes",
       "fromHex",
       "toBytes",
+      "toParts",
+      "fromParts",
       "toHex",
       "validate",
       "InvalidError",
@@ -534,5 +536,78 @@ describe('PublicKey.validate', () => {
         y: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
       }),
     ).toBe(false)
+  })
+})
+
+describe('PublicKey.toParts', () => {
+  test('default', () => {
+    const parts = PublicKey.toParts({
+      prefix: 4,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+      y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+    })
+    expect(parts).toEqual({
+      prefix: 4,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+      y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+    })
+  })
+
+  test('behavior: compressed', () => {
+    const parts = PublicKey.toParts<true>({
+      prefix: 3,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+    })
+    expect(parts).toEqual({
+      prefix: 3,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+    })
+    expect('y' in parts).toBe(false)
+  })
+
+  test('behavior: returns a fresh object (no aliasing)', () => {
+    const pk = {
+      prefix: 4,
+      x: 1n,
+      y: 2n,
+    }
+    const parts = PublicKey.toParts(pk)
+    expect(parts).not.toBe(pk)
+  })
+})
+
+describe('PublicKey.fromParts', () => {
+  test('default', () => {
+    const publicKey = PublicKey.fromParts({
+      prefix: 4,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+      y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+    })
+    expect(publicKey).toEqual({
+      prefix: 4,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+      y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+    })
+  })
+
+  test('behavior: compressed', () => {
+    const publicKey = PublicKey.fromParts<true>({
+      prefix: 2,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+    })
+    expect(publicKey).toEqual({
+      prefix: 2,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+    })
+    expect('y' in publicKey).toBe(false)
+  })
+
+  test('behavior: roundtrip', () => {
+    const original = {
+      prefix: 4,
+      x: 59295962801117472859457908919941473389380284132224861839820747729565200149877n,
+      y: 24099691209996290925259367678540227198235484593389470330605641003500238088869n,
+    }
+    expect(PublicKey.fromParts(PublicKey.toParts(original))).toEqual(original)
   })
 })

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -493,3 +493,119 @@ test('exports', () => {
     ]
   `)
 })
+
+describe('as option', () => {
+  test("sign + recoverPublicKey + getPublicKey: as 'Hex'", () => {
+    const privateKey = accounts[0].privateKey
+    const sigHex = Secp256k1.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    expect(typeof sigHex).toBe('string')
+    expect((sigHex as Hex.Hex).startsWith('0x')).toBe(true)
+
+    const pkHex = Secp256k1.getPublicKey({ privateKey, as: 'Hex' })
+    expect(typeof pkHex).toBe('string')
+
+    const recoveredHex = Secp256k1.recoverPublicKey({
+      payload: '0xdeadbeef',
+      signature: sigHex,
+      as: 'Hex',
+    })
+    expect(recoveredHex).toBe(pkHex)
+  })
+
+  test("sign + recoverPublicKey + getPublicKey: as 'Bytes'", () => {
+    const privateKey = accounts[0].privateKey
+    const sigBytes = Secp256k1.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Bytes',
+    })
+    expect(sigBytes).toBeInstanceOf(Uint8Array)
+
+    const pkBytes = Secp256k1.getPublicKey({ privateKey, as: 'Bytes' })
+    expect(pkBytes).toBeInstanceOf(Uint8Array)
+
+    const recoveredBytes = Secp256k1.recoverPublicKey({
+      payload: '0xdeadbeef',
+      signature: sigBytes,
+      as: 'Bytes',
+    })
+    expect(recoveredBytes).toEqual(pkBytes)
+  })
+
+  test('default as remains Object (no behavior regression)', () => {
+    const sigObj = Secp256k1.sign({
+      payload: '0xdeadbeef',
+      privateKey: accounts[0].privateKey,
+    })
+    expect(typeof sigObj).toBe('object')
+    expect('r' in (sigObj as object)).toBe(true)
+  })
+
+  test('verify accepts Hex signature + Hex publicKey', () => {
+    const privateKey = accounts[0].privateKey
+    const sigHex = Secp256k1.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    const pkHex = Secp256k1.getPublicKey({ privateKey, as: 'Hex' })
+    expect(
+      Secp256k1.verify({
+        payload: '0xdeadbeef',
+        publicKey: pkHex,
+        signature: sigHex,
+      }),
+    ).toBe(true)
+  })
+
+  test('verify accepts Bytes signature + Bytes publicKey', () => {
+    const privateKey = accounts[0].privateKey
+    const sigBytes = Secp256k1.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Bytes',
+    })
+    const pkBytes = Secp256k1.getPublicKey({ privateKey, as: 'Bytes' })
+    expect(
+      Secp256k1.verify({
+        payload: '0xdeadbeef',
+        publicKey: pkBytes,
+        signature: sigBytes,
+      }),
+    ).toBe(true)
+  })
+
+  test('recoverAddress accepts Hex signature', () => {
+    const privateKey = accounts[0].privateKey
+    const sigHex = Secp256k1.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    expect(
+      Secp256k1.recoverAddress({
+        payload: '0xdeadbeef',
+        signature: sigHex,
+      }),
+    ).toBe(Address.fromPublicKey(Secp256k1.getPublicKey({ privateKey })))
+  })
+
+  test('getSharedSecret accepts Hex publicKey', () => {
+    const a = Secp256k1.createKeyPair()
+    const b = Secp256k1.createKeyPair()
+    const bPubHex = PublicKey.toHex(b.publicKey)
+    const ss1 = Secp256k1.getSharedSecret({
+      privateKey: a.privateKey,
+      publicKey: bPubHex,
+    })
+    const ss2 = Secp256k1.getSharedSecret({
+      privateKey: a.privateKey,
+      publicKey: b.publicKey,
+    })
+    expect(ss1).toBe(ss2)
+  })
+})

--- a/src/core/_test/Signature.parts.test-d.ts
+++ b/src/core/_test/Signature.parts.test-d.ts
@@ -1,30 +1,30 @@
 import type { Signature } from 'ox'
 import { expectTypeOf, test } from 'vitest'
 
-test('SignatureParts<true> matches Signature<true> structurally', () => {
-  expectTypeOf<Signature.SignatureParts<true>>().toEqualTypeOf<
+test('Parts<true> matches Signature<true> structurally', () => {
+  expectTypeOf<Signature.Parts<true>>().toEqualTypeOf<
     Signature.Signature<true>
   >()
 })
 
-test('SignatureParts<false> matches Signature<false> structurally', () => {
-  expectTypeOf<Signature.SignatureParts<false>>().toEqualTypeOf<
+test('Parts<false> matches Signature<false> structurally', () => {
+  expectTypeOf<Signature.Parts<false>>().toEqualTypeOf<
     Signature.Signature<false>
   >()
 })
 
-test('SignatureParts default matches Signature default', () => {
-  expectTypeOf<Signature.SignatureParts>().toEqualTypeOf<Signature.Signature>()
+test('Parts default matches Signature default', () => {
+  expectTypeOf<Signature.Parts>().toEqualTypeOf<Signature.Signature>()
 })
 
-test('toParts return is SignatureParts', () => {
+test('toParts return is Parts', () => {
   type Result = ReturnType<typeof Signature.toParts<true>>
-  expectTypeOf<Result>().toEqualTypeOf<Signature.SignatureParts<true>>()
+  expectTypeOf<Result>().toEqualTypeOf<Signature.Parts<true>>()
 })
 
-test('fromParts accepts SignatureParts and returns Signature', () => {
+test('fromParts accepts Parts and returns Signature', () => {
   type Param = Parameters<typeof Signature.fromParts<true>>[0]
   type Result = ReturnType<typeof Signature.fromParts<true>>
-  expectTypeOf<Param>().toEqualTypeOf<Signature.SignatureParts<true>>()
+  expectTypeOf<Param>().toEqualTypeOf<Signature.Parts<true>>()
   expectTypeOf<Result>().toEqualTypeOf<Signature.Signature<true>>()
 })

--- a/src/core/_test/Signature.parts.test-d.ts
+++ b/src/core/_test/Signature.parts.test-d.ts
@@ -1,0 +1,30 @@
+import type { Signature } from 'ox'
+import { expectTypeOf, test } from 'vitest'
+
+test('SignatureParts<true> matches Signature<true> structurally', () => {
+  expectTypeOf<Signature.SignatureParts<true>>().toEqualTypeOf<
+    Signature.Signature<true>
+  >()
+})
+
+test('SignatureParts<false> matches Signature<false> structurally', () => {
+  expectTypeOf<Signature.SignatureParts<false>>().toEqualTypeOf<
+    Signature.Signature<false>
+  >()
+})
+
+test('SignatureParts default matches Signature default', () => {
+  expectTypeOf<Signature.SignatureParts>().toEqualTypeOf<Signature.Signature>()
+})
+
+test('toParts return is SignatureParts', () => {
+  type Result = ReturnType<typeof Signature.toParts<true>>
+  expectTypeOf<Result>().toEqualTypeOf<Signature.SignatureParts<true>>()
+})
+
+test('fromParts accepts SignatureParts and returns Signature', () => {
+  type Param = Parameters<typeof Signature.fromParts<true>>[0]
+  type Result = ReturnType<typeof Signature.fromParts<true>>
+  expectTypeOf<Param>().toEqualTypeOf<Signature.SignatureParts<true>>()
+  expectTypeOf<Result>().toEqualTypeOf<Signature.Signature<true>>()
+})

--- a/src/core/_test/Signature.test.ts
+++ b/src/core/_test/Signature.test.ts
@@ -786,6 +786,70 @@ describe('yParityToV', () => {
   })
 })
 
+describe('Signature.toParts', () => {
+  test('default', () => {
+    const parts = Signature.toParts({
+      r: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
+      s: 33726695977844476214676913201140481102225469284307016937915595756355928419768n,
+      yParity: 1,
+    })
+    expect(parts).toEqual({
+      r: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
+      s: 33726695977844476214676913201140481102225469284307016937915595756355928419768n,
+      yParity: 1,
+    })
+  })
+
+  test('behavior: unrecovered', () => {
+    const parts = Signature.toParts<false>({
+      r: 1n,
+      s: 2n,
+    })
+    expect(parts).toEqual({ r: 1n, s: 2n })
+    expect('yParity' in parts).toBe(false)
+  })
+
+  test('behavior: returns a fresh object (no aliasing)', () => {
+    const sig = {
+      r: 1n,
+      s: 2n,
+      yParity: 0 as const,
+    }
+    const parts = Signature.toParts(sig)
+    expect(parts).not.toBe(sig)
+  })
+})
+
+describe('Signature.fromParts', () => {
+  test('default', () => {
+    const signature = Signature.fromParts({
+      r: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
+      s: 33726695977844476214676913201140481102225469284307016937915595756355928419768n,
+      yParity: 1,
+    })
+    expect(signature).toEqual({
+      r: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
+      s: 33726695977844476214676913201140481102225469284307016937915595756355928419768n,
+      yParity: 1,
+    })
+  })
+
+  test('behavior: unrecovered', () => {
+    const signature = Signature.fromParts<false>({ r: 1n, s: 2n })
+    expect(signature).toEqual({ r: 1n, s: 2n })
+    expect('yParity' in signature).toBe(false)
+  })
+
+  test('behavior: roundtrip', () => {
+    const original = {
+      r: 49782753348462494199823712700004552394425719014458918871452329774910450607807n,
+      s: 33726695977844476214676913201140481102225469284307016937915595756355928419768n,
+      yParity: 1 as const,
+    }
+    expect(Signature.fromParts(Signature.toParts(original))).toEqual(original)
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(Signature)).toMatchInlineSnapshot(`
     [
@@ -804,6 +868,8 @@ test('exports', () => {
       "fromCompactBytes",
       "toRecoveredBytes",
       "fromRecoveredBytes",
+      "toParts",
+      "fromParts",
       "toHex",
       "toDerBytes",
       "toDerHex",

--- a/src/core/_test/WebCryptoP256.test.ts
+++ b/src/core/_test/WebCryptoP256.test.ts
@@ -223,3 +223,53 @@ test('exports', () => {
     ]
   `)
 })
+
+describe('as option / serialized inputs', () => {
+  test("sign: as 'Hex' returns hex string", async () => {
+    const { privateKey } = await WebCryptoP256.createKeyPair()
+    const sigHex = await WebCryptoP256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    expect(typeof sigHex).toBe('string')
+    expect((sigHex as Hex.Hex).startsWith('0x')).toBe(true)
+  })
+
+  test("sign: as 'Bytes' returns Uint8Array", async () => {
+    const { privateKey } = await WebCryptoP256.createKeyPair()
+    const sigBytes = await WebCryptoP256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Bytes',
+    })
+    expect(sigBytes).toBeInstanceOf(Uint8Array)
+  })
+
+  test('default as remains Object', async () => {
+    const { privateKey } = await WebCryptoP256.createKeyPair()
+    const sig = await WebCryptoP256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+    })
+    expect(typeof sig).toBe('object')
+    expect('r' in sig).toBe(true)
+  })
+
+  test('verify accepts Hex publicKey + Hex signature', async () => {
+    const { privateKey, publicKey } = await WebCryptoP256.createKeyPair()
+    const sigHex = await WebCryptoP256.sign({
+      payload: '0xdeadbeef',
+      privateKey,
+      as: 'Hex',
+    })
+    const pkHex = PublicKey.toHex(publicKey)
+    expect(
+      await WebCryptoP256.verify({
+        payload: '0xdeadbeef',
+        publicKey: pkHex,
+        signature: sigHex,
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/core/internal/cryptoIo.ts
+++ b/src/core/internal/cryptoIo.ts
@@ -1,0 +1,74 @@
+import type * as Bytes from '../Bytes.js'
+import type * as Hex from '../Hex.js'
+import * as PublicKey from '../PublicKey.js'
+import * as Signature from '../Signature.js'
+
+/**
+ * Coerces a serialized or structured signature input into a structured
+ * {@link ox#Signature.Signature} object.
+ *
+ * Accepts the existing structured form (pass-through), a hex string, or a
+ * `Uint8Array` (delegates to `Signature.fromHex` / `Signature.fromBytes`).
+ *
+ * @internal
+ */
+export function normalizeSignature<recovered extends boolean = boolean>(
+  value:
+    | Hex.Hex
+    | Bytes.Bytes
+    | Signature.Signature<recovered>
+    | Signature.Signature<boolean>,
+): Signature.Signature<recovered> {
+  if (typeof value === 'string')
+    return Signature.fromHex(value) as Signature.Signature<recovered>
+  if (value instanceof Uint8Array)
+    return Signature.fromBytes(value) as Signature.Signature<recovered>
+  return value as Signature.Signature<recovered>
+}
+
+/**
+ * Coerces a serialized or structured public key input into a structured
+ * {@link ox#PublicKey.PublicKey}.
+ *
+ * @internal
+ */
+export function normalizePublicKey<compressed extends boolean = boolean>(
+  value: Hex.Hex | Bytes.Bytes | PublicKey.PublicKey<compressed>,
+): PublicKey.PublicKey<compressed> {
+  if (typeof value === 'string')
+    return PublicKey.fromHex(value) as PublicKey.PublicKey<compressed>
+  if (value instanceof Uint8Array)
+    return PublicKey.fromBytes(value) as PublicKey.PublicKey<compressed>
+  return value
+}
+
+/**
+ * Formats a structured {@link ox#Signature.Signature} as the requested
+ * representation: the structured object (`'Object'`), serialized hex
+ * (`'Hex'`), or serialized bytes (`'Bytes'`).
+ *
+ * @internal
+ */
+export function formatSignature(
+  signature: Signature.Signature<boolean>,
+  as: 'Hex' | 'Bytes' | 'Object',
+): unknown {
+  if (as === 'Hex') return Signature.toHex(signature)
+  if (as === 'Bytes') return Signature.toBytes(signature)
+  return signature
+}
+
+/**
+ * Formats a structured {@link ox#PublicKey.PublicKey} as the requested
+ * representation.
+ *
+ * @internal
+ */
+export function formatPublicKey(
+  publicKey: PublicKey.PublicKey<boolean>,
+  as: 'Hex' | 'Bytes' | 'Object',
+): unknown {
+  if (as === 'Hex') return PublicKey.toHex(publicKey)
+  if (as === 'Bytes') return PublicKey.toBytes(publicKey)
+  return publicKey
+}


### PR DESCRIPTION
Foundational signature/public-key part codecs and serialized-input acceptance for the crypto modules.

Highlights:

- Adds `Signature.Parts`, `PublicKey.Parts`, and `BlsPoint.G1Parts` / `G2Parts` types with matching `toParts` / `fromParts` codecs.
- Adds `as: 'Hex' | 'Bytes' | 'Object'` option to `Secp256k1.sign` / `getPublicKey` / `recoverPublicKey`, `P256.sign` / `getPublicKey` / `recoverPublicKey`, `WebCryptoP256.sign`, and `Bls.sign` / `getPublicKey`. Default `'Object'` keeps existing behavior.
- `verify` / `recoverAddress` / `recoverPublicKey` / `getSharedSecret` across the same modules now accept `Hex.Hex | Bytes.Bytes | Signature.Signature` for `signature` and `Hex.Hex | Bytes.Bytes | PublicKey.PublicKey` for `publicKey`.
