### PR TITLE
feat(v1): `RpcRequest.build` / `RpcResponse` helpers, HTTP retry hooks, and `Provider.discover` / `announce`

### DIFF
--- a/.changeset/rpc-phase-2-transport-discovery.md
+++ b/.changeset/rpc-phase-2-transport-discovery.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added optional HTTP retry hooks (`retryCount`, `retryDelay`, `shouldRetry`) and `requestRaw` / `batch` helpers to `RpcTransport.fromHttp`, plus EIP-6963 `Provider.discover` / `Provider.announce` and a sibling `ProviderEvents` module that re-exports `createEmitter` for request-only consumers.

--- a/.changeset/rpc-phase-3-explicit-helpers.md
+++ b/.changeset/rpc-phase-3-explicit-helpers.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `RpcRequest.build`, `RpcResponse.envelope`, `RpcResponse.parseResult`, and `RpcResponse.parseEnvelope` as explicit-name companions to the broader `from` / `parse` helpers, plus schema-first generic overloads for `Provider.from<MySchema>(provider)` and `RpcTransport.fromHttp<MySchema>(url)`; `RpcSchema.from()` and the broad `from` / `parse` aliases are now `@deprecated` in JSDoc but continue to work as compatibility wrappers.

--- a/package.json
+++ b/package.json
@@ -406,6 +406,11 @@
       "src": "./src/core/Provider.ts",
       "default": "./dist/core/Provider.js"
     },
+    "./ProviderEvents": {
+      "types": "./dist/core/ProviderEvents.d.ts",
+      "src": "./src/core/ProviderEvents.ts",
+      "default": "./dist/core/ProviderEvents.js"
+    },
     "./PublicKey": {
       "types": "./dist/core/PublicKey.d.ts",
       "src": "./src/core/PublicKey.ts",

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -676,3 +676,159 @@ export class IsUndefinedError extends Errors.BaseError {
     super('`provider` is undefined.')
   }
 }
+
+/**
+ * [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected provider info.
+ */
+export type EIP6963ProviderInfo = {
+  /** Globally unique identifier for the provider session. */
+  uuid: string
+  /** Human-readable name of the wallet. */
+  name: string
+  /** Data URI (or HTTP URL) of the wallet icon. */
+  icon: string
+  /** Reverse-DNS identifier of the wallet (e.g. `io.metamask`). */
+  rdns: string
+}
+
+/**
+ * [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected provider detail
+ * yielded by {@link ox#Provider.(discover:function)} and accepted by
+ * {@link ox#Provider.(announce:function)}.
+ */
+export type EIP6963ProviderDetail<
+  schema extends RpcSchema.Generic = RpcSchema.Default,
+> = {
+  info: EIP6963ProviderInfo
+  provider: Provider<{ schema: schema }>
+}
+
+/**
+ * `eip6963:announceProvider` event payload -- dispatched by wallets to advertise their
+ * EIP-1193 Provider.
+ */
+export type EIP6963AnnounceProviderEvent<
+  schema extends RpcSchema.Generic = RpcSchema.Default,
+> = CustomEvent<EIP6963ProviderDetail<schema>> & {
+  type: 'eip6963:announceProvider'
+}
+
+/**
+ * `eip6963:requestProvider` event -- dispatched by dapps to request that wallets re-announce
+ * themselves via `eip6963:announceProvider`.
+ */
+export type EIP6963RequestProviderEvent = Event & {
+  type: 'eip6963:requestProvider'
+}
+
+/**
+ * Announces an [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected provider.
+ *
+ * Dispatches an `eip6963:announceProvider` `CustomEvent` on `window`. Wallets typically call
+ * this immediately after they inject themselves and again whenever they receive an
+ * `eip6963:requestProvider` event from a dapp.
+ *
+ * Browser-only: throws if called in a non-browser environment.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import 'ox/window'
+ * import { Provider } from 'ox'
+ *
+ * Provider.announce({
+ *   info: {
+ *     uuid: '350670db-19fa-4704-a166-e52e178b59d2',
+ *     name: 'Example Wallet',
+ *     icon: 'data:image/svg+xml;base64,...',
+ *     rdns: 'sh.oxlib.example',
+ *   },
+ *   provider: window.ethereum!,
+ * })
+ * ```
+ *
+ * @param detail - Provider detail to announce.
+ */
+export function announce<schema extends RpcSchema.Generic = RpcSchema.Default>(
+  detail: EIP6963ProviderDetail<schema>,
+): void {
+  if (typeof window === 'undefined') throw new IsUndefinedError()
+  window.dispatchEvent(
+    new CustomEvent('eip6963:announceProvider', {
+      detail: Object.freeze(detail),
+    }),
+  )
+}
+
+export declare namespace announce {
+  type ErrorType = IsUndefinedError | Errors.GlobalErrorType
+}
+
+/**
+ * Discovers [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) injected providers.
+ *
+ * Subscribes to `eip6963:announceProvider` events on `window` and dispatches
+ * `eip6963:requestProvider` so already-injected wallets re-announce themselves. Returns a handle
+ * with an `unsubscribe` function. Each unique announcement (deduped by `uuid`) is delivered to the
+ * supplied callback.
+ *
+ * Browser-only: throws if called in a non-browser environment.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import 'ox/window'
+ * import { Provider } from 'ox'
+ *
+ * const handle = Provider.discover({
+ *   onAnnounce(detail) {
+ *     console.log(detail.info.name, detail.provider)
+ *   },
+ * })
+ *
+ * // Stop listening when finished:
+ * handle.unsubscribe()
+ * ```
+ *
+ * @param options - Discovery options.
+ * @returns A handle exposing an `unsubscribe()` function.
+ */
+export function discover<schema extends RpcSchema.Generic = RpcSchema.Default>(
+  options: discover.Options<schema>,
+): discover.Handle {
+  if (typeof window === 'undefined') throw new IsUndefinedError()
+
+  const seen = new Set<string>()
+  const handler = (event: Event) => {
+    const detail = (event as EIP6963AnnounceProviderEvent<schema>).detail
+    if (!detail || !detail.info || !detail.provider) return
+    const { uuid } = detail.info
+    if (seen.has(uuid)) return
+    seen.add(uuid)
+    options.onAnnounce(detail)
+  }
+  window.addEventListener('eip6963:announceProvider', handler as EventListener)
+  window.dispatchEvent(new Event('eip6963:requestProvider'))
+  return {
+    unsubscribe() {
+      window.removeEventListener(
+        'eip6963:announceProvider',
+        handler as EventListener,
+      )
+    },
+  }
+}
+
+export declare namespace discover {
+  type Options<schema extends RpcSchema.Generic = RpcSchema.Default> = {
+    /** Called once per unique announced provider (deduped by `info.uuid`). */
+    onAnnounce: (detail: EIP6963ProviderDetail<schema>) => void
+  }
+
+  type Handle = {
+    /** Stop listening for announced providers. */
+    unsubscribe: () => void
+  }
+
+  type ErrorType = IsUndefinedError | Errors.GlobalErrorType
+}

--- a/src/core/Provider.ts
+++ b/src/core/Provider.ts
@@ -478,6 +478,13 @@ export function from<
   options?: options | Options,
 ): from.ReturnType<options, provider>
 // eslint-disable-next-line jsdoc/require-jsdoc
