### PR TITLE
feat(v1): tempo WASM `mineSaltAsync` fallback, `ZoneRpcAuthentication.prepare`, and shared codec refactor

### DIFF
--- a/.changeset/tempo-mine-salt-wasm-fallback.md
+++ b/.changeset/tempo-mine-salt-wasm-fallback.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Improved `tempo` `VirtualMaster.mineSaltAsync`: the single-threaded fallback (`workers: 1`, or environments without `Worker` / `worker_threads`) now runs the same WASM keccak256 loop as the worker pool on the main thread instead of the pure-JS implementation, and the default worker count uses `os.availableParallelism()` on Node/Bun/Deno instead of the browser-only `navigator.hardwareConcurrency` probe.

--- a/.changeset/tempo-zone-rpc-authentication-prepare.md
+++ b/.changeset/tempo-zone-rpc-authentication-prepare.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added `tempo` `ZoneRpcAuthentication.prepare` to pre-compute `fields`, `hash`, `serialized`, and the request `header` once for the common case where the same signed token is reused across many RPC requests.

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -457,21 +457,12 @@ export function fromRpc(authorization: Rpc): Signed {
     authorization
   const signature = SignatureEnvelope.fromRpc(authorization.signature)
 
-  // Unflatten nested allowedCalls into flat scopes
+  // Unflatten nested allowedCalls into flat scopes.
   const scopes = allowedCalls
-    ? allowedCalls.flatMap((callScope) => {
-        if (!callScope.selectorRules || callScope.selectorRules.length === 0)
-          return [{ address: callScope.target }] as Scope[]
-        return callScope.selectorRules.map(
-          (rule): Scope => ({
-            address: callScope.target,
-            selector: normalizeSelector(rule.selector),
-            ...(rule.recipients && rule.recipients.length > 0
-              ? { recipients: rule.recipients }
-              : {}),
-          }),
-        )
-      })
+    ? flattenGroupedScopes(allowedCalls, (callScope) => ({
+        address: callScope.target,
+        rules: callScope.selectorRules,
+      }))
     : undefined
 
   return {
@@ -581,23 +572,27 @@ export function fromTuple<const tuple extends Tuple>(
       : {}),
     ...(typeof scopes !== 'undefined' && Array.isArray(scopes)
       ? {
-          scopes: scopes.flatMap((scopeTuple: any) => {
-            const [address, selectorRules] = scopeTuple
-            // If no selector rules, this is an address-only scope
-            if (!Array.isArray(selectorRules) || selectorRules.length === 0)
-              return [{ address }]
-            // Flatten each selector rule into a separate scope entry
-            return selectorRules.map((ruleTuple: any) => {
-              const [selector, recipients] = ruleTuple
+          scopes: flattenGroupedScopes(
+            scopes as readonly (readonly [
+              Address.Address,
+              readonly (readonly [
+                Hex.Hex,
+                readonly Address.Address[] | undefined,
+              ])[],
+            ])[],
+            (scopeTuple) => {
+              const [address, selectorRules] = scopeTuple
               return {
                 address,
-                selector,
-                ...(Array.isArray(recipients) && recipients.length > 0
-                  ? { recipients }
-                  : {}),
+                rules: Array.isArray(selectorRules)
+                  ? selectorRules.map(([selector, recipients]) => ({
+                      selector,
+                      recipients,
+                    }))
+                  : undefined,
               }
-            })
-          }),
+            },
+          ),
         }
       : {}),
   }
@@ -806,29 +801,13 @@ export function toRpc(authorization: Signed): Rpc {
   const { address, scopes, chainId, expiry, limits, type, signature } =
     authorization
 
-  // Group flat scopes by address into nested allowedCalls wire format
-  const allowedCalls = (() => {
-    if (!scopes) return undefined
-    const grouped = new Map<string, RpcSelectorRule[]>()
-    for (const scope of scopes) {
-      const key = scope.address as string
-      if (!grouped.has(key)) grouped.set(key, [])
-      if (scope.selector) {
-        grouped.get(key)!.push({
-          selector: resolveSelector(scope.selector)!,
-          ...(scope.recipients && scope.recipients.length > 0
-            ? { recipients: scope.recipients }
-            : {}),
-        })
-      }
-    }
-    return [...grouped.entries()].map(
-      ([target, selectorRules]): RpcCallScope => ({
-        target: target as Address.Address,
-        ...(selectorRules.length > 0 ? { selectorRules } : {}),
-      }),
-    )
-  })()
+  // Group flat scopes by address into the nested `allowedCalls` wire format.
+  const allowedCalls = groupScopesByAddress(scopes)?.map(
+    ({ address, rules }): RpcCallScope => ({
+      target: address,
+      ...(rules.length > 0 ? { selectorRules: rules } : {}),
+    }),
+  )
 
   return {
     chainId: chainId === 0n ? '0x' : Hex.fromNumber(chainId),
@@ -905,31 +884,11 @@ export function toTuple<const authorization extends KeyAuthorization>(
     if (limit.period && limit.period > 0) tuple.push(numberToHex(limit.period))
     return tuple
   })
-  // Group flat scopes by address for wire format
-  const callsValue = (() => {
-    if (!scopes) return undefined
-    const grouped = new Map<
-      string,
-      [Hex.Hex, (readonly Address.Address[])[]][]
-    >()
-    for (const scope of scopes) {
-      const key = scope.address as string
-      if (!grouped.has(key)) grouped.set(key, [])
-      if (scope.selector) {
-        grouped
-          .get(key)!
-          .push([
-            resolveSelector(scope.selector)!,
-            (scope.recipients ??
-              []) as unknown as (readonly Address.Address[])[],
-          ])
-      }
-    }
-    return [...grouped.entries()].map(([address, selectorRules]) => [
-      address,
-      selectorRules.map(([selector, recipients]) => [selector, recipients]),
-    ])
-  })()
+  // Group flat scopes by address for the tuple wire format.
+  const callsValue = groupScopesByAddress(scopes)?.map(({ address, rules }) => [
+    address,
+    rules.map((rule) => [rule.selector, rule.recipients ?? []]),
+  ])
   const authorizationTuple = [
     bigintToHex(chainId),
     type,
@@ -984,4 +943,77 @@ function resolveSelector(
   if (!selector) return undefined
   if (selector.startsWith('0x')) return selector as Hex.Hex
   return AbiItem.getSelector(selector)
+}
+
+/**
+ * Internal grouped-scope shape used by both RPC and tuple encoders.
+ *
+ * @internal
+ */
+type GroupedScope = {
+  address: Address.Address
+  rules: RpcSelectorRule[]
+}
+
+/**
+ * Groups a flat `Scope[]` list by address into the wire-native shape used by
+ * both `toRpc` and `toTuple`. Returns `undefined` when `scopes` is undefined
+ * so callers can preserve the "unrestricted" sentinel.
+ *
+ * @internal
+ */
+function groupScopesByAddress(
+  scopes: readonly Scope[] | undefined,
+): GroupedScope[] | undefined {
+  if (!scopes) return undefined
+  const grouped = new Map<string, GroupedScope>()
+  for (const scope of scopes) {
+    const key = scope.address as string
+    let entry = grouped.get(key)
+    if (!entry) {
+      entry = { address: scope.address as Address.Address, rules: [] }
+      grouped.set(key, entry)
+    }
+    if (scope.selector)
+      entry.rules.push({
+        selector: resolveSelector(scope.selector)!,
+        ...(scope.recipients && scope.recipients.length > 0
+          ? { recipients: scope.recipients }
+          : {}),
+      })
+  }
+  return [...grouped.values()]
+}
+
+/**
+ * Flattens a grouped (address, rules) iterable back into the public flat
+ * `Scope[]` form. Used by both `fromRpc` and `fromTuple`.
+ *
+ * @internal
+ */
+function flattenGroupedScopes<T>(
+  groups: readonly T[],
+  read: (group: T) => {
+    address: Address.Address
+    rules:
+      | ReadonlyArray<{
+          selector: Hex.Hex | number[]
+          recipients?: readonly Address.Address[] | undefined
+        }>
+      | undefined
+  },
+): Scope[] {
+  return groups.flatMap((group) => {
+    const { address, rules } = read(group)
+    if (!rules || rules.length === 0) return [{ address }] as Scope[]
+    return rules.map(
+      (rule): Scope => ({
+        address,
+        selector: normalizeSelector(rule.selector),
+        ...(rule.recipients && rule.recipients.length > 0
+          ? { recipients: rule.recipients }
+          : {}),
+      }),
+    )
+  })
 }

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -1,5 +1,5 @@
 import * as Address from '../core/Address.js'
-import type * as Bytes from '../core/Bytes.js'
+import * as Bytes from '../core/Bytes.js'
 import * as Errors from '../core/Errors.js'
 import * as Hex from '../core/Hex.js'
 import type {
@@ -476,24 +476,19 @@ export function deserialize(value: Serialized): SignatureEnvelope {
     const webauthnDataSize = dataSize - 128
     const webauthnData = Hex.slice(data, 0, webauthnDataSize)
 
-    // Parse webauthnData into authenticatorData and clientDataJSON
-    // According to the Rust code, it's authenticatorData || clientDataJSON
-    // We need to find the split point (minimum authenticatorData is 37 bytes)
-    let authenticatorData: Hex.Hex | undefined
-    let clientDataJSON: string | undefined
-
-    // Try to find the JSON start (clientDataJSON should start with '{')
-    for (let split = 37; split < webauthnDataSize; split++) {
-      const potentialJson = Hex.toString(Hex.slice(webauthnData, split))
-      if (potentialJson.startsWith('{') && potentialJson.endsWith('}')) {
-        try {
-          JSON.parse(potentialJson)
-          authenticatorData = Hex.slice(webauthnData, 0, split)
-          clientDataJSON = potentialJson
-          break
-        } catch {}
-      }
-    }
+    // Parse webauthnData into authenticatorData and clientDataJSON.
+    // According to the Rust code, it's authenticatorData || clientDataJSON,
+    // and clientDataJSON is well-formed JSON ending with '}'. The minimum
+    // authenticatorData length is 37 bytes.
+    //
+    // The previous implementation re-decoded a UTF-8 string from every
+    // candidate byte offset (O(n) string allocations + JSON.parse calls).
+    // Decode the byte payload once and only try JSON.parse on actual `{`
+    // candidate positions, which is typically O(1) attempts in practice.
+    const { authenticatorData, clientDataJSON } = parseWebAuthnSplit(
+      webauthnData,
+      webauthnDataSize,
+    ) ?? { authenticatorData: undefined, clientDataJSON: undefined }
 
     if (!authenticatorData || !clientDataJSON)
       throw new InvalidSerializedError({
@@ -1363,4 +1358,40 @@ export class InvalidSerializedError extends Errors.BaseError {
  */
 export class VerificationError extends Errors.BaseError {
   override readonly name = 'SignatureEnvelope.VerificationError'
+}
+
+/**
+ * Splits the WebAuthn `webauthnData` into `authenticatorData` and
+ * `clientDataJSON` by decoding the byte payload once and trying `JSON.parse`
+ * only at candidate `{` byte positions. The previous implementation re-decoded
+ * a UTF-8 string from every byte offset.
+ *
+ * @internal
+ */
+function parseWebAuthnSplit(
+  webauthnData: Hex.Hex,
+  webauthnDataSize: number,
+): { authenticatorData: Hex.Hex; clientDataJSON: string } | undefined {
+  const minAuthenticatorBytes = 37
+  if (webauthnDataSize <= minAuthenticatorBytes) return undefined
+
+  const bytes = Bytes.fromHex(webauthnData)
+  // clientDataJSON must end with the `}` byte.
+  if (bytes[bytes.length - 1] !== 0x7d) return undefined
+
+  const decoder = new TextDecoder('utf-8', { fatal: false })
+
+  for (let split = minAuthenticatorBytes; split < webauthnDataSize; split++) {
+    if (bytes[split] !== 0x7b) continue
+    const candidate = decoder.decode(bytes.subarray(split))
+    try {
+      JSON.parse(candidate)
+      return {
+        authenticatorData: Hex.fromBytes(bytes.subarray(0, split)),
+        clientDataJSON: candidate,
+      }
+    } catch {}
+  }
+
+  return undefined
 }

--- a/src/tempo/TxEnvelopeTempo.ts
+++ b/src/tempo/TxEnvelopeTempo.ts
@@ -326,21 +326,22 @@ export function deserialize(serialized: Serialized): Compute<TxEnvelopeTempo> {
     type,
   } as TxEnvelopeTempo
 
-  if (Hex.validate(gas) && gas !== '0x') transaction.gas = BigInt(gas)
-  if (Hex.validate(nonce))
+  // RLP leaves are guaranteed to be hex strings; the previous `Hex.validate`
+  // calls here were redundant. `'0x'` is the canonical "missing/zero" marker.
+  if (gas && gas !== '0x') transaction.gas = BigInt(gas)
+  if (nonce !== undefined)
     transaction.nonce = nonce === '0x' ? 0n : BigInt(nonce)
-  if (Hex.validate(maxFeePerGas) && maxFeePerGas !== '0x')
+  if (maxFeePerGas && maxFeePerGas !== '0x')
     transaction.maxFeePerGas = BigInt(maxFeePerGas)
-  if (Hex.validate(maxPriorityFeePerGas) && maxPriorityFeePerGas !== '0x')
+  if (maxPriorityFeePerGas && maxPriorityFeePerGas !== '0x')
     transaction.maxPriorityFeePerGas = BigInt(maxPriorityFeePerGas)
-  if (Hex.validate(nonceKey))
+  if (nonceKey !== undefined)
     transaction.nonceKey = nonceKey === '0x' ? 0n : BigInt(nonceKey)
-  if (Hex.validate(validBefore) && validBefore !== '0x')
+  if (validBefore && validBefore !== '0x')
     transaction.validBefore = Number(validBefore)
-  if (Hex.validate(validAfter) && validAfter !== '0x')
+  if (validAfter && validAfter !== '0x')
     transaction.validAfter = Number(validAfter)
-  if (Hex.validate(feeToken) && feeToken !== '0x')
-    transaction.feeToken = feeToken
+  if (feeToken && feeToken !== '0x') transaction.feeToken = feeToken
 
   // Parse calls array
   if (calls && calls !== '0x') {
@@ -395,10 +396,13 @@ export function deserialize(serialized: Serialized): Compute<TxEnvelopeTempo> {
     }
 
   // Recover sender address from the signature if not already set.
+  // The transaction was just produced from a successful RLP parse — there is
+  // no need to re-run `from()` (which only re-resolves `TempoAddress` inputs
+  // and re-asserts) before computing the sign payload.
   if (!transaction.from && signatureEnvelope) {
     try {
       transaction.from = SignatureEnvelope.extractAddress({
-        payload: getSignPayload(from(transaction)),
+        payload: getSignPayload(transaction),
         signature: signatureEnvelope,
         root: true,
       })

--- a/src/tempo/VirtualMaster.ts
+++ b/src/tempo/VirtualMaster.ts
@@ -277,15 +277,17 @@ export async function mineSaltAsync(
     onProgress,
     signal,
     start: start_ = 0n,
-    workers = getDefaultWorkerCount(),
   } = parameters
 
   const address = resolveAddress(parameters.address)
   const start = toFixedHex(start_, 32)
 
   assertCount(count)
-  if (workers !== undefined) assertWorkers(workers)
   throwIfAborted(signal)
+
+  const workers =
+    parameters.workers ?? (await VirtualMasterPool.getDefaultWorkerCount())
+  assertWorkers(workers)
 
   const workerCount = Math.max(
     1,
@@ -346,9 +348,10 @@ export declare namespace mineSaltAsync {
     /**
      * Number of workers to use.
      *
-     * Set to `0` or `1` to disable worker parallelism.
+     * Set to `0` or `1` to use a single-threaded WASM miner on the main
+     * thread instead of spawning a worker pool.
      *
-     * @default os.availableParallelism() - 1
+     * @default `os.availableParallelism() - 1` on Node/Bun/Deno, `navigator.hardwareConcurrency - 1` in the browser, and `1` otherwise.
      */
     workers?: number | undefined
   }
@@ -493,7 +496,9 @@ declare namespace mineSaltWithWorkerPool {
 }
 
 /**
- * Single-threaded chunked fallback when no worker pool is available.
+ * Single-threaded fallback used when worker parallelism is disabled or no
+ * worker pool is available. Prefers a WASM-backed main-thread miner and only
+ * drops to pure JS when WASM cannot be instantiated.
  *
  * @internal
  */
@@ -502,8 +507,39 @@ async function mineSaltAsyncFallback(
   value: mineSaltAsyncFallback.Options,
 ): Promise<mineSalt.ReturnType | undefined> {
   const startedAt = Date.now()
-  const startBigInt = BigInt(value.start)
+  let attempts = 0
 
+  const reportProgress = (added: number) => {
+    attempts += added
+    if (!value.onProgress) return
+    const elapsed = Date.now() - startedAt
+    const seconds = elapsed / 1000
+    value.onProgress({
+      attempts,
+      chunkSize: value.chunkSize,
+      count: value.count,
+      elapsed,
+      progress: Math.min(1, attempts / value.count),
+      rate: seconds === 0 ? 0 : attempts / seconds,
+      workers: 1,
+    })
+  }
+
+  const miner = await VirtualMasterPool.resolveSingleThreaded()
+  if (miner) {
+    const result = await miner.mine({
+      address: value.address,
+      chunkSize: value.chunkSize,
+      count: value.count,
+      onProgress: reportProgress,
+      signal: value.signal,
+      start: value.start,
+    })
+    return result as mineSalt.ReturnType | undefined
+  }
+
+  // Pure JS fallback only when WASM cannot be instantiated.
+  const startBigInt = BigInt(value.start)
   for (let offset = 0; offset < value.count; offset += value.chunkSize) {
     throwIfAborted(value.signal)
 
@@ -514,21 +550,7 @@ async function mineSaltAsyncFallback(
       start: startBigInt + BigInt(offset),
     })
 
-    if (value.onProgress) {
-      const attempts = Math.min(value.count, offset + count)
-      const elapsed = Date.now() - startedAt
-      const seconds = elapsed / 1000
-      value.onProgress({
-        attempts,
-        chunkSize: value.chunkSize,
-        count: value.count,
-        elapsed,
-        progress: Math.min(1, attempts / value.count),
-        rate: seconds === 0 ? 0 : attempts / seconds,
-        workers: 1,
-      })
-    }
-
+    reportProgress(count)
     if (result) return result
 
     // Yield to the event loop between chunks.
@@ -576,19 +598,6 @@ function getAbortError(signal?: AbortSignal): Error {
   const reason = signal?.reason
   if (reason instanceof Error) return reason
   return new Errors.BaseError('The operation was aborted.')
-}
-
-/**
- * Returns the default number of workers for the current platform.
- *
- * @internal
- */
-function getDefaultWorkerCount(): number {
-  if (typeof navigator !== 'undefined') {
-    const c = navigator.hardwareConcurrency
-    if (c && c > 1) return c - 1
-  }
-  return 1
 }
 
 /**

--- a/src/tempo/ZoneRpcAuthentication.ts
+++ b/src/tempo/ZoneRpcAuthentication.ts
@@ -383,8 +383,15 @@ export function serialize(
   const signature = options.signature || authentication.signature
   if (!signature) throw new MissingSignatureError()
 
+  // Skip `SignatureEnvelope.from` re-coercion when the signature is already
+  // a typed envelope object — the common case for `prepare()` callers.
+  const envelope =
+    typeof signature === 'object' && signature !== null && 'type' in signature
+      ? (signature as SignatureEnvelope.SignatureEnvelope)
+      : SignatureEnvelope.from(signature)
+
   return Hex.concat(
-    SignatureEnvelope.serialize(SignatureEnvelope.from(signature)),
+    SignatureEnvelope.serialize(envelope),
     getFields(authentication),
   )
 }
@@ -399,6 +406,76 @@ export declare namespace serialize {
     | getFields.ErrorType
     | MissingSignatureError
     | SignatureEnvelope.CoercionError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Pre-computes the fixed fields, hash, and serialized form of a Zone RPC
+ * authentication token in a single pass. Useful when the same signed token is
+ * sent across many RPC requests — the previous "create once, reuse many"
+ * pattern paid the field/hash/serialization cost on every request.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Secp256k1 } from 'ox'
+ * import { ZoneRpcAuthentication } from 'ox/tempo'
+ *
+ * const authentication = ZoneRpcAuthentication.from({
+ *   chainId: 4217000026,
+ *   expiresAt: 1711235160,
+ *   issuedAt: 1711234560,
+ *   zoneId: 26,
+ * })
+ *
+ * const signature = Secp256k1.sign({
+ *   payload: ZoneRpcAuthentication.getSignPayload(authentication),
+ *   privateKey: '0x...',
+ * })
+ *
+ * const prepared = ZoneRpcAuthentication.prepare(authentication, { signature })
+ *
+ * // Reuse `prepared.serialized` and `prepared.header` across many requests.
+ * fetch(url, { headers: prepared.header })
+ * ```
+ *
+ * @param authentication - The Zone RPC authentication token.
+ * @param options - Preparation options.
+ * @returns A bundle of pre-computed token fields ready to be sent.
+ */
+export function prepare(
+  authentication: PartialBy<ZoneRpcAuthentication, 'version'>,
+  options: prepare.Options = {},
+): prepare.ReturnValue {
+  const fields = getFields(authentication)
+  const authHash = Hash.keccak256(Hex.concat(magicBytes, fields))
+  const serialized = serialize(authentication, options)
+
+  return {
+    fields,
+    hash: authHash,
+    header: { [headerName]: serialized },
+    serialized,
+  }
+}
+
+export declare namespace prepare {
+  type Options = serialize.Options
+
+  type ReturnValue = {
+    /** 29-byte fixed fields suffix. */
+    fields: Fields
+    /** Authorization hash (`keccak256(magicBytes || fields)`). */
+    hash: Hex.Hex
+    /** Pre-built header object keyed by `headerName`. */
+    header: { [K in typeof headerName]: Serialized }
+    /** Hex-encoded serialized authentication token. */
+    serialized: Serialized
+  }
+
+  type ErrorType =
+    | getFields.ErrorType
+    | hash.ErrorType
+    | serialize.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/tempo/internal/virtualMasterPool.ts
+++ b/src/tempo/internal/virtualMasterPool.ts
@@ -17,6 +17,19 @@ export type Message =
     }
   | { type: 'progress'; attempts: number }
 
+/** A mining result returned from a single-threaded WASM session. */
+export type MineResult = Extract<Message, { type: 'found' }>['result']
+
+/** Parameters for a single-threaded WASM mining session. */
+export type MineOptions = {
+  address: string
+  chunkSize: number
+  count: number
+  signal?: AbortSignal | undefined
+  start: string
+  onProgress?: ((attempts: number) => void) | undefined
+}
+
 /** A platform-agnostic worker pool for parallel salt mining. */
 export type Pool = {
   spawn(
@@ -27,6 +40,12 @@ export type Pool = {
 }
 
 let cachedPool: Pool | undefined
+let cachedMiner: Promise<SingleThreadedMiner | undefined> | undefined
+
+/** A WASM-backed miner suitable for running on the main thread. */
+export type SingleThreadedMiner = {
+  mine(options: MineOptions): Promise<MineResult | undefined>
+}
 
 /**
  * Whether the current runtime is Node.js.
@@ -46,6 +65,153 @@ export async function resolve(): Promise<Pool | undefined> {
   if (cachedPool) return cachedPool
   cachedPool = isNode ? await resolveNode() : await resolveBrowser()
   return cachedPool
+}
+
+/**
+ * Returns a recommended default worker count for the current runtime, using
+ * actual process parallelism on Node/Bun/Deno and `navigator.hardwareConcurrency`
+ * in the browser. Falls back to `1` when neither probe is available.
+ *
+ * @internal
+ */
+export async function getDefaultWorkerCount(): Promise<number> {
+  if (isNode) {
+    try {
+      const id = 'node:os'
+      const os = (await import(id)) as {
+        availableParallelism?: () => number
+        cpus?: () => unknown[]
+      }
+      const c = os.availableParallelism?.() ?? os.cpus?.().length
+      if (c && c > 1) return c - 1
+    } catch {}
+  }
+  if (typeof navigator !== 'undefined') {
+    const c = navigator.hardwareConcurrency
+    if (c && c > 1) return c - 1
+  }
+  return 1
+}
+
+/**
+ * Resolves a WASM-backed single-threaded miner for the current runtime.
+ *
+ * Used when no worker pool is available, when the caller explicitly requests
+ * a single worker, or for environments without `Worker` / `worker_threads`
+ * support. The miner runs the same WASM keccak256 loop the worker pool uses,
+ * just on the main thread, yielding to the event loop between chunks.
+ *
+ * @internal
+ */
+export async function resolveSingleThreaded(): Promise<
+  SingleThreadedMiner | undefined
+> {
+  if (cachedMiner) return cachedMiner
+  cachedMiner = (async () => {
+    if (typeof WebAssembly === 'undefined') return undefined
+    const { wasmBase64, dataOffset } = await import('./mine.wasm.js')
+    const binary = decodeBase64(wasmBase64)
+    const { instance } = await WebAssembly.instantiate(binary)
+    const exports = instance.exports as {
+      memory: WebAssembly.Memory
+      mine: (count: number) => number
+    }
+    const mem = new Uint8Array(exports.memory.buffer)
+    return {
+      async mine(options) {
+        return mineMainThread(options, exports, mem, dataOffset)
+      },
+    }
+  })()
+  return cachedMiner
+}
+
+/**
+ * Decodes a base64 string into bytes. `atob` is available in modern browsers
+ * and Node 16+; this mirrors the inline worker bootstrap.
+ *
+ * @internal
+ */
+function decodeBase64(value: string): Uint8Array {
+  const binary = atob(value)
+  const out = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+  return out
+}
+
+/**
+ * Runs the WASM mining loop on the main thread, yielding between chunks so
+ * that an aborted signal or unrelated work can make progress.
+ *
+ * @internal
+ */
+async function mineMainThread(
+  options: MineOptions,
+  exports: { mine: (count: number) => number },
+  mem: Uint8Array,
+  dataOffset: number,
+): Promise<MineResult | undefined> {
+  const addressBytes = hexToBytes(options.address)
+  const startBigInt = BigInt(options.start)
+
+  mem.set(addressBytes, dataOffset)
+
+  for (let offset = 0; offset < options.count; offset += options.chunkSize) {
+    if (options.signal?.aborted) throw getAbortError(options.signal)
+
+    const limit = Math.min(options.chunkSize, options.count - offset)
+    bigIntToBytes32(startBigInt + BigInt(offset), mem, dataOffset + 20)
+
+    const found = exports.mine(limit)
+    if (found) {
+      const hashOut = mem.slice(dataOffset + 52, dataOffset + 84)
+      const salt = mem.slice(dataOffset + 20, dataOffset + 52)
+      return {
+        masterId: bytesToHex(hashOut.subarray(4, 8)),
+        registrationHash: bytesToHex(hashOut),
+        salt: bytesToHex(salt),
+      }
+    }
+
+    options.onProgress?.(limit)
+
+    // Yield to the event loop between chunks.
+    await new Promise<void>((r) => setTimeout(r, 0))
+  }
+  return undefined
+}
+
+/** @internal */
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith('0x') ? hex.slice(2) : hex
+  const out = new Uint8Array(h.length / 2)
+  for (let i = 0; i < out.length; i++)
+    out[i] = Number.parseInt(h.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+/** @internal */
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = '0x'
+  for (let i = 0; i < bytes.length; i++)
+    hex += bytes[i]!.toString(16).padStart(2, '0')
+  return hex
+}
+
+/** @internal */
+function bigIntToBytes32(value: bigint, out: Uint8Array, offset: number) {
+  let v = value
+  for (let i = 31; i >= 0; i--) {
+    out[offset + i] = Number(v & 0xffn)
+    v >>= 8n
+  }
+}
+
+/** @internal */
+function getAbortError(signal?: AbortSignal): Error {
+  const reason = signal?.reason
+  if (reason instanceof Error) return reason
+  return new Errors.BaseError('The operation was aborted.')
 }
 
 /**


### PR DESCRIPTION
Tempo additions, perf rewrites, and shared-codec refactor.

Highlights:

- Adds a WASM `mineSaltAsync` fallback: `workers: 1` (or environments without `Worker` / `worker_threads`) now run the same WASM keccak256 loop as the worker pool on the main thread instead of the pure-JS implementation.
- Default worker count now uses `os.availableParallelism()` on Node/Bun/Deno instead of the browser-only `navigator.hardwareConcurrency` probe.
- Adds `ZoneRpcAuthentication.prepare` to pre-compute `fields`, `hash`, `serialized`, and the request `header` once for the common case where the same signed token is reused across many RPC requests.
- Rewrites `TxEnvelopeTempo` and the WebAuthn envelope hot paths.
- Factors shared `Authorization`, `KeyAuthorization`, and transaction codecs into reusable internal modules.
