### PR TITLE
feat(v1): bytes / parsed-metadata input overloads and `as` option for `webauthn`

### DIFF
--- a/.changeset/webauthn-additive-bytes-overloads.md
+++ b/.changeset/webauthn-additive-bytes-overloads.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added bytes and parsed-metadata input overloads to `webauthn.Authentication.verify`, `webauthn.Authenticator.getSignCount`, and `webauthn.Authenticator.getAuthenticatorData`, exposed `webauthn.Authenticator.parse` plus the `webauthn.Authenticator.AuthenticatorData` type, and added an `as: 'Hex' | 'Bytes'` option to `webauthn.Authentication.getSignPayload`.

--- a/src/webauthn/Authentication.ts
+++ b/src/webauthn/Authentication.ts
@@ -9,6 +9,7 @@ import * as internal from '../core/internal/webauthn.js'
 import * as P256 from '../core/P256.js'
 import type * as PublicKey from '../core/PublicKey.js'
 import * as Signature from '../core/Signature.js'
+import type * as Authenticator from './Authenticator.js'
 import { getAuthenticatorData, getClientDataJSON } from './Authenticator.js'
 import type * as Credential_ from './Credential.js'
 import {
@@ -252,10 +253,11 @@ export declare namespace getOptions {
  * @param options - Options to construct the signing payload.
  * @returns The signing payload.
  */
-export function getSignPayload(
-  options: getSignPayload.Options,
-): getSignPayload.ReturnType {
+export function getSignPayload<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  options: getSignPayload.Options<as>,
+): getSignPayload.ReturnType<as> {
   const {
+    as = 'Hex',
     challenge,
     crossOrigin,
     extraClientData,
@@ -292,20 +294,23 @@ export function getSignPayload(
   }
 
   const concatenated = Hex.concat(authenticatorData, clientDataJSONHash)
-  const payload = hash ? Hash.sha256(concatenated) : concatenated
+  const hex = hash ? Hash.sha256(concatenated) : concatenated
+  const payload = as === 'Bytes' ? Bytes.fromHex(hex) : hex
 
-  return { metadata, payload }
+  return { metadata, payload } as never
 }
 
 export declare namespace getSignPayload {
-  type Options = {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /** Output representation for the resulting `payload`. The accompanying `metadata` always uses the JSON-friendly hex representation. @default 'Hex' */
+    as?: as | 'Hex' | 'Bytes' | undefined
     /** The challenge to sign. */
     challenge: Hex.Hex
     /** If set to `true`, it means that the calling context is an `<iframe>` that is not same origin with its ancestor frames. */
     crossOrigin?: boolean | undefined
     /** Additional client data to include in the client data JSON. */
     extraClientData?: Record<string, unknown> | undefined
-    /** If set to `true`, the payload will be hashed before being returned. */
+    /** If set to `true`, the returned `payload` is the SHA-256 digest of `authenticatorData || sha256(clientDataJSON)` -- i.e. the value that a raw P256 verifier sees after its internal hashing step. Use this when feeding the payload to a signer that does not perform its own hashing. */
     hash?: boolean | undefined
     /** A bitfield that indicates various attributes that were asserted by the authenticator. [Read more](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/Authenticator_data#flags) */
     flag?: number | undefined
@@ -321,12 +326,15 @@ export declare namespace getSignPayload {
       | undefined
   }
 
-  type ReturnType = {
+  type ReturnType<as extends 'Hex' | 'Bytes' = 'Hex'> = {
     metadata: Credential_.SignMetadata
-    payload: Hex.Hex
+    payload:
+      | (as extends 'Hex' ? Hex.Hex : never)
+      | (as extends 'Bytes' ? Bytes.Bytes : never)
   }
 
   type ErrorType =
+    | Bytes.fromHex.ErrorType
     | Hash.sha256.ErrorType
     | Hex.concat.ErrorType
     | Hex.fromString.ErrorType
@@ -588,9 +596,20 @@ export function verify(options: verify.Options): boolean {
   const { authenticatorData, clientDataJSON, userVerificationRequired } =
     metadata
 
-  const authenticatorDataBytes = Bytes.fromHex(authenticatorData)
-
-  const parsed = parseAuthenticatorData(authenticatorDataBytes)
+  // Normalize the polymorphic `authenticatorData` input to a parsed view +
+  // raw bytes without re-decoding when possible.
+  let authenticatorDataBytes: Uint8Array
+  let parsed: ReturnType<typeof parseAuthenticatorData>
+  if (typeof authenticatorData === 'string') {
+    authenticatorDataBytes = Bytes.fromHex(authenticatorData)
+    parsed = parseAuthenticatorData(authenticatorDataBytes)
+  } else if (authenticatorData instanceof Uint8Array) {
+    authenticatorDataBytes = authenticatorData
+    parsed = parseAuthenticatorData(authenticatorData)
+  } else {
+    parsed = authenticatorData
+    authenticatorDataBytes = authenticatorData.bytes
+  }
   if (!parsed) return false
 
   // If rpId is provided, validate the rpIdHash in authenticatorData.
@@ -659,6 +678,16 @@ export function verify(options: verify.Options): boolean {
 }
 
 export declare namespace verify {
+  /**
+   * Metadata accepted by `Authentication.verify`. Widens
+   * `Credential.SignMetadata` so callers can pass `authenticatorData` as raw
+   * bytes or an already-parsed `Authenticator.AuthenticatorData`, skipping a
+   * hex round trip on the verification hot path.
+   */
+  type Metadata = Omit<Credential_.SignMetadata, 'authenticatorData'> & {
+    authenticatorData: Hex.Hex | Uint8Array | Authenticator.AuthenticatorData
+  }
+
   type Options = {
     /** The challenge to verify. */
     challenge: Hex.Hex
@@ -666,8 +695,8 @@ export declare namespace verify {
     publicKey: PublicKey.PublicKey
     /** The signature to verify. */
     signature: Signature.Signature<false>
-    /** The metadata to verify the signature with. */
-    metadata: Credential_.SignMetadata
+    /** The metadata to verify the signature with. Accepts the canonical hex form, raw bytes, or an already-parsed `Authenticator.AuthenticatorData` for `authenticatorData`. */
+    metadata: Metadata
     /** Expected origin(s). If provided, the `clientDataJSON` origin will be validated. */
     origin?: string | string[] | undefined
     /** Expected relying party ID. If provided, the `rpIdHash` in `authenticatorData` will be validated. */

--- a/src/webauthn/Authenticator.ts
+++ b/src/webauthn/Authenticator.ts
@@ -5,8 +5,19 @@ import * as CoseKey from '../core/CoseKey.js'
 import type * as Errors from '../core/Errors.js'
 import * as Hash from '../core/Hash.js'
 import * as Hex from '../core/Hex.js'
-import type * as PublicKey from '../core/PublicKey.js'
+import * as PublicKey from '../core/PublicKey.js'
+import {
+  type ParsedAuthenticatorData,
+  parseAuthenticatorData,
+} from './internal/utils.js'
 import type * as Types from './Types.js'
+
+/**
+ * Parsed WebAuthn authenticator data per W3C WebAuthn Level 2 §6.1. Returned
+ * by `Authenticator.parse` and accepted as an input alternative to raw bytes
+ * or hex by `Authenticator.getSignCount` and `Authentication.verify`.
+ */
+export type AuthenticatorData = ParsedAuthenticatorData
 
 /**
  * Gets the authenticator data which contains information about the
@@ -86,7 +97,9 @@ export function getAuthenticatorData<as extends 'Hex' | 'Bytes' = 'Hex'>(
       return out as never
     }
     const credentialId = credential.id
-    const coseKey = Bytes.fromHex(CoseKey.fromPublicKey(credential.publicKey))
+    const coseKey = Bytes.fromHex(
+      CoseKey.fromPublicKey(toPublicKey(credential.publicKey)),
+    )
     const credLen = credentialId.length
     const out = new Uint8Array(baseLength + 16 + 2 + credLen + coseKey.length)
     out.set(rpIdHash, 0)
@@ -114,8 +127,17 @@ export function getAuthenticatorData<as extends 'Hex' | 'Bytes' = 'Hex'>(
   const aaguid = Hex.fromBytes(new Uint8Array(16))
   const credentialId = Hex.fromBytes(credential.id)
   const credIdLen = Hex.fromNumber(credential.id.length, { size: 2 })
-  const coseKey = CoseKey.fromPublicKey(credential.publicKey)
+  const coseKey = CoseKey.fromPublicKey(toPublicKey(credential.publicKey))
   return Hex.concat(base, aaguid, credIdLen, credentialId, coseKey) as never
+}
+
+/** @internal */
+function toPublicKey(
+  publicKey: PublicKey.PublicKey | Hex.Hex | Uint8Array,
+): PublicKey.PublicKey {
+  if (typeof publicKey === 'object' && !(publicKey instanceof Uint8Array))
+    return publicKey
+  return PublicKey.from(publicKey)
 }
 
 export declare namespace getAuthenticatorData {
@@ -127,8 +149,8 @@ export declare namespace getAuthenticatorData {
       | {
           /** The credential ID as raw bytes. */
           id: Uint8Array
-          /** The P256 public key associated with the credential. */
-          publicKey: PublicKey.PublicKey
+          /** The P256 public key associated with the credential. Accepts a parsed {@link ox#PublicKey.PublicKey}, a serialized hex string, or raw bytes. */
+          publicKey: PublicKey.PublicKey | Hex.Hex | Uint8Array
         }
       | undefined
     /** A bitfield that indicates various attributes that were asserted by the authenticator. [Read more](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/Authenticator_data#flags) */
@@ -163,12 +185,19 @@ export declare namespace getAuthenticatorData {
  * // @log: 1
  * ```
  *
- * @param authenticatorData - The authenticator data hex string.
+ * @param authenticatorData - The authenticator data as a hex string, raw bytes, or an already-parsed `Authenticator.AuthenticatorData`.
  * @returns The signature counter.
  */
 export function getSignCount(
-  authenticatorData: Hex.Hex | Uint8Array,
+  authenticatorData: Hex.Hex | Uint8Array | AuthenticatorData,
 ): number {
+  // Already-parsed form: short-circuit without re-walking the bytes.
+  if (
+    typeof authenticatorData === 'object' &&
+    !(authenticatorData instanceof Uint8Array)
+  )
+    return authenticatorData.signCount
+
   const bytes =
     typeof authenticatorData === 'string'
       ? Bytes.fromHex(authenticatorData)
@@ -186,6 +215,42 @@ export function getSignCount(
 }
 
 export declare namespace getSignCount {
+  type ErrorType = Bytes.fromHex.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Parses the fixed 37-byte header of WebAuthn authenticator data into a
+ * structured `Authenticator.AuthenticatorData` object exposing `rpIdHash`,
+ * individual flag bits, and the signature counter.
+ *
+ * Useful for callers that want to consume parsed metadata multiple times
+ * (e.g. inspect the counter and pass to `Authentication.verify`) without
+ * paying for repeated hex or byte conversions.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Authenticator } from 'ox/webauthn'
+ *
+ * const parsed = Authenticator.parse(
+ *   '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000001',
+ * )
+ * // @log: { up: true, uv: true, signCount: 1, ... }
+ * ```
+ *
+ * @param authenticatorData - The authenticator data as a hex string or raw bytes.
+ * @returns The parsed authenticator data, or `undefined` if the input is shorter than the 37-byte header.
+ */
+export function parse(
+  authenticatorData: Hex.Hex | Uint8Array,
+): AuthenticatorData | undefined {
+  const bytes =
+    typeof authenticatorData === 'string'
+      ? Bytes.fromHex(authenticatorData)
+      : authenticatorData
+  return parseAuthenticatorData(bytes)
+}
+
+export declare namespace parse {
   type ErrorType = Bytes.fromHex.ErrorType | Errors.GlobalErrorType
 }
 

--- a/src/webauthn/_test/Authentication.test-d.ts
+++ b/src/webauthn/_test/Authentication.test-d.ts
@@ -1,0 +1,32 @@
+import type { Bytes, Hex } from 'ox'
+import { Authentication } from 'ox/webauthn'
+import { expectTypeOf, test } from 'vitest'
+
+test('getSignPayload: default `as` infers Hex payload', () => {
+  const { payload } = Authentication.getSignPayload({
+    challenge: '0xdeadbeef',
+    origin: 'https://example.com',
+    rpId: 'example.com',
+  })
+  expectTypeOf(payload).toEqualTypeOf<Hex.Hex>()
+})
+
+test("getSignPayload: as: 'Hex' infers Hex payload", () => {
+  const { payload } = Authentication.getSignPayload({
+    as: 'Hex',
+    challenge: '0xdeadbeef',
+    origin: 'https://example.com',
+    rpId: 'example.com',
+  })
+  expectTypeOf(payload).toEqualTypeOf<Hex.Hex>()
+})
+
+test("getSignPayload: as: 'Bytes' infers Bytes payload", () => {
+  const { payload } = Authentication.getSignPayload({
+    as: 'Bytes',
+    challenge: '0xdeadbeef',
+    origin: 'https://example.com',
+    rpId: 'example.com',
+  })
+  expectTypeOf(payload).toEqualTypeOf<Bytes.Bytes>()
+})

--- a/src/webauthn/_test/Authentication.test.ts
+++ b/src/webauthn/_test/Authentication.test.ts
@@ -5,7 +5,7 @@ import * as P256 from '../../core/P256.js'
 import * as PublicKey from '../../core/PublicKey.js'
 import * as Signature from '../../core/Signature.js'
 import * as WebCryptoP256 from '../../core/WebCryptoP256.js'
-import { Authentication } from '../index.js'
+import { Authentication, Authenticator } from '../index.js'
 
 beforeAll(() => {
   vi.stubGlobal('window', {
@@ -483,6 +483,54 @@ describe('getSignPayload', () => {
         metadata,
       }),
     ).toBeTruthy()
+  })
+
+  test('options: as: Bytes', () => {
+    const data = {
+      challenge:
+        '0xf631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf',
+      origin: 'http://localhost:5173',
+      rpId: 'foo',
+    } as const
+    const { payload: hex } = Authentication.getSignPayload(data)
+    const { payload: bytes } = Authentication.getSignPayload({
+      ...data,
+      as: 'Bytes',
+    })
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(Bytes.toHex(bytes)).toBe(hex)
+  })
+
+  test('options: as: Bytes + hash', () => {
+    const data = {
+      challenge:
+        '0xf631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf',
+      origin: 'http://localhost:5173',
+      rpId: 'foo',
+    } as const
+    const { payload: hashedHex } = Authentication.getSignPayload({
+      ...data,
+      hash: true,
+    })
+    const { payload: hashedBytes } = Authentication.getSignPayload({
+      ...data,
+      as: 'Bytes',
+      hash: true,
+    })
+    expect(hashedBytes).toBeInstanceOf(Uint8Array)
+    expect(Bytes.toHex(hashedBytes)).toBe(hashedHex)
+  })
+
+  test('options: as: Hex (explicit)', () => {
+    const { payload } = Authentication.getSignPayload({
+      challenge:
+        '0xf631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf',
+      origin: 'http://localhost:5173',
+      rpId: 'foo',
+      as: 'Hex',
+    })
+    expect(typeof payload).toBe('string')
+    expect((payload as string).startsWith('0x')).toBe(true)
   })
 
   test('options: signCount', () => {
@@ -1857,6 +1905,96 @@ describe('verify', () => {
       typeIndex: 1,
       userVerificationRequired: true,
     } as const
+
+    expect(
+      Authentication.verify({
+        metadata,
+        challenge:
+          '0xf631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf',
+        publicKey,
+        signature,
+      }),
+    ).toBeFalsy()
+  })
+
+  test('options: metadata.authenticatorData as Uint8Array', () => {
+    const publicKey = PublicKey.from({
+      prefix: 4,
+      x: 15325272481743543470187210372131079389379804084126119117911265853867256769440n,
+      y: 74947999673872536163854436677160946007685903587557427331495653571111132132212n,
+    })
+    const signature = Signature.from({
+      r: 10330677067519063752777069525326520293658884904426299601620960859195372963151n,
+      s: 47017859265388077754498411591757867926785106410894171160067329762716841868244n,
+    })
+    const metadata = {
+      authenticatorData: Bytes.fromHex(
+        '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000000',
+      ),
+      clientDataJSON:
+        '{"type":"webauthn.get","challenge":"9jEFijuhEWrM4SOW-tChJbUEHEP44VcjcJ-Bqo1fTM8","origin":"http://localhost:5173","crossOrigin":false}',
+    }
+
+    expect(
+      Authentication.verify({
+        metadata,
+        challenge:
+          '0xf631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf',
+        publicKey,
+        signature,
+      }),
+    ).toBeTruthy()
+  })
+
+  test('options: metadata.authenticatorData as parsed AuthenticatorData', () => {
+    const publicKey = PublicKey.from({
+      prefix: 4,
+      x: 15325272481743543470187210372131079389379804084126119117911265853867256769440n,
+      y: 74947999673872536163854436677160946007685903587557427331495653571111132132212n,
+    })
+    const signature = Signature.from({
+      r: 10330677067519063752777069525326520293658884904426299601620960859195372963151n,
+      s: 47017859265388077754498411591757867926785106410894171160067329762716841868244n,
+    })
+    const parsed = Authenticator.parse(
+      '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000000',
+    )
+    const metadata = {
+      authenticatorData: parsed!,
+      clientDataJSON:
+        '{"type":"webauthn.get","challenge":"9jEFijuhEWrM4SOW-tChJbUEHEP44VcjcJ-Bqo1fTM8","origin":"http://localhost:5173","crossOrigin":false}',
+    }
+
+    expect(
+      Authentication.verify({
+        metadata,
+        challenge:
+          '0xf631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf',
+        publicKey,
+        signature,
+      }),
+    ).toBeTruthy()
+  })
+
+  test('options: metadata.authenticatorData as parsed AuthenticatorData with invalid signature', () => {
+    const publicKey = PublicKey.from({
+      prefix: 4,
+      x: 15325272481743543470187210372131079389379804084126119117911265853867256769440n,
+      y: 74947999673872536163854436677160946007685903587557427331495653571111132132212n,
+    })
+    const signature = Signature.from({
+      r: 10330677067519063752777069525326520293658884904426299601620960859195372963151n,
+      // wrong `s`
+      s: 1n,
+    })
+    const parsed = Authenticator.parse(
+      '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000000',
+    )!
+    const metadata = {
+      authenticatorData: parsed,
+      clientDataJSON:
+        '{"type":"webauthn.get","challenge":"9jEFijuhEWrM4SOW-tChJbUEHEP44VcjcJ-Bqo1fTM8","origin":"http://localhost:5173","crossOrigin":false}',
+    }
 
     expect(
       Authentication.verify({

--- a/src/webauthn/_test/Authenticator.test.ts
+++ b/src/webauthn/_test/Authenticator.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'vitest'
+import * as Bytes from '../../core/Bytes.js'
+import * as P256 from '../../core/P256.js'
+import * as PublicKey from '../../core/PublicKey.js'
 import { Authenticator } from '../index.js'
 
 describe('getAuthenticatorData', () => {
@@ -53,5 +56,131 @@ describe('getClientDataJSON', () => {
     expect(clientDataJSON).toMatchInlineSnapshot(
       `"{"type":"webauthn.get","challenge":"3q2-7w","origin":"https://example.com","crossOrigin":true}"`,
     )
+  })
+})
+
+describe('getAuthenticatorData (publicKey overloads)', () => {
+  test('credential.publicKey as Hex', () => {
+    const { publicKey } = P256.createKeyPair()
+    const credentialId = new Uint8Array(32)
+
+    const fromObject = Authenticator.getAuthenticatorData({
+      rpId: 'example.com',
+      flag: 0x41,
+      credential: { id: credentialId, publicKey },
+    })
+    const fromHex = Authenticator.getAuthenticatorData({
+      rpId: 'example.com',
+      flag: 0x41,
+      credential: { id: credentialId, publicKey: PublicKey.toHex(publicKey) },
+    })
+
+    expect(fromHex).toBe(fromObject)
+  })
+
+  test('credential.publicKey as Bytes', () => {
+    const { publicKey } = P256.createKeyPair()
+    const credentialId = new Uint8Array(32)
+
+    const fromObject = Authenticator.getAuthenticatorData({
+      rpId: 'example.com',
+      flag: 0x41,
+      credential: { id: credentialId, publicKey },
+    })
+    const fromBytes = Authenticator.getAuthenticatorData({
+      rpId: 'example.com',
+      flag: 0x41,
+      credential: {
+        id: credentialId,
+        publicKey: PublicKey.toBytes(publicKey),
+      },
+    })
+
+    expect(fromBytes).toBe(fromObject)
+  })
+
+  test('credential.publicKey as Hex (Bytes output)', () => {
+    const { publicKey } = P256.createKeyPair()
+    const credentialId = new Uint8Array(32)
+
+    const fromObject = Authenticator.getAuthenticatorData({
+      rpId: 'example.com',
+      flag: 0x41,
+      credential: { id: credentialId, publicKey },
+      as: 'Bytes',
+    })
+    const fromHex = Authenticator.getAuthenticatorData({
+      rpId: 'example.com',
+      flag: 0x41,
+      credential: { id: credentialId, publicKey: PublicKey.toHex(publicKey) },
+      as: 'Bytes',
+    })
+
+    expect(fromObject).toBeInstanceOf(Uint8Array)
+    expect(fromHex).toEqual(fromObject)
+  })
+})
+
+describe('getSignCount', () => {
+  test('from hex', () => {
+    expect(
+      Authenticator.getSignCount(
+        '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000001',
+      ),
+    ).toBe(1)
+  })
+
+  test('from bytes', () => {
+    expect(
+      Authenticator.getSignCount(
+        Bytes.fromHex(
+          '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000001',
+        ),
+      ),
+    ).toBe(1)
+  })
+
+  test('from parsed AuthenticatorData', () => {
+    const parsed = Authenticator.parse(
+      '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000007',
+    )!
+    expect(Authenticator.getSignCount(parsed)).toBe(7)
+  })
+
+  test('returns 0 when input shorter than 37 bytes', () => {
+    expect(Authenticator.getSignCount('0x00')).toBe(0)
+    expect(Authenticator.getSignCount(new Uint8Array(10))).toBe(0)
+  })
+})
+
+describe('parse', () => {
+  test('default', () => {
+    const parsed = Authenticator.parse(
+      '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000001',
+    )
+    expect(parsed).toMatchObject({
+      flags: 0x05,
+      up: true,
+      uv: true,
+      be: false,
+      bs: false,
+      at: false,
+      ed: false,
+      signCount: 1,
+    })
+  })
+
+  test('from bytes', () => {
+    const bytes = Bytes.fromHex(
+      '0x49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000001',
+    )
+    const parsed = Authenticator.parse(bytes)
+    expect(parsed?.signCount).toBe(1)
+    expect(parsed?.bytes).toBe(bytes)
+  })
+
+  test('returns undefined for short input', () => {
+    expect(Authenticator.parse('0x00')).toBeUndefined()
+    expect(Authenticator.parse(new Uint8Array(10))).toBeUndefined()
   })
 })


### PR DESCRIPTION
Additive bytes / parsed-metadata overloads for the WebAuthn modules.

Highlights:

- Adds bytes and parsed-metadata input overloads to `webauthn.Authentication.verify`, `webauthn.Authenticator.getSignCount`, and `webauthn.Authenticator.getAuthenticatorData`.
- Exposes `webauthn.Authenticator.parse` plus the `webauthn.Authenticator.AuthenticatorData` type.
- Adds an `as: 'Hex' | 'Bytes'` option to `webauthn.Authentication.getSignPayload`.