+export function from<
+  schema extends RpcSchema.Generic,
+  provider extends from.Value<{ schema: schema }> | undefined = undefined,
+>(
+  provider: provider | from.Value<{ schema: schema }> | undefined,
+): from.ReturnType<{ schema: schema }, provider>
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function from(provider: any, _options: Options = {}): Provider {
   if (!provider) throw new IsUndefinedError()
   const wrapped = Object.create(Object.getPrototypeOf(provider))

--- a/src/core/ProviderEvents.ts
+++ b/src/core/ProviderEvents.ts
@@ -1,0 +1,34 @@
+/**
+ * Explicit entry point for [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) Provider event
+ * helpers. Re-exports {@link ox#Provider.(createEmitter:function)} and the related types so
+ * request-only consumers can avoid this module's dependency on `eventemitter3` from their import
+ * graph.
+ *
+ * @example
+ * ```ts twoslash
+ * import { ProviderEvents } from 'ox'
+ *
+ * const emitter = ProviderEvents.createEmitter()
+ *
+ * emitter.on('accountsChanged', (accounts) => {
+ *   console.log(accounts)
+ * })
+ *
+ * emitter.emit('accountsChanged', ['0x...'])
+ * ```
+ */
+
+export {
+  /** Re-export of {@link ox#Provider.ConnectInfo}. */
+  type ConnectInfo,
+  /** Re-export of {@link ox#Provider.(createEmitter:function)}. */
+  createEmitter,
+  /** Re-export of {@link ox#Provider.Emitter}. */
+  type Emitter,
+  /** Re-export of {@link ox#Provider.EventMap}. */
+  type EventMap,
+  /** Re-export of {@link ox#Provider.Message}. */
+  type Message,
+  /** Re-export of {@link ox#Provider.ProviderRpcError}. */
+  ProviderRpcError,
+} from './Provider.js'

--- a/src/core/RpcRequest.ts
+++ b/src/core/RpcRequest.ts
@@ -168,6 +168,9 @@ export declare namespace createStore {
  *  .then((response) => RpcResponse.parse(response, { request }))
  * ```
  *
+ * @deprecated Prefer {@link ox#RpcRequest.(build:function)} for new code. `from` remains as a
+ * compatibility wrapper.
+ *
  * @param options - JSON-RPC request options.
  * @returns The fully-formed JSON-RPC request object.
  */
@@ -190,6 +193,80 @@ export declare namespace from {
   type ReturnType<methodName extends RpcSchema.MethodNameGeneric> = Compute<
     RpcRequest<RpcSchema.ExtractItem<RpcSchema.Default, methodName>>
   >
+
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Builds a JSON-RPC request object as per the [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification#request_object).
+ *
+ * Equivalent to {@link ox#RpcRequest.(from:function)} with a more explicit name. Prefer this
+ * helper in new code.
+ *
+ * @example
+ * ```ts twoslash
+ * import { RpcRequest } from 'ox'
+ *
+ * const request = RpcRequest.build({
+ *   id: 0,
+ *   method: 'eth_blockNumber',
+ * })
+ * // @log: { id: 0, jsonrpc: '2.0', method: 'eth_blockNumber' }
+ * ```
+ *
+ * @example
+ * ### Type-safe Custom Schemas
+ *
+ * Pass a {@link ox#RpcSchema.Generic} as the first generic parameter to type the request without
+ * a runtime schema tag.
+ *
+ * ```ts twoslash
+ * import { RpcSchema, RpcRequest } from 'ox'
+ *
+ * type Schema = RpcSchema.From<{
+ *   Request: { method: 'abe_foo'; params: [number] }
+ *   ReturnType: string
+ * }>
+ *
+ * const request = RpcRequest.build<Schema>({
+ *   id: 0,
+ *   method: 'abe_foo',
+ *   params: [42],
+ * })
+ * ```
+ *
+ * @param options - JSON-RPC request options.
+ * @returns The fully-formed JSON-RPC request object.
+ */
+export function build<
+  schema extends RpcSchema.Generic = RpcSchema.Default,
+  methodName extends
+    RpcSchema.MethodNameGeneric<schema> = RpcSchema.MethodNameGeneric<schema>,
+>(
+  options: build.Options<schema, methodName>,
+): build.ReturnType<schema, methodName> {
+  return {
+    ...options,
+    jsonrpc: '2.0',
+  } as never
+}
+
+export declare namespace build {
+  type Options<
+    schema extends RpcSchema.Generic = RpcSchema.Default,
+    methodName extends
+      RpcSchema.MethodNameGeneric<schema> = RpcSchema.MethodNameGeneric<schema>,
+  > = Compute<
+    RpcSchema_internal.ExtractRequestOpaque<schema, methodName> & {
+      id: number
+    }
+  >
+
+  type ReturnType<
+    schema extends RpcSchema.Generic = RpcSchema.Default,
+    methodName extends
+      RpcSchema.MethodNameGeneric<schema> = RpcSchema.MethodNameGeneric<schema>,
+  > = Compute<RpcRequest<RpcSchema.ExtractItem<schema, methodName>>>
 
   type ErrorType = Errors.GlobalErrorType
 }

--- a/src/core/RpcResponse.ts
+++ b/src/core/RpcResponse.ts
@@ -58,6 +58,9 @@ export type ErrorObject = {
  * )
  * ```
  *
+ * @deprecated Prefer {@link ox#RpcResponse.(envelope:function)} for new code. `from` remains as
+ * a compatibility wrapper.
+ *
  * @param response - Opaque JSON-RPC response object.
  * @param options - Parsing options.
  * @returns Typed JSON-RPC result, or response object (if `raw` is `true`).
@@ -199,6 +202,10 @@ export declare namespace from {
  *
  * ```
  *
+ * @deprecated Prefer {@link ox#RpcResponse.(parseResult:function)} or
+ * {@link ox#RpcResponse.(parseEnvelope:function)} for new code. `parse` remains as a
+ * compatibility wrapper.
+ *
  * @param response - Opaque JSON-RPC response object.
  * @param options - Parsing options.
  * @returns Typed JSON-RPC result, or response object (if `raw` is `true`).
@@ -233,6 +240,155 @@ export function parse<
   if (raw) return response as never
   if (response_.error) throw parseError(response_.error)
   return response_.result as never
+}
+
+/**
+ * Instantiates a JSON-RPC response envelope. Equivalent to {@link ox#RpcResponse.(from:function)}
+ * with a more explicit name. Prefer this helper in new code.
+ *
+ * @example
+ * ```ts twoslash
+ * import { RpcResponse } from 'ox'
+ *
+ * const response = RpcResponse.envelope({
+ *   id: 0,
+ *   jsonrpc: '2.0',
+ *   result: '0x69420',
+ * })
+ * ```
+ *
+ * @param response - Opaque JSON-RPC response object.
+ * @param options - Envelope options.
+ * @returns Typed JSON-RPC response envelope.
+ */
+export function envelope<
+  request extends RpcRequest.RpcRequest | undefined = undefined,
+  const response =
+    | (request extends RpcRequest.RpcRequest
+        ? request['_returnType']
+        : RpcResponse)
+    | unknown,
+>(
+  response: from.Response<request, response>,
+  options?: from.Options<request>,
+): Compute<from.ReturnType<response>>
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function envelope(response: any, options: any = {}): any {
+  return from(response, options)
+}
+
+export declare namespace envelope {
+  type Options<
+    request extends RpcRequest.RpcRequest | undefined =
+      | RpcRequest.RpcRequest
+      | undefined,
+  > = from.Options<request>
+
+  type ErrorType = ParseError | Errors.GlobalErrorType
+}
+
+/**
+ * Validates a JSON-RPC response envelope and unwraps the typed `result`. Throws if the response
+ * is malformed or contains a JSON-RPC error.
+ *
+ * Equivalent to calling {@link ox#RpcResponse.(parse:function)} without the `raw` option. Prefer
+ * this helper in new code.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { RpcRequest, RpcResponse } from 'ox'
+ *
+ * const store = RpcRequest.createStore()
+ *
+ * const block = await fetch('https://1.rpc.thirdweb.com', {
+ *   body: JSON.stringify(store.prepare({ method: 'eth_blockNumber' })),
+ *   method: 'POST',
+ *   headers: { 'Content-Type': 'application/json' },
+ * })
+ *  .then((res) => res.json())
+ *  .then(RpcResponse.parseResult)
+ * ```
+ *
+ * @param response - Opaque JSON-RPC response object.
+ * @param options - Parsing options.
+ * @returns Typed JSON-RPC result.
+ */
+export function parseResult<
+  const response extends RpcResponse | unknown,
+  returnType,
+>(
+  response: response,
+  options: parseResult.Options<returnType> = {},
+): parseResult.ReturnType<
+  unknown extends response
+    ? returnType
+    : response extends RpcResponse
+      ? response extends { result: infer result }
+        ? result
+        : never
+      : returnType
+> {
+  return parse(response, options) as never
+}
+
+export declare namespace parseResult {
+  type Options<returnType> = Omit<parse.Options<returnType, false>, 'raw'>
+
+  type ReturnType<returnType> = Compute<returnType>
+
+  type ErrorType = parse.ErrorType
+}
+
+/**
+ * Validates a JSON-RPC response envelope and returns it intact (does not unwrap `result` or
+ * throw on `error`). Use when you need to inspect both branches of the envelope yourself.
+ *
+ * Equivalent to calling {@link ox#RpcResponse.(parse:function)} with `raw: true`. Prefer this
+ * helper in new code.
+ *
+ * @example
+ * ```ts twoslash
+ * import { RpcResponse } from 'ox'
+ *
+ * const envelope = RpcResponse.parseEnvelope({
+ *   id: 0,
+ *   jsonrpc: '2.0',
+ *   result: '0x1',
+ * })
+ *
+ * envelope
+ * // ^?
+ * ```
+ *
+ * @param response - Opaque JSON-RPC response object.
+ * @param options - Parsing options.
+ * @returns Typed JSON-RPC response envelope.
+ */
+export function parseEnvelope<
+  const response extends RpcResponse | unknown,
+  returnType,
+>(
+  response: response,
+  options: parseEnvelope.Options<returnType> = {},
+): parseEnvelope.ReturnType<
+  unknown extends response
+    ? returnType
+    : response extends RpcResponse
+      ? response extends { result: infer result }
+        ? result
+        : never
+      : returnType
+> {
+  return parse(response, { ...options, raw: true }) as never
+}
+
+export declare namespace parseEnvelope {
+  type Options<returnType> = Omit<parse.Options<returnType, true>, 'raw'>
+
+  type ReturnType<returnType> = Compute<RpcResponse<returnType>>
+
+  type ErrorType = parse.ErrorType
 }
 
 export declare namespace parse {

--- a/src/core/RpcSchema.ts
+++ b/src/core/RpcSchema.ts
@@ -9,6 +9,11 @@ export type { Wallet } from './internal/rpcSchemas/wallet.js'
  * to be used as a type-level tag to be used with {@link ox#Provider.(from:function)} or
  * {@link ox#RpcTransport.(fromHttp:function)}.
  *
+ * @deprecated Prefer passing the schema as a type generic directly:
+ * `Provider.from<MySchema>(provider)` and
+ * `RpcTransport.fromHttp<false, MySchema>(url)`. `RpcSchema.from()` remains as a compatibility
+ * wrapper.
+ *
  * @example
  * ### Using with `Provider.from`
  *

--- a/src/core/RpcTransport.ts
+++ b/src/core/RpcTransport.ts
@@ -251,6 +251,18 @@ const wait = (ms: number) =>
  * @param options - Transport options.
  * @returns HTTP JSON-RPC Transport.
  */
+// Existing overload: `RpcTransport.fromHttp<raw, schema>(url, options)`.
+export function fromHttp<
+  raw extends boolean = false,
+  schema extends RpcSchema.Generic = RpcSchema.Default,
+>(url: string, options?: fromHttp.Options<raw, schema>): Http<raw, schema>
+// Schema-first overload: `RpcTransport.fromHttp<MySchema>(url)`.
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function fromHttp<schema extends RpcSchema.Generic>(
+  url: string,
+  options?: fromHttp.Options<false, schema>,
+): Http<false, schema>
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function fromHttp<
   raw extends boolean = false,
   schema extends RpcSchema.Generic = RpcSchema.Default,

--- a/src/core/RpcTransport.ts
+++ b/src/core/RpcTransport.ts
@@ -4,7 +4,7 @@ import * as promise from './internal/promise.js'
 import type * as RpcSchema_internal from './internal/rpcSchema.js'
 import * as internal from './internal/rpcTransport.js'
 import type { Compute } from './internal/types.js'
-import type * as RpcResponse from './RpcResponse.js'
+import * as RpcResponse from './RpcResponse.js'
 import type * as RpcSchema from './RpcSchema.js'
 
 /** Root type for an RPC Transport. */
@@ -20,7 +20,21 @@ export type RpcTransport<
 export type Http<
   raw extends boolean = false,
   schema extends RpcSchema.Generic = RpcSchema.Default,
-> = RpcTransport<raw, HttpOptions, schema>
+> = Compute<
+  RpcTransport<raw, HttpOptions, schema> & {
+    /**
+     * Sends a JSON-RPC request and returns the full {@link ox#RpcResponse.RpcResponse} envelope
+     * (instead of unwrapping `result` and throwing on `error`).
+     */
+    requestRaw: RequestRawFn<HttpOptions, schema>
+    /**
+     * Sends a JSON-RPC batch request, returning an array of envelopes (one per request, in order).
+     *
+     * Always HTTP-only. Empty input is rejected.
+     */
+    batch: BatchFn<HttpOptions, schema>
+  }
+>
 
 export type HttpOptions = {
   /** Request configuration to pass to `fetch`. */
@@ -34,6 +48,50 @@ export type HttpOptions = {
   fetchFn?: typeof fetch | undefined
   /** Timeout for the request in milliseconds. @default 10_000 */
   timeout?: number | undefined
+  /**
+   * Number of times to retry the request on failure. Set to `0` to disable.
+   *
+   * Retries are scoped to HTTP-level failures and only fire when `shouldRetry`
+   * returns `true`. Wallet methods (`wallet_*`) and state-changing methods (`eth_sendTransaction`,
+   * `eth_sendRawTransaction`, `eth_signTransaction`, `personal_sign`, `eth_sign*`) are skipped by
+   * the default predicate to avoid double-submitting writes.
+   *
+   * @default 0
+   */
+  retryCount?: number | undefined
+  /**
+   * Delay in milliseconds between retry attempts. May be a static number or a function called with
+   * the retry attempt number (1-indexed) and the originating error. Defaults to exponential
+   * backoff starting at 150ms.
+   */
+  retryDelay?:
+    | number
+    | ((parameters: RetryDelayParameters) => number)
+    | undefined
+  /**
+   * Predicate controlling whether a failed request should be retried. Receives the originating
+   * error and the next attempt number (1-indexed). Defaults to skipping wallet / state-changing
+   * methods and retrying on network errors, timeouts, and 5xx / 408 / 429 statuses.
+   */
+  shouldRetry?: ((parameters: ShouldRetryParameters) => boolean) | undefined
+}
+
+/** @internal */
+export type RetryDelayParameters = {
+  /** The 1-indexed retry attempt number. */
+  count: number
+  /** The error that triggered the retry. */
+  error: Error
+}
+
+/** @internal */
+export type ShouldRetryParameters = {
+  /** The 1-indexed retry attempt number. */
+  count: number
+  /** The error that triggered the retry. */
+  error: Error
+  /** The originating JSON-RPC request method. */
+  method: string
 }
 
 export type RequestFn<
@@ -58,6 +116,68 @@ export type RequestFn<
       : RpcSchema.ExtractReturnType<schema, methodName>
 >
 
+export type RequestRawFn<
+  options extends Record<string, unknown> = {},
+  schema extends RpcSchema.Generic = RpcSchema.Default,
+> = <methodName extends RpcSchema.MethodNameGeneric>(
+  parameters: Compute<
+    RpcSchema_internal.ExtractRequestOpaque<schema, methodName>
+  >,
+  options?: internal.Options<true, options, schema> | undefined,
+) => Promise<
+  RpcResponse.RpcResponse<RpcSchema.ExtractReturnType<schema, methodName>>
+>
+
+export type BatchFn<
+  options extends Record<string, unknown> = {},
+  schema extends RpcSchema.Generic = RpcSchema.Default,
+> = <methodName extends RpcSchema.MethodNameGeneric>(
+  requests: ReadonlyArray<
+    Compute<RpcSchema_internal.ExtractRequestOpaque<schema, methodName>>
+  >,
+  options?: internal.Options<true, options, schema> | undefined,
+) => Promise<
+  ReadonlyArray<
+    RpcResponse.RpcResponse<RpcSchema.ExtractReturnType<schema, methodName>>
+  >
+>
+
+const defaultRetryableMethodPredicate = (method: string) => {
+  // Skip methods with side-effects to avoid double-submitting state changes.
+  if (method.startsWith('wallet_')) return false
+  if (method.startsWith('personal_sign')) return false
+  if (method.startsWith('eth_sign')) return false
+  if (method === 'eth_sendTransaction') return false
+  if (method === 'eth_sendRawTransaction') return false
+  return true
+}
+
+const defaultShouldRetry = ({ error, method }: ShouldRetryParameters) => {
+  if (!defaultRetryableMethodPredicate(method)) return false
+  // Retry on transport-level failures.
+  if (error instanceof MalformedResponseError) return true
+  if (error instanceof promise.TimeoutError) return true
+  if (error instanceof HttpError) {
+    const status = error.status ?? 0
+    // Retry server errors and the canonical transient client errors.
+    if (status === 408 || status === 429) return true
+    if (status >= 500) return true
+    return false
+  }
+  // Network-level fetch errors typically surface as TypeError.
+  if (error?.name === 'TypeError') return true
+  if (error?.name === 'AbortError') return true
+  return false
+}
+
+const defaultRetryDelay = ({ count }: RetryDelayParameters) =>
+  150 * 2 ** (count - 1)
+
+const wait = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
 /**
  * Creates a HTTP JSON-RPC Transport from a URL.
  *
@@ -71,6 +191,62 @@ export type RequestFn<
  * // @log: '0x1a2b3c'
  * ```
  *
+ * @example
+ * ### Generic Schema Inference
+ *
+ * Pass a custom {@link ox#RpcSchema.Generic} as the type parameter to type both
+ * `request` and `requestRaw` without a runtime schema tag.
+ *
+ * ```ts twoslash
+ * import { RpcSchema, RpcTransport } from 'ox'
+ *
+ * type Schema = RpcSchema.From<{
+ *   Request: { method: 'abe_foo'; params: [number] }
+ *   ReturnType: string
+ * }>
+ *
+ * const transport = RpcTransport.fromHttp<false, Schema>(
+ *   'https://1.rpc.thirdweb.com',
+ * )
+ * ```
+ *
+ * @example
+ * ### Retry on Failure
+ *
+ * Opt in to retries by setting `retryCount > 0`. Wallet/state-changing methods are skipped by the
+ * default predicate. Override `shouldRetry` to customize the policy and `retryDelay` to control
+ * backoff timing.
+ *
+ * ```ts twoslash
+ * import { RpcTransport } from 'ox'
+ *
+ * const transport = RpcTransport.fromHttp('https://1.rpc.thirdweb.com', {
+ *   retryCount: 3,
+ *   retryDelay: ({ count }) => 100 * count,
+ *   shouldRetry: ({ error }) => error.name !== 'AbortError',
+ * })
+ * ```
+ *
+ * @example
+ * ### Raw Envelopes & Batch
+ *
+ * Use `requestRaw` to receive the full JSON-RPC envelope, or `batch` to send several requests in a
+ * single HTTP round-trip (HTTP-only).
+ *
+ * ```ts twoslash
+ * import { RpcTransport } from 'ox'
+ *
+ * const transport = RpcTransport.fromHttp('https://1.rpc.thirdweb.com')
+ *
+ * const envelope = await transport.requestRaw({ method: 'eth_blockNumber' })
+ * // @log: { id: 0, jsonrpc: '2.0', result: '0x...' }
+ *
+ * const [blockNumber, chainId] = await transport.batch([
+ *   { method: 'eth_blockNumber' },
+ *   { method: 'eth_chainId' },
+ * ])
+ * ```
+ *
  * @param url - URL to perform the JSON-RPC requests to.
  * @param options - Transport options.
  * @returns HTTP JSON-RPC Transport.
@@ -79,96 +255,184 @@ export function fromHttp<
   raw extends boolean = false,
   schema extends RpcSchema.Generic = RpcSchema.Default,
 >(url: string, options: fromHttp.Options<raw, schema> = {}): Http<raw, schema> {
-  return internal.create<HttpOptions, schema, raw>(
+  let nextBatchId = 0
+
+  async function performHttp(
+    body: unknown,
+    options_: HttpOptions,
+  ): Promise<unknown> {
+    const {
+      fetchFn = options.fetchFn ?? fetch,
+      fetchOptions: fetchOptions_ = options.fetchOptions,
+      timeout = options.timeout ?? 10_000,
+    } = options_
+
+    const serializedBody = JSON.stringify(body)
+
+    const fetchOptions =
+      typeof fetchOptions_ === 'function'
+        ? await fetchOptions_(body as RpcSchema.Generic['Request'])
+        : fetchOptions_
+
+    const response = await promise.withTimeout(
+      ({ signal }) => {
+        const externalSignal = fetchOptions?.signal
+        const timeoutSignal = timeout > 0 ? signal : null
+        const signals = [externalSignal, timeoutSignal].filter(
+          (s): s is AbortSignal => Boolean(s),
+        )
+        const composedSignal =
+          signals.length === 0
+            ? null
+            : signals.length === 1
+              ? signals[0]!
+              : AbortSignal.any(signals)
+        const init: RequestInit = {
+          ...fetchOptions,
+          body: serializedBody,
+          headers: {
+            'Content-Type': 'application/json',
+            ...fetchOptions?.headers,
+          },
+          method: fetchOptions?.method ?? 'POST',
+          signal: composedSignal,
+        }
+        return fetchFn(url, init)
+      },
+      {
+        timeout,
+        signal: true,
+      },
+    )
+
+    const data = await (async () => {
+      if (response.headers.get('Content-Type')?.startsWith('application/json'))
+        return response.json()
+      return response.text().then((data) => {
+        if (data === '') {
+          if (response.ok) throw new MalformedResponseError({ response: data })
+          return { error: undefined }
+        }
+        try {
+          return JSON.parse(data)
+        } catch (_err) {
+          if (response.ok)
+            throw new MalformedResponseError({
+              response: data,
+            })
+          return { error: data }
+        }
+      })
+    })()
+
+    if (!response.ok) {
+      const error = (data as { error?: unknown })?.error
+      throw new HttpError({
+        body: serializedBody,
+        details:
+          typeof error === 'string'
+            ? error
+            : error
+              ? JSON.stringify(error)
+              : response.statusText,
+        response,
+        url,
+      })
+    }
+
+    return data
+  }
+
+  async function performWithRetry(
+    body: unknown,
+    options_: HttpOptions,
+    method: string,
+  ): Promise<unknown> {
+    const retryCount = options_.retryCount ?? options.retryCount ?? 0
+    const retryDelayOption =
+      options_.retryDelay ?? options.retryDelay ?? defaultRetryDelay
+    const shouldRetry =
+      options_.shouldRetry ?? options.shouldRetry ?? defaultShouldRetry
+
+    let attempt = 0
+    while (true) {
+      try {
+        return await performHttp(body, options_)
+      } catch (err) {
+        const error = err as Error
+        attempt++
+        if (attempt > retryCount) throw error
+        if (!shouldRetry({ count: attempt, error, method })) throw error
+        const delay =
+          typeof retryDelayOption === 'function'
+            ? retryDelayOption({ count: attempt, error })
+            : retryDelayOption
+        if (delay > 0) await wait(delay)
+      }
+    }
+  }
+
+  const transport = internal.create<HttpOptions, schema, raw>(
     {
       async request(body_, options_) {
-        const {
-          fetchFn = options.fetchFn ?? fetch,
-          fetchOptions: fetchOptions_ = options.fetchOptions,
-          timeout = options.timeout ?? 10_000,
-        } = options_
-
-        const body = JSON.stringify(body_)
-
-        const fetchOptions =
-          typeof fetchOptions_ === 'function'
-            ? await fetchOptions_(body_)
-            : fetchOptions_
-
-        const response = await promise.withTimeout(
-          ({ signal }) => {
-            const externalSignal = fetchOptions?.signal
-            const timeoutSignal = timeout > 0 ? signal : null
-            const signals = [externalSignal, timeoutSignal].filter(
-              (s): s is AbortSignal => Boolean(s),
-            )
-            const composedSignal =
-              signals.length === 0
-                ? null
-                : signals.length === 1
-                  ? signals[0]!
-                  : AbortSignal.any(signals)
-            const init: RequestInit = {
-              ...fetchOptions,
-              body,
-              headers: {
-                'Content-Type': 'application/json',
-                ...fetchOptions?.headers,
-              },
-              method: fetchOptions?.method ?? 'POST',
-              signal: composedSignal,
-            }
-            return fetchFn(url, init)
-          },
-          {
-            timeout,
-            signal: true,
-          },
-        )
-
-        const data = await (async () => {
-          if (
-            response.headers.get('Content-Type')?.startsWith('application/json')
-          )
-            return response.json()
-          return response.text().then((data) => {
-            if (data === '') {
-              if (response.ok)
-                throw new MalformedResponseError({ response: data })
-              return { error: undefined }
-            }
-            try {
-              return JSON.parse(data)
-            } catch (_err) {
-              if (response.ok)
-                throw new MalformedResponseError({
-                  response: data,
-                })
-              return { error: data }
-            }
-          })
-        })()
-
-        if (!response.ok) {
-          const error = (data as { error?: unknown })?.error
-          throw new HttpError({
-            body,
-            details:
-              typeof error === 'string'
-                ? error
-                : error
-                  ? JSON.stringify(error)
-                  : response.statusText,
-            response,
-            url,
-          })
-        }
-
-        return data as never
+        const method = (body_ as { method?: string }).method ?? ''
+        return (await performWithRetry(body_, options_, method)) as never
       },
     },
     { raw: options.raw },
   )
+
+  const requestRaw: RequestRawFn<HttpOptions, schema> = (
+    parameters: any,
+    rawOptions: any = {},
+  ) => transport.request(parameters, { ...rawOptions, raw: true } as any) as any
+
+  const batch: BatchFn<HttpOptions, schema> = (async (
+    requests: ReadonlyArray<{ method: string }>,
+    batchOptions: HttpOptions = {},
+  ) => {
+    if (!Array.isArray(requests) || requests.length === 0)
+      throw new EmptyBatchError()
+
+    const body = requests.map((request) => ({
+      id: nextBatchId++,
+      ...request,
+      jsonrpc: '2.0',
+    }))
+    const methods = requests.map((r) => r.method ?? '').join(',')
+    const data = (await performWithRetry(body, batchOptions, methods)) as
+      | RpcResponse.RpcResponse[]
+      | RpcResponse.RpcResponse
+
+    if (!Array.isArray(data))
+      throw new MalformedBatchResponseError({
+        details: 'Expected an array of JSON-RPC responses.',
+      })
+
+    if (data.length !== body.length)
+      throw new MalformedBatchResponseError({
+        details: `Expected ${body.length} responses, got ${data.length}.`,
+      })
+
+    // Re-order responses to match the request order via `id`.
+    const byId = new Map<number, RpcResponse.RpcResponse>()
+    for (const response of data) byId.set(response.id, response)
+    return body.map((req) => {
+      const response = byId.get(req.id)
+      if (!response)
+        throw new MalformedBatchResponseError({
+          details: `Missing response for id ${req.id}.`,
+        })
+      // Validate as JSON-RPC envelope without unwrapping.
+      return RpcResponse.parse(response, { raw: true }) as never
+    })
+  }) as never
+
+  return {
+    ...transport,
+    requestRaw,
+    batch,
+  }
 }
 
 export declare namespace fromHttp {
@@ -180,12 +444,17 @@ export declare namespace fromHttp {
   type ErrorType =
     | promise.withTimeout.ErrorType
     | HttpError
+    | EmptyBatchError
+    | MalformedBatchResponseError
     | Errors.GlobalErrorType
 }
 
 /** Thrown when a HTTP request fails. */
 export class HttpError extends Errors.BaseError {
   override readonly name = 'RpcTransport.HttpError'
+
+  /** Response status code, if available. */
+  readonly status: number | undefined
 
   constructor({
     body,
@@ -201,6 +470,7 @@ export class HttpError extends Errors.BaseError {
         body ? `Body: ${JSON.stringify(body)}` : undefined,
       ],
     })
+    this.status = response.status
   }
 }
 
@@ -212,5 +482,23 @@ export class MalformedResponseError extends Errors.BaseError {
     super('HTTP Response could not be parsed as JSON.', {
       metaMessages: [`Response: ${response}`],
     })
+  }
+}
+
+/** Thrown when {@link ox#RpcTransport.fromHttp}'s `batch` is called with an empty array. */
+export class EmptyBatchError extends Errors.BaseError {
+  override readonly name = 'RpcTransport.EmptyBatchError'
+
+  constructor() {
+    super('A JSON-RPC batch must contain at least one request.')
+  }
+}
+
+/** Thrown when a JSON-RPC batch response cannot be matched against the request batch. */
+export class MalformedBatchResponseError extends Errors.BaseError {
+  override readonly name = 'RpcTransport.MalformedBatchResponseError'
+
+  constructor({ details }: { details: string }) {
+    super('JSON-RPC batch response is malformed.', { details })
   }
 }

--- a/src/core/_test/Provider.browser.test.ts
+++ b/src/core/_test/Provider.browser.test.ts
@@ -1,0 +1,92 @@
+import { Provider } from 'ox'
+import { describe, expect, test } from 'vitest'
+
+describe('Provider.announce / Provider.discover', () => {
+  test('discovers an announced provider', async () => {
+    const detail: Provider.EIP6963ProviderDetail = {
+      info: {
+        uuid: 'eef39d31-8a1f-4f02-9c01-9bdf8b4c6b48',
+        name: 'Example Wallet',
+        icon: 'data:image/svg+xml;base64,',
+        rdns: 'sh.oxlib.example',
+      },
+      provider: {
+        request: async () => '0x1' as never,
+      } as Provider.Provider,
+    }
+
+    const seen: Provider.EIP6963ProviderDetail[] = []
+    const handle = Provider.discover({
+      onAnnounce(d) {
+        seen.push(d)
+      },
+    })
+    Provider.announce(detail)
+    handle.unsubscribe()
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0]?.info).toEqual(detail.info)
+    expect(seen[0]?.provider).toBe(detail.provider)
+  })
+
+  test('deduplicates announcements by uuid', async () => {
+    const detail: Provider.EIP6963ProviderDetail = {
+      info: {
+        uuid: '5fe0228c-30b3-4f2e-9be1-9eaa2f8a8a1b',
+        name: 'Example Wallet',
+        icon: 'data:image/svg+xml;base64,',
+        rdns: 'sh.oxlib.example',
+      },
+      provider: { request: async () => '0x1' as never } as Provider.Provider,
+    }
+
+    const seen: Provider.EIP6963ProviderDetail[] = []
+    const handle = Provider.discover({
+      onAnnounce(d) {
+        seen.push(d)
+      },
+    })
+    Provider.announce(detail)
+    Provider.announce(detail)
+    Provider.announce(detail)
+    handle.unsubscribe()
+
+    expect(seen).toHaveLength(1)
+  })
+
+  test('unsubscribe stops receiving announcements', async () => {
+    const seen: Provider.EIP6963ProviderDetail[] = []
+    const handle = Provider.discover({
+      onAnnounce(d) {
+        seen.push(d)
+      },
+    })
+    handle.unsubscribe()
+
+    Provider.announce({
+      info: {
+        uuid: 'a16f5dac-69b6-4f9d-bd7a-f06b69cf2f3d',
+        name: 'Example Wallet',
+        icon: 'data:image/svg+xml;base64,',
+        rdns: 'sh.oxlib.example',
+      },
+      provider: { request: async () => '0x1' as never } as Provider.Provider,
+    })
+
+    expect(seen).toHaveLength(0)
+  })
+
+  test('discover triggers eip6963:requestProvider for re-announcement', async () => {
+    let announcementsRequested = 0
+    const handler = () => {
+      announcementsRequested++
+    }
+    window.addEventListener('eip6963:requestProvider', handler)
+
+    const handle = Provider.discover({ onAnnounce() {} })
+    handle.unsubscribe()
+    window.removeEventListener('eip6963:requestProvider', handler)
+
+    expect(announcementsRequested).toBe(1)
+  })
+})

--- a/src/core/_test/Provider.test.ts
+++ b/src/core/_test/Provider.test.ts
@@ -888,6 +888,32 @@ test('Provider.ChainDisconnectedError', () => {
   )
 })
 
+describe('Provider.announce / Provider.discover (no window)', () => {
+  test('announce throws IsUndefinedError without window', () => {
+    expect(() =>
+      Provider.announce({
+        info: {
+          uuid: '00000000-0000-0000-0000-000000000000',
+          name: 'x',
+          icon: 'data:image/svg+xml;base64,',
+          rdns: 'sh.oxlib.example',
+        },
+        provider: { request: async () => '0x' as never } as never,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Provider.IsUndefinedError: `provider` is undefined.]',
+    )
+  })
+
+  test('discover throws IsUndefinedError without window', () => {
+    expect(() =>
+      Provider.discover({ onAnnounce() {} }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Provider.IsUndefinedError: `provider` is undefined.]',
+    )
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(Provider)).toMatchInlineSnapshot(`
     [
@@ -909,6 +935,8 @@ test('exports', () => {
       "from",
       "parseError",
       "IsUndefinedError",
+      "announce",
+      "discover",
     ]
   `)
 })

--- a/src/core/_test/ProviderEvents.test.ts
+++ b/src/core/_test/ProviderEvents.test.ts
@@ -1,0 +1,34 @@
+import { ProviderEvents } from 'ox'
+import { describe, expect, test } from 'vitest'
+
+describe('ProviderEvents.createEmitter', () => {
+  test('default', () => {
+    const emitter = ProviderEvents.createEmitter()
+
+    expect(typeof emitter.on).toBe('function')
+    expect(typeof emitter.emit).toBe('function')
+    expect(typeof emitter.off).toBe('function')
+  })
+
+  test('emits and listens to events', () => {
+    const emitter = ProviderEvents.createEmitter()
+
+    const calls: unknown[] = []
+    emitter.on('accountsChanged', (accounts) => calls.push(accounts))
+
+    emitter.emit('accountsChanged', [
+      '0x0000000000000000000000000000000000000000',
+    ])
+
+    expect(calls).toEqual([['0x0000000000000000000000000000000000000000']])
+  })
+})
+
+test('exports', () => {
+  expect(Object.keys(ProviderEvents).sort()).toMatchInlineSnapshot(`
+    [
+      "ProviderRpcError",
+      "createEmitter",
+    ]
+  `)
+})

--- a/src/core/_test/RpcRequest.test.ts
+++ b/src/core/_test/RpcRequest.test.ts
@@ -202,11 +202,54 @@ describe('from', () => {
   })
 })
 
+describe('build', () => {
+  test('default', () => {
+    expect(
+      RpcRequest.build({
+        id: 0,
+        method: 'eth_blockNumber',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "id": 0,
+        "jsonrpc": "2.0",
+        "method": "eth_blockNumber",
+      }
+    `)
+  })
+
+  test('with params', () => {
+    expect(
+      RpcRequest.build({
+        id: 1,
+        method: 'eth_call',
+        params: [
+          { to: '0x0000000000000000000000000000000000000000' },
+          'latest',
+        ],
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "method": "eth_call",
+        "params": [
+          {
+            "to": "0x0000000000000000000000000000000000000000",
+          },
+          "latest",
+        ],
+      }
+    `)
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(RpcRequest)).toMatchInlineSnapshot(`
     [
       "createStore",
       "from",
+      "build",
     ]
   `)
 })

--- a/src/core/_test/RpcResponse.test.ts
+++ b/src/core/_test/RpcResponse.test.ts
@@ -403,6 +403,102 @@ describe('parse', () => {
   })
 })
 
+describe('envelope', () => {
+  test('default', () => {
+    expect(
+      RpcResponse.envelope({ id: 0, jsonrpc: '2.0', result: '0x69420' }),
+    ).toMatchInlineSnapshot(`
+      {
+        "id": 0,
+        "jsonrpc": "2.0",
+        "result": "0x69420",
+      }
+    `)
+  })
+
+  test('with request', () => {
+    const request = RpcRequest.build({ id: 1, method: 'eth_blockNumber' })
+    expect(
+      RpcResponse.envelope({ result: '0x69420' }, { request }),
+    ).toMatchInlineSnapshot(`
+      {
+        "id": 1,
+        "jsonrpc": "2.0",
+        "result": "0x69420",
+      }
+    `)
+  })
+})
+
+describe('parseResult', () => {
+  test('default: returns result', () => {
+    expect(
+      RpcResponse.parseResult({ id: 0, jsonrpc: '2.0', result: '0x1' }),
+    ).toBe('0x1')
+  })
+
+  test('throws on error envelope', () => {
+    expect(() =>
+      RpcResponse.parseResult({
+        id: 0,
+        jsonrpc: '2.0',
+        error: { code: -32601, message: 'Method does not exist.' },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[RpcResponse.MethodNotFoundError: Method does not exist.]',
+    )
+  })
+
+  test('throws on malformed envelope', () => {
+    expect(() =>
+      RpcResponse.parseResult({}),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[RpcResponse.ParseError: Invalid JSON-RPC response.]',
+    )
+  })
+})
+
+describe('parseEnvelope', () => {
+  test('default: returns full envelope', () => {
+    expect(
+      RpcResponse.parseEnvelope({ id: 0, jsonrpc: '2.0', result: '0x1' }),
+    ).toMatchInlineSnapshot(`
+      {
+        "id": 0,
+        "jsonrpc": "2.0",
+        "result": "0x1",
+      }
+    `)
+  })
+
+  test('does not throw on error envelope', () => {
+    expect(
+      RpcResponse.parseEnvelope({
+        id: 0,
+        jsonrpc: '2.0',
+        error: { code: -32601, message: 'Method does not exist.' },
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "error": {
+          "code": -32601,
+          "message": "Method does not exist.",
+        },
+        "id": 0,
+        "jsonrpc": "2.0",
+      }
+    `)
+  })
+
+  test('throws on malformed envelope', () => {
+    expect(() =>
+      RpcResponse.parseEnvelope({}),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[RpcResponse.ParseError: Invalid JSON-RPC response.]',
+    )
+  })
+})
+
 describe('parseError', () => {
   test('InternalError', () => {
     const error = RpcResponse.parseError({
@@ -706,6 +802,9 @@ test('exports', () => {
     [
       "from",
       "parse",
+      "envelope",
+      "parseResult",
+      "parseEnvelope",
       "parseError",
       "BaseError",
       "InvalidInputError",

--- a/src/core/_test/RpcTransport.test.ts
+++ b/src/core/_test/RpcTransport.test.ts
@@ -250,12 +250,284 @@ describe('fromHttp', () => {
   })
 })
 
+describe('fromHttp: requestRaw', () => {
+  test('default', async () => {
+    const server = await createHttpServer((_, res) => {
+      res.end(JSON.stringify({ id: 0, jsonrpc: '2.0', result: '0x1' }))
+    })
+
+    const transport = RpcTransport.fromHttp(server.url)
+
+    const envelope = await transport.requestRaw({ method: 'eth_blockNumber' })
+
+    expect(envelope).toMatchInlineSnapshot(`
+      {
+        "id": 0,
+        "jsonrpc": "2.0",
+        "result": "0x1",
+      }
+    `)
+  })
+
+  test('error envelope', async () => {
+    const server = await createHttpServer((_, res) => {
+      res.end(
+        JSON.stringify({
+          id: 0,
+          jsonrpc: '2.0',
+          error: { code: -32601, message: 'Method does not exist.' },
+        }),
+      )
+    })
+
+    const transport = RpcTransport.fromHttp(server.url)
+
+    const envelope = await transport.requestRaw({ method: 'eth_blockNumber' })
+
+    expect(envelope).toMatchInlineSnapshot(`
+      {
+        "error": {
+          "code": -32601,
+          "message": "Method does not exist.",
+        },
+        "id": 0,
+        "jsonrpc": "2.0",
+      }
+    `)
+  })
+})
+
+describe('fromHttp: batch', () => {
+  test('default', async () => {
+    const server = await createHttpServer((req, res) => {
+      let body = ''
+      req.on('data', (chunk) => {
+        body += chunk
+      })
+      req.on('end', () => {
+        const requests = JSON.parse(body) as Array<{
+          id: number
+          method: string
+        }>
+        const responses = requests.map((r) => ({
+          id: r.id,
+          jsonrpc: '2.0',
+          result: r.method === 'eth_blockNumber' ? '0x1' : '0x2',
+        }))
+        res.end(JSON.stringify(responses))
+      })
+    })
+
+    const transport = RpcTransport.fromHttp(server.url)
+
+    const responses = await transport.batch([
+      { method: 'eth_blockNumber' },
+      { method: 'eth_chainId' },
+    ])
+
+    expect(responses).toMatchInlineSnapshot(`
+      [
+        {
+          "id": 0,
+          "jsonrpc": "2.0",
+          "result": "0x1",
+        },
+        {
+          "id": 1,
+          "jsonrpc": "2.0",
+          "result": "0x2",
+        },
+      ]
+    `)
+  })
+
+  test('reorders responses by id', async () => {
+    const server = await createHttpServer((req, res) => {
+      let body = ''
+      req.on('data', (chunk) => {
+        body += chunk
+      })
+      req.on('end', () => {
+        const requests = JSON.parse(body) as Array<{
+          id: number
+          method: string
+        }>
+        // Return responses in reverse order to verify re-ordering.
+        const responses = requests
+          .map((r) => ({
+            id: r.id,
+            jsonrpc: '2.0',
+            result: r.method,
+          }))
+          .reverse()
+        res.end(JSON.stringify(responses))
+      })
+    })
+
+    const transport = RpcTransport.fromHttp(server.url)
+
+    const responses = await transport.batch([
+      { method: 'eth_blockNumber' },
+      { method: 'eth_chainId' },
+    ])
+
+    expect(responses[0]?.result).toBe('eth_blockNumber')
+    expect(responses[1]?.result).toBe('eth_chainId')
+  })
+
+  test('rejects empty input', async () => {
+    const transport = RpcTransport.fromHttp('http://localhost:0')
+
+    await expect(() =>
+      transport.batch([]),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      '[RpcTransport.EmptyBatchError: A JSON-RPC batch must contain at least one request.]',
+    )
+  })
+
+  test('throws on malformed response (not array)', async () => {
+    const server = await createHttpServer((_, res) => {
+      res.end(JSON.stringify({ id: 0, jsonrpc: '2.0', result: '0x1' }))
+    })
+
+    const transport = RpcTransport.fromHttp(server.url)
+
+    await expect(() =>
+      transport.batch([{ method: 'eth_blockNumber' }]),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [RpcTransport.MalformedBatchResponseError: JSON-RPC batch response is malformed.
+
+      Details: Expected an array of JSON-RPC responses.]
+    `)
+  })
+
+  test('throws on missing response id', async () => {
+    const server = await createHttpServer((_, res) => {
+      res.end(JSON.stringify([{ id: 999, jsonrpc: '2.0', result: '0x1' }]))
+    })
+
+    const transport = RpcTransport.fromHttp(server.url)
+
+    await expect(() =>
+      transport.batch([{ method: 'eth_blockNumber' }]),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [RpcTransport.MalformedBatchResponseError: JSON-RPC batch response is malformed.
+
+      Details: Missing response for id 0.]
+    `)
+  })
+})
+
+describe('fromHttp: retry', () => {
+  test('retries on 5xx and eventually succeeds', async () => {
+    let attempts = 0
+    const server = await createHttpServer((_, res) => {
+      attempts++
+      if (attempts < 3) {
+        res.statusCode = 503
+        res.end()
+        return
+      }
+      res.end(JSON.stringify({ id: 0, jsonrpc: '2.0', result: '0xff' }))
+    })
+
+    const transport = RpcTransport.fromHttp(server.url, {
+      retryCount: 5,
+      retryDelay: 0,
+    })
+
+    const result = await transport.request({ method: 'eth_blockNumber' })
+    expect(result).toBe('0xff')
+    expect(attempts).toBe(3)
+  })
+
+  test('does not retry by default', async () => {
+    let attempts = 0
+    const server = await createHttpServer((_, res) => {
+      attempts++
+      res.statusCode = 503
+      res.end()
+    })
+
+    const transport = RpcTransport.fromHttp(server.url)
+
+    await expect(() =>
+      transport.request({ method: 'eth_blockNumber' }),
+    ).rejects.toThrow(RpcTransport.HttpError)
+    expect(attempts).toBe(1)
+  })
+
+  test('default predicate skips wallet/state-changing methods', async () => {
+    let attempts = 0
+    const server = await createHttpServer((_, res) => {
+      attempts++
+      res.statusCode = 503
+      res.end()
+    })
+
+    const transport = RpcTransport.fromHttp(server.url, {
+      retryCount: 3,
+      retryDelay: 0,
+    })
+
+    await expect(() =>
+      transport.request({
+        method: 'eth_sendTransaction',
+        params: [{} as never],
+      } as never),
+    ).rejects.toThrow(RpcTransport.HttpError)
+    expect(attempts).toBe(1)
+  })
+
+  test('custom shouldRetry overrides default', async () => {
+    let attempts = 0
+    const server = await createHttpServer((_, res) => {
+      attempts++
+      res.statusCode = 503
+      res.end()
+    })
+
+    const transport = RpcTransport.fromHttp(server.url, {
+      retryCount: 2,
+      retryDelay: 0,
+      shouldRetry: () => false,
+    })
+
+    await expect(() =>
+      transport.request({ method: 'eth_blockNumber' }),
+    ).rejects.toThrow(RpcTransport.HttpError)
+    expect(attempts).toBe(1)
+  })
+
+  test('respects retryCount limit', async () => {
+    let attempts = 0
+    const server = await createHttpServer((_, res) => {
+      attempts++
+      res.statusCode = 503
+      res.end()
+    })
+
+    const transport = RpcTransport.fromHttp(server.url, {
+      retryCount: 2,
+      retryDelay: 0,
+    })
+
+    await expect(() =>
+      transport.request({ method: 'eth_blockNumber' }),
+    ).rejects.toThrow(RpcTransport.HttpError)
+    // 1 initial + 2 retries
+    expect(attempts).toBe(3)
+  })
+})
+
 test('exports', () => {
   expect(Object.keys(RpcTransport)).toMatchInlineSnapshot(`
     [
       "fromHttp",
       "HttpError",
       "MalformedResponseError",
+      "EmptyBatchError",
+      "MalformedBatchResponseError",
     ]
   `)
 })

--- a/src/core/_test/index.test.ts
+++ b/src/core/_test/index.test.ts
@@ -49,6 +49,7 @@ test('exports', () => {
       "P256",
       "PersonalMessage",
       "Provider",
+      "ProviderEvents",
       "PublicKey",
       "Rlp",
       "RpcRequest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2087,6 +2087,29 @@ export * as PersonalMessage from './core/PersonalMessage.js'
  */
 export * as Provider from './core/Provider.js'
 /**
+ * Explicit entry point for [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) Provider event
+ * helpers (re-exports {@link ox#Provider.(createEmitter:function)}).
+ *
+ * Use this module if your bundle is request-only today and you want a stable import path that
+ * will keep working as event helpers move out of the request-only path in a future major.
+ *
+ * @example
+ * ```ts twoslash
+ * import { ProviderEvents } from 'ox'
+ *
+ * const emitter = ProviderEvents.createEmitter()
+ *
+ * emitter.on('accountsChanged', (accounts) => {
+ *   console.log(accounts)
+ * })
+ *
+ * emitter.emit('accountsChanged', ['0x...'])
+ * ```
+ *
+ * @category Providers (EIP-1193)
+ */
+export * as ProviderEvents from './core/ProviderEvents.js'
+/**
  * Utility functions for working with ECDSA public keys.
  *
  * @example

--- a/src/window/index.ts
+++ b/src/window/index.ts
@@ -1,7 +1,16 @@
-import type { Provider } from '../core/Provider.js'
+import type {
+  EIP6963AnnounceProviderEvent,
+  EIP6963RequestProviderEvent,
+  Provider,
+} from '../core/Provider.js'
 
 declare global {
   interface Window {
     ethereum?: Provider | undefined
+  }
+
+  interface WindowEventMap {
+    'eip6963:announceProvider': EIP6963AnnounceProviderEvent
+    'eip6963:requestProvider': EIP6963RequestProviderEvent
   }
 }


### PR DESCRIPTION
Additive RPC transport, discovery, and explicit-helper APIs.

Highlights:

- `RpcTransport.fromHttp` gains optional retry hooks (`retryCount`, `retryDelay`, `shouldRetry`) plus `requestRaw` / `batch` helpers.
- Adds EIP-6963 `Provider.discover` / `Provider.announce` and a sibling `ProviderEvents` module that re-exports `createEmitter` for request-only consumers.
- Adds `RpcRequest.build`, `RpcResponse.envelope`, `RpcResponse.parseResult`, and `RpcResponse.parseEnvelope` as explicit-name companions to the broader `from` / `parse` helpers.
- Adds schema-first generic overloads for `Provider.from<MySchema>(provider)` and `RpcTransport.fromHttp<MySchema>(url)`.
- `RpcSchema.from()` and the broad `from` / `parse` aliases are now `@deprecated` in JSDoc but continue to work as compatibility wrappers.
