### PR TITLE
feat(v1): canonical `encode`/`decode` for `Base32`/`Base58`/`Base64`/`CompactSize`/`Rlp` codecs

### DIFF
--- a/.changeset/encoding-canonical-encode-decode.md
+++ b/.changeset/encoding-canonical-encode-decode.md
@@ -1,0 +1,42 @@
+---
+"ox": major
+---
+
+Unified the `Base32`, `Base58`, `Base64`, `CompactSize`, and `Rlp` modules around canonical `encode` / `decode` entrypoints that accept `Bytes`/`Hex`/`string` inputs and gate the output shape via an `as` option, replacing the per-shape `from*` / `to*` exports.
+
+```diff
+-Base32.fromBytes(bytes)
+-Base32.fromHex(hex)
+-Base32.toBytes(str)
+-Base32.toHex(str)
++Base32.encode(bytesOrHex)
++Base32.decode(str)              // -> Bytes
++Base32.decode(str, { as: 'Hex' })
+
+-Base58.fromBytes(bytes); Base58.fromHex(hex); Base58.fromString(str)
+-Base58.toBytes(str); Base58.toHex(str); Base58.toString(str)
++Base58.encode(bytesOrHexOrString)
++Base58.decode(str)              // -> Bytes
++Base58.decode(str, { as: 'Hex' | 'String' })
+
+-Base64.fromBytes(bytes, opts); Base64.fromHex(hex, opts); Base64.fromString(str, opts)
+-Base64.toBytes(str); Base64.toHex(str); Base64.toString(str)
++Base64.encode(bytesOrHexOrString, opts)
++Base64.decode(str)              // -> Bytes
++Base64.decode(str, { as: 'Hex' | 'String' })
+
+-CompactSize.toBytes(n); CompactSize.toHex(n)
+-CompactSize.fromBytes(bytes); CompactSize.fromHex(hex)
++CompactSize.encode(n)           // -> Bytes
++CompactSize.encode(n, { as: 'Hex' })
++CompactSize.decode(bytesOrHex)
+
+-Rlp.from(value, { as }); Rlp.fromBytes(value); Rlp.fromHex(value)
+-Rlp.toBytes(value); Rlp.toHex(value)
++Rlp.encode(value)               // -> Bytes
++Rlp.encode(value, { as: 'Hex' })
++Rlp.decode(value)               // -> RecursiveArray<Bytes>
++Rlp.decode(value, { as: 'Hex' })
+```
+
+Also flipped the default for `Bech32m.encode` / `Bech32m.decode`'s `limit` option from `90` to `undefined` (no limit). Pass `{ limit: 90 }` explicitly to restore BIP-173 segwit-style length capping.

--- a/site/pages/guides/rlp.md
+++ b/site/pages/guides/rlp.md
@@ -13,33 +13,33 @@ RLP is commonly used for use cases on Ethereum Applications such as:
 
 ### Encoding
 
-We can serialize arbitrary data into RLP-encoded format using the [`Rlp.fromHex`](/api/Rlp/fromHex) or [`Rlp.fromBytes`](/api/Rlp/fromBytes) functions.
+We can serialize arbitrary data into RLP-encoded format using the [`Rlp.encode`](/api/Rlp/encode) function. Pass `{ as: 'Hex' }` to receive a hex string, or omit the option for a `Bytes` value.
 
 ```ts twoslash
 import { Hex, Rlp } from 'ox'
 
-const rlp = Rlp.fromHex([
+const rlp = Rlp.encode([
   Hex.fromString('hello'),
   Hex.fromNumber(1337),
   [Hex.fromString('foo'), Hex.fromString('bar')],
-])
+], { as: 'Hex' })
 // @log: 0xd28568656c6c6f820539c883666f6f83626172
 ```
 
 ### Decoding
 
-We can deserialize RLP-encoded data into its original format using the [`Rlp.toHex`](/api/Rlp/toHex) or [`Rlp.toBytes`](/api/Rlp/toBytes) functions.
+We can deserialize RLP-encoded data into its original format using the [`Rlp.decode`](/api/Rlp/decode) function. Pass `{ as: 'Hex' }` to receive a `Hex` tree, or omit the option for a `Bytes` tree.
 
 ```ts twoslash
 import { Hex, Rlp } from 'ox'
 
-const rlp = Rlp.fromHex([
+const rlp = Rlp.encode([
   Hex.fromString('hello'),
   Hex.fromNumber(1337),
   [Hex.fromString('foo'), Hex.fromString('bar')],
-])
+], { as: 'Hex' })
 
-const values = Rlp.toHex(rlp) // [!code focus]
+const values = Rlp.decode(rlp, { as: 'Hex' }) // [!code focus]
 // @log: [Hex.fromString('hello'), Hex.fromNumber(1337), [Hex.fromString('foo'), Hex.fromString('bar')]]
 ```
 

--- a/site/pages/imports.md
+++ b/site/pages/imports.md
@@ -14,7 +14,7 @@ Modules can be imported via their respective module export in the root `ox` name
 ```ts twoslash
 import { Hex, Rlp } from 'ox'
 
-const rlp = Rlp.fromHex([Hex.fromString('hello'), Hex.fromString('world')])
+const rlp = Rlp.encode([Hex.fromString('hello'), Hex.fromString('world')], { as: 'Hex' })
 ```
 
 This approach does not compromise on [tree-shakability](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking), as most modern bundlers support Deep Scope Analysis. As a result, this will not impact the bundle size of your application.
@@ -30,7 +30,7 @@ If your bundler does not support Deep Scope Analysis, you are also able to impor
 import * as Hex from 'ox/Hex'
 import * as Rlp from 'ox/Rlp'
 
-const rlp = Rlp.fromHex([Hex.fromString('hello'), Hex.fromString('world')])
+const rlp = Rlp.encode([Hex.fromString('hello'), Hex.fromString('world')], { as: 'Hex' })
 ```
 
 ## Tree Shakability & Bundle Size

--- a/site/pages/index.md
+++ b/site/pages/index.md
@@ -33,7 +33,7 @@ Below is an example of using the [`Hex`](/api/Hex) and [`Rlp`](/api/Rlp) modules
 ```ts twoslash
 import { Hex, Rlp } from 'ox'
 
-const rlp = Rlp.fromHex([Hex.fromString('hello'), Hex.fromString('world')])
+const rlp = Rlp.encode([Hex.fromString('hello'), Hex.fromString('world')], { as: 'Hex' })
 ```
 
 :::tip

--- a/src/core/Authorization.ts
+++ b/src/core/Authorization.ts
@@ -421,7 +421,7 @@ export function hash(
   return Hash.keccak256(
     Hex.concat(
       '0x05',
-      Rlp.fromHex(
+      Rlp.encode(
         toTuple(
           presign
             ? {
@@ -431,6 +431,7 @@ export function hash(
               }
             : authorization,
         ),
+        { as: 'Hex' },
       ),
     ),
   )
@@ -441,7 +442,7 @@ export declare namespace hash {
     | toTuple.ErrorType
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 
   type Options = {

--- a/src/core/Base32.ts
+++ b/src/core/Base32.ts
@@ -8,65 +8,58 @@ import {
 } from './internal/codec/bech32-base32.js'
 
 /**
- * Encodes a {@link ox#Bytes.Bytes} value to a Base32-encoded string (using the BIP-173 bech32 alphabet).
+ * Encodes a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value to a Base32-encoded string (using the BIP-173 bech32 alphabet).
  *
  * @example
  * ```ts twoslash
- * import { Base32, Bytes } from 'ox'
+ * import { Base32 } from 'ox'
  *
- * const value = Base32.fromBytes(new Uint8Array([0x00, 0xff, 0x00]))
+ * Base32.encode(new Uint8Array([0x00, 0xff, 0x00]))
+ * // @log: 'qrlsq'
+ *
+ * Base32.encode('0x00ff00')
+ * // @log: 'qrlsq'
  * ```
  *
- * @param value - The byte array to encode.
+ * @param value - The byte array or hex value to encode.
  * @returns The Base32 encoded string.
  */
-export function fromBytes(value: Bytes.Bytes): string {
-  const data5 = convertBits(value, 8, 5, true)
+export function encode(value: Bytes.Bytes | Hex.Hex): string {
+  const bytes = value instanceof Uint8Array ? value : Bytes.fromHex(value)
+  const data5 = convertBits(bytes, 8, 5, true)
   const len = data5.length
   const out = new Array<string>(len)
   for (let i = 0; i < len; i++) out[i] = alphabet[data5[i]!]!
   return out.join('')
 }
 
-export declare namespace fromBytes {
-  type ErrorType = Errors.GlobalErrorType
+export declare namespace encode {
+  type ErrorType = Bytes.fromHex.ErrorType | Errors.GlobalErrorType
 }
 
 /**
- * Encodes a {@link ox#Hex.Hex} value to a Base32-encoded string (using the BIP-173 bech32 alphabet).
+ * Decodes a Base32-encoded string (using the BIP-173 bech32 alphabet) to a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
  *
  * @example
  * ```ts twoslash
  * import { Base32 } from 'ox'
  *
- * const value = Base32.fromHex('0x00ff00')
- * ```
+ * Base32.decode('qrlsq')
+ * // @log: Uint8Array [ 0, 255, 0 ]
  *
- * @param value - The hex value to encode.
- * @returns The Base32 encoded string.
- */
-export function fromHex(value: Hex.Hex): string {
-  return fromBytes(Bytes.fromHex(value))
-}
-
-export declare namespace fromHex {
-  type ErrorType = fromBytes.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a Base32-encoded string (using the BIP-173 bech32 alphabet) to {@link ox#Bytes.Bytes}.
- *
- * @example
- * ```ts twoslash
- * import { Base32 } from 'ox'
- *
- * const value = Base32.toBytes('qqsa0')
+ * Base32.decode('qrlsq', { as: 'Hex' })
+ * // @log: '0x00ff00'
  * ```
  *
  * @param value - The Base32 encoded string.
- * @returns The decoded byte array.
+ * @param options - Decoding options.
+ * @returns The decoded value.
  */
-export function toBytes(value: string): Bytes.Bytes {
+export function decode<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  value: string,
+  options: decode.Options<as> = {},
+): decode.ReturnType<as> {
+  const { as = 'Bytes' } = options
   const len = value.length
   const values = new Array<number>(len)
   for (let i = 0; i < len; i++) {
@@ -79,42 +72,32 @@ export function toBytes(value: string): Bytes.Bytes {
   let bits = 0
   let acc = 0
   // Worst-case: every 5 bits maps to up to 1 byte; preallocate.
-  const bytes = new Uint8Array((len * 5) >> 3)
+  const buffer = new Uint8Array((len * 5) >> 3)
   let n = 0
   for (let i = 0; i < len; i++) {
     acc = (acc << 5) | values[i]!
     bits += 5
     if (bits >= 8) {
       bits -= 8
-      bytes[n++] = (acc >>> bits) & 0xff
+      buffer[n++] = (acc >>> bits) & 0xff
     }
   }
-  return bytes.subarray(0, n)
+  const bytes = buffer.subarray(0, n)
+  if (as === 'Hex') return Hex.fromBytes(bytes) as decode.ReturnType<as>
+  return bytes as decode.ReturnType<as>
 }
 
-export declare namespace toBytes {
+export declare namespace decode {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> = {
+    /** The format to return the decoded value in. @default 'Bytes' */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
   type ErrorType = InvalidCharacterError | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a Base32-encoded string (using the BIP-173 bech32 alphabet) to {@link ox#Hex.Hex}.
- *
- * @example
- * ```ts twoslash
- * import { Base32 } from 'ox'
- *
- * const value = Base32.toHex('qqsa0')
- * ```
- *
- * @param value - The Base32 encoded string.
- * @returns The decoded hex string.
- */
-export function toHex(value: string): Hex.Hex {
-  return Hex.fromBytes(toBytes(value))
-}
-
-export declare namespace toHex {
-  type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
 }
 
 /** Thrown when a Base32 string contains an invalid character. */

--- a/src/core/Base58.ts
+++ b/src/core/Base58.ts
@@ -4,108 +4,90 @@ import * as Hex from './Hex.js'
 import * as internal from './internal/base58.js'
 
 /**
- * Encodes a {@link ox#Bytes.Bytes} to a Base58-encoded string.
+ * Encodes a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or string value to a Base58-encoded string.
+ *
+ * A string input that starts with `0x` is treated as hex; any other string is
+ * encoded as its UTF-8 byte representation.
  *
  * @example
  * ```ts twoslash
- * import { Base58, Bytes } from 'ox'
+ * import { Base58, Bytes, Hex } from 'ox'
  *
- * const value = Base58.fromBytes(Bytes.fromString('Hello World!'))
+ * Base58.encode(Bytes.fromString('Hello World!'))
+ * // @log: '2NEpo7TZRRrLZSi2U'
+ *
+ * Base58.encode(Hex.fromString('Hello World!'))
+ * // @log: '2NEpo7TZRRrLZSi2U'
+ *
+ * Base58.encode('Hello World!')
  * // @log: '2NEpo7TZRRrLZSi2U'
  * ```
  *
- * @param value - The byte array to encode.
+ * @param value - The byte array, hex value, or string to encode.
  * @returns The Base58 encoded string.
  */
-export function fromBytes(value: Bytes.Bytes) {
-  return internal.from(value)
-}
-
-export declare namespace fromBytes {
-  type ErrorType = internal.from.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Encodes a {@link ox#Hex.Hex} to a Base58-encoded string.
- *
- * @example
- * ```ts twoslash
- * import { Base58, Hex } from 'ox'
- *
- * const value = Base58.fromHex(Hex.fromString('Hello World!'))
- * // @log: '2NEpo7TZRRrLZSi2U'
- * ```
- *
- * @param value - The byte array to encode.
- * @returns The Base58 encoded string.
- */
-export function fromHex(value: Hex.Hex) {
-  return internal.from(value)
-}
-
-export declare namespace fromHex {
-  type ErrorType = internal.from.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Encodes a string to a Base58-encoded string.
- *
- * @example
- * ```ts twoslash
- * import { Base58 } from 'ox'
- *
- * const value = Base58.fromString('Hello World!')
- * // @log: '2NEpo7TZRRrLZSi2U'
- * ```
- *
- * @param value - The string to encode.
- * @returns The Base58 encoded string.
- */
-export function fromString(value: string) {
+export function encode(value: Bytes.Bytes | Hex.Hex | string): string {
+  if (value instanceof Uint8Array) return internal.from(value)
+  if (typeof value === 'string' && value.startsWith('0x'))
+    return internal.from(value as Hex.Hex)
   return internal.from(Bytes.fromString(value))
 }
 
-export declare namespace fromString {
+export declare namespace encode {
   type ErrorType = internal.from.ErrorType | Errors.GlobalErrorType
 }
 
 /**
- * Decodes a Base58-encoded string to a {@link ox#Bytes.Bytes}.
+ * Decodes a Base58-encoded string to a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or string value.
  *
  * @example
  * ```ts twoslash
  * import { Base58 } from 'ox'
  *
- * const value = Base58.toBytes('2NEpo7TZRRrLZSi2U')
+ * Base58.decode('2NEpo7TZRRrLZSi2U')
  * // @log: Uint8Array [ 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33 ]
- * ```
  *
- * @param value - The Base58 encoded string.
- * @returns The decoded byte array.
- */
-export function toBytes(value: string): Bytes.Bytes {
-  return Bytes.fromHex(toHex(value))
-}
-
-export declare namespace toBytes {
-  type ErrorType = Errors.GlobalErrorType
-}
-
-/**
- * Decodes a Base58-encoded string to {@link ox#Hex.Hex}.
- *
- * @example
- * ```ts twoslash
- * import { Base58 } from 'ox'
- *
- * const value = Base58.toHex('2NEpo7TZRRrLZSi2U')
+ * Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'Hex' })
  * // @log: '0x48656c6c6f20576f726c6421'
+ *
+ * Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'String' })
+ * // @log: 'Hello World!'
  * ```
  *
  * @param value - The Base58 encoded string.
- * @returns The decoded hex string.
+ * @param options - Decoding options.
+ * @returns The decoded value.
  */
-export function toHex(value: string): Hex.Hex {
+export function decode<as extends 'Bytes' | 'Hex' | 'String' = 'Bytes'>(
+  value: string,
+  options: decode.Options<as> = {},
+): decode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  const hex = decodeToHex(value)
+  if (as === 'String') return Hex.toString(hex) as decode.ReturnType<as>
+  if (as === 'Hex') return hex as decode.ReturnType<as>
+  return Bytes.fromHex(hex) as decode.ReturnType<as>
+}
+
+export declare namespace decode {
+  type Options<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > = {
+    /** The format to return the decoded value in. @default 'Bytes' */
+    as?: as | 'Bytes' | 'Hex' | 'String' | undefined
+  }
+
+  type ReturnType<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'String' ? string : never)
+
+  type ErrorType = InvalidCharacterError | Errors.GlobalErrorType
+}
+
+function decodeToHex(value: string): Hex.Hex {
   if (value.length === 0) return '0x'
 
   let integer = BigInt(0)
@@ -130,32 +112,6 @@ export function toHex(value: string): Hex.Hex {
   let body = integer === 0n ? '' : integer.toString(16)
   if ((body.length & 1) !== 0) body = `0${body}`
   return `0x${'00'.repeat(pad)}${body}` as Hex.Hex
-}
-
-export declare namespace toHex {
-  type ErrorType = InvalidCharacterError | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a Base58-encoded string to a string.
- *
- * @example
- * ```ts twoslash
- * import { Base58 } from 'ox'
- *
- * const value = Base58.toString('2NEpo7TZRRrLZSi2U')
- * // @log: 'Hello World!'
- * ```
- *
- * @param value - The Base58 encoded string.
- * @returns The decoded string.
- */
-export function toString(value: string): string {
-  return Hex.toString(toHex(value))
-}
-
-export declare namespace toString {
-  type ErrorType = Errors.GlobalErrorType
 }
 
 /** Thrown when a Base58 string contains an invalid character. */

--- a/src/core/Base64.bench.ts
+++ b/src/core/Base64.bench.ts
@@ -5,66 +5,66 @@ const small = new Uint8Array(32).map((_, i) => i)
 const medium = new Uint8Array(256).map((_, i) => i & 0xff)
 const large = new Uint8Array(4096).map((_, i) => i & 0xff)
 
-const smallEncoded = Base64.fromBytes(small)
-const mediumEncoded = Base64.fromBytes(medium)
-const largeEncoded = Base64.fromBytes(large)
+const smallEncoded = Base64.encode(small)
+const mediumEncoded = Base64.encode(medium)
+const largeEncoded = Base64.encode(large)
 
-const smallEncodedNoPad = Base64.fromBytes(small, { pad: false })
-const smallEncodedUrl = Base64.fromBytes(small, { url: true })
+const smallEncodedNoPad = Base64.encode(small, { pad: false })
+const smallEncodedUrl = Base64.encode(small, { url: true })
 
 const helloString = 'hello world'
 const loremString = 'lorem ipsum '.repeat(64)
 
-describe('Base64.fromBytes', () => {
+describe('Base64.encode (Bytes input)', () => {
   bench('32 bytes (padded)', () => {
-    Base64.fromBytes(small)
+    Base64.encode(small)
   })
   bench('256 bytes (padded)', () => {
-    Base64.fromBytes(medium)
+    Base64.encode(medium)
   })
   bench('4096 bytes (padded)', () => {
-    Base64.fromBytes(large)
+    Base64.encode(large)
   })
   bench('32 bytes (no pad)', () => {
-    Base64.fromBytes(small, { pad: false })
+    Base64.encode(small, { pad: false })
   })
   bench('32 bytes (url)', () => {
-    Base64.fromBytes(small, { url: true })
+    Base64.encode(small, { url: true })
   })
 })
 
-describe('Base64.toBytes', () => {
+describe('Base64.decode', () => {
   bench('32 bytes (padded)', () => {
-    Base64.toBytes(smallEncoded)
+    Base64.decode(smallEncoded)
   })
   bench('256 bytes (padded)', () => {
-    Base64.toBytes(mediumEncoded)
+    Base64.decode(mediumEncoded)
   })
   bench('4096 bytes (padded)', () => {
-    Base64.toBytes(largeEncoded)
+    Base64.decode(largeEncoded)
   })
   bench('32 bytes (no pad)', () => {
-    Base64.toBytes(smallEncodedNoPad)
+    Base64.decode(smallEncodedNoPad)
   })
   bench('32 bytes (url)', () => {
-    Base64.toBytes(smallEncodedUrl)
+    Base64.decode(smallEncodedUrl)
   })
 })
 
-describe('Base64.fromString / toString', () => {
-  const helloEncoded = Base64.fromString(helloString)
-  const loremEncoded = Base64.fromString(loremString)
+describe('Base64.encode (String input) / decode (String output)', () => {
+  const helloEncoded = Base64.encode(helloString)
+  const loremEncoded = Base64.encode(loremString)
 
   bench('fromString hello', () => {
-    Base64.fromString(helloString)
+    Base64.encode(helloString)
   })
   bench('fromString lorem (768 chars)', () => {
-    Base64.fromString(loremString)
+    Base64.encode(loremString)
   })
   bench('toString hello', () => {
-    Base64.toString(helloEncoded)
+    Base64.decode(helloEncoded, { as: 'String' })
   })
   bench('toString lorem (768 chars)', () => {
-    Base64.toString(loremEncoded)
+    Base64.decode(loremEncoded, { as: 'String' })
   })
 })

--- a/src/core/Base64.ts
+++ b/src/core/Base64.ts
@@ -63,13 +63,19 @@ const nativeFromBase64:
 ).fromBase64
 
 /**
- * Encodes a {@link ox#Bytes.Bytes} to a Base64-encoded string (with optional padding and/or URL-safe characters).
+ * Encodes a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or string value to a Base64-encoded string (with optional padding and/or URL-safe characters).
  *
  * @example
  * ```ts twoslash
- * import { Base64, Bytes } from 'ox'
+ * import { Base64, Bytes, Hex } from 'ox'
  *
- * const value = Base64.fromBytes(Bytes.fromString('hello world'))
+ * Base64.encode(Bytes.fromString('hello world'))
+ * // @log: 'aGVsbG8gd29ybGQ='
+ *
+ * Base64.encode(Hex.fromString('hello world'))
+ * // @log: 'aGVsbG8gd29ybGQ='
+ *
+ * Base64.encode('hello world')
  * // @log: 'aGVsbG8gd29ybGQ='
  * ```
  *
@@ -79,56 +85,66 @@ const nativeFromBase64:
  * Turn off [padding of encoded data](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2) with the `pad` option:
  *
  * ```ts twoslash
- * import { Base64, Bytes } from 'ox'
+ * import { Base64 } from 'ox'
  *
- * const value = Base64.fromBytes(Bytes.fromString('hello world'), { pad: false })
+ * Base64.encode('hello world', { pad: false })
  * // @log: 'aGVsbG8gd29ybGQ'
  * ```
  *
+ * @example
  * ### URL-safe Encoding
  *
  * Turn on [URL-safe encoding](https://datatracker.ietf.org/doc/html/rfc4648#section-5) (Base64 URL) with the `url` option:
  *
  * ```ts twoslash
- * import { Base64, Bytes } from 'ox'
+ * import { Base64 } from 'ox'
  *
- * const value = Base64.fromBytes(Bytes.fromString('hello wod'), { url: true })
+ * Base64.encode('hello wod', { url: true })
  * // @log: 'aGVsbG8gd29_77-9ZA=='
  * ```
  *
- * @param value - The byte array to encode.
+ * @param value - The byte array, hex value, or string to encode.
  * @param options - Encoding options.
  * @returns The Base64 encoded string.
  */
-export function fromBytes(value: Bytes.Bytes, options: fromBytes.Options = {}) {
+export function encode(
+  value: Bytes.Bytes | Hex.Hex | string,
+  options: encode.Options = {},
+): string {
+  const bytes =
+    value instanceof Uint8Array
+      ? value
+      : typeof value === 'string' && value.startsWith('0x')
+        ? Bytes.fromHex(value as Hex.Hex)
+        : Bytes.fromString(value)
   const { pad = true, url = false } = options
 
   if (nativeToBase64) {
-    const out = nativeToBase64.call(value, {
+    const out = nativeToBase64.call(bytes, {
       alphabet: url ? 'base64url' : 'base64',
       omitPadding: !pad,
     })
     // Native `base64url` already omits padding; if pad was requested, restore it.
     if (url && pad) {
-      const k = value.length % 3
+      const k = bytes.length % 3
       if (k === 1) return `${out}==`
       if (k === 2) return `${out}=`
     }
     return out
   }
 
-  const encoded = new Uint8Array(Math.ceil(value.length / 3) * 4)
+  const encoded = new Uint8Array(Math.ceil(bytes.length / 3) * 4)
 
-  for (let i = 0, j = 0; j < value.length; i += 4, j += 3) {
-    const y = (value[j]! << 16) + (value[j + 1]! << 8) + (value[j + 2]! | 0)
+  for (let i = 0, j = 0; j < bytes.length; i += 4, j += 3) {
+    const y = (bytes[j]! << 16) + (bytes[j + 1]! << 8) + (bytes[j + 2]! | 0)
     encoded[i] = integerToCharacter[y >> 18]!
     encoded[i + 1] = integerToCharacter[(y >> 12) & 0x3f]!
     encoded[i + 2] = integerToCharacter[(y >> 6) & 0x3f]!
     encoded[i + 3] = integerToCharacter[y & 0x3f]!
   }
 
-  const k = value.length % 3
-  const end = Math.floor(value.length / 3) * 4 + (k && k + 1)
+  const k = bytes.length % 3
+  const end = Math.floor(bytes.length / 3) * 4 + (k && k + 1)
   let base64 = decoder.decode(new Uint8Array(encoded.buffer, 0, end))
   if (pad && k === 1) base64 += '=='
   if (pad && k === 2) base64 += '='
@@ -136,7 +152,7 @@ export function fromBytes(value: Bytes.Bytes, options: fromBytes.Options = {}) {
   return base64
 }
 
-export declare namespace fromBytes {
+export declare namespace encode {
   type Options = {
     /**
      * Whether to [pad](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2) the Base64 encoded string.
@@ -152,146 +168,67 @@ export declare namespace fromBytes {
     url?: boolean | undefined
   }
 
-  type ErrorType = Errors.GlobalErrorType
+  type ErrorType =
+    | Bytes.fromHex.ErrorType
+    | Bytes.fromString.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /**
- * Encodes a {@link ox#Hex.Hex} to a Base64-encoded string (with optional padding and/or URL-safe characters).
- *
- * @example
- * ```ts twoslash
- * import { Base64, Hex } from 'ox'
- *
- * const value = Base64.fromHex(Hex.fromString('hello world'))
- * // @log: 'aGVsbG8gd29ybGQ='
- * ```
- *
- * @example
- * ### No Padding
- *
- * Turn off [padding of encoded data](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2) with the `pad` option:
- *
- * ```ts twoslash
- * import { Base64, Hex } from 'ox'
- *
- * const value = Base64.fromHex(Hex.fromString('hello world'), { pad: false })
- * // @log: 'aGVsbG8gd29ybGQ'
- * ```
- *
- * ### URL-safe Encoding
- *
- * Turn on [URL-safe encoding](https://datatracker.ietf.org/doc/html/rfc4648#section-5) (Base64 URL) with the `url` option:
- *
- * ```ts twoslash
- * import { Base64, Hex } from 'ox'
- *
- * const value = Base64.fromHex(Hex.fromString('hello wod'), { url: true })
- * // @log: 'aGVsbG8gd29_77-9ZA=='
- * ```
- *
- * @param value - The hex value to encode.
- * @param options - Encoding options.
- * @returns The Base64 encoded string.
- */
-export function fromHex(value: Hex.Hex, options: fromHex.Options = {}) {
-  return fromBytes(Bytes.fromHex(value), options)
-}
-
-export declare namespace fromHex {
-  type Options = {
-    /**
-     * Whether to [pad](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2) the Base64 encoded string.
-     *
-     * @default true
-     */
-    pad?: boolean | undefined
-    /**
-     * Whether to Base64 encode with [URL safe characters](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
-     *
-     * @default false
-     */
-    url?: boolean | undefined
-  }
-
-  type ErrorType = fromBytes.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Encodes a string to a Base64-encoded string (with optional padding and/or URL-safe characters).
+ * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to a {@link ox#Bytes.Bytes}, {@link ox#Hex.Hex}, or string value.
  *
  * @example
  * ```ts twoslash
  * import { Base64 } from 'ox'
  *
- * const value = Base64.fromString('hello world')
- * // @log: 'aGVsbG8gd29ybGQ='
- * ```
- *
- * @example
- * ### No Padding
- *
- * Turn off [padding of encoded data](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2) with the `pad` option:
- *
- * ```ts twoslash
- * import { Base64 } from 'ox'
- *
- * const value = Base64.fromString('hello world', { pad: false })
- * // @log: 'aGVsbG8gd29ybGQ'
- * ```
- *
- * ### URL-safe Encoding
- *
- * Turn on [URL-safe encoding](https://datatracker.ietf.org/doc/html/rfc4648#section-5) (Base64 URL) with the `url` option:
- *
- * ```ts twoslash
- * import { Base64 } from 'ox'
- *
- * const value = Base64.fromString('hello wod', { url: true })
- * // @log: 'aGVsbG8gd29_77-9ZA=='
- * ```
- *
- * @param value - The string to encode.
- * @param options - Encoding options.
- * @returns The Base64 encoded string.
- */
-export function fromString(value: string, options: fromString.Options = {}) {
-  return fromBytes(Bytes.fromString(value), options)
-}
-
-export declare namespace fromString {
-  type Options = {
-    /**
-     * Whether to [pad](https://datatracker.ietf.org/doc/html/rfc4648#section-3.2) the Base64 encoded string.
-     *
-     * @default true
-     */
-    pad?: boolean | undefined
-    /**
-     * Whether to Base64 encode with [URL safe characters](https://datatracker.ietf.org/doc/html/rfc4648#section-5).
-     *
-     * @default false
-     */
-    url?: boolean | undefined
-  }
-
-  type ErrorType = fromBytes.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to {@link ox#Bytes.Bytes}.
- *
- * @example
- * ```ts twoslash
- * import { Base64, Bytes } from 'ox'
- *
- * const value = Base64.toBytes('aGVsbG8gd29ybGQ=')
+ * Base64.decode('aGVsbG8gd29ybGQ=')
  * // @log: Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+ *
+ * Base64.decode('aGVsbG8gd29ybGQ=', { as: 'Hex' })
+ * // @log: '0x68656c6c6f20776f726c64'
+ *
+ * Base64.decode('aGVsbG8gd29ybGQ=', { as: 'String' })
+ * // @log: 'hello world'
  * ```
  *
- * @param value - The string, hex value, or byte array to encode.
- * @returns The Base64 decoded {@link ox#Bytes.Bytes}.
+ * @param value - The Base64 encoded string.
+ * @param options - Decoding options.
+ * @returns The decoded value.
  */
-export function toBytes(value: string): Bytes.Bytes {
+export function decode<as extends 'Bytes' | 'Hex' | 'String' = 'Bytes'>(
+  value: string,
+  options: decode.Options<as> = {},
+): decode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  const bytes = decodeToBytes(value)
+  if (as === 'String') return Bytes.toString(bytes) as decode.ReturnType<as>
+  if (as === 'Hex') return Hex.fromBytes(bytes) as decode.ReturnType<as>
+  return bytes as decode.ReturnType<as>
+}
+
+export declare namespace decode {
+  type Options<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > = {
+    /** The format to return the decoded value in. @default 'Bytes' */
+    as?: as | 'Bytes' | 'Hex' | 'String' | undefined
+  }
+
+  type ReturnType<
+    as extends 'Bytes' | 'Hex' | 'String' = 'Bytes' | 'Hex' | 'String',
+  > =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+    | (as extends 'String' ? string : never)
+
+  type ErrorType =
+    | InvalidCharacterError
+    | InvalidLengthError
+    | InvalidPaddingError
+    | Errors.GlobalErrorType
+}
+
+function decodeToBytes(value: string): Bytes.Bytes {
   // Strip trailing '=' padding (only at the very end).
   let bodyEnd = value.length
   let pad = 0
@@ -340,58 +277,6 @@ export function toBytes(value: string): Bytes.Bytes {
     }
   }
   return decoded
-}
-
-export declare namespace toBytes {
-  type ErrorType =
-    | InvalidCharacterError
-    | InvalidLengthError
-    | InvalidPaddingError
-    | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to {@link ox#Hex.Hex}.
- *
- * @example
- * ```ts twoslash
- * import { Base64, Hex } from 'ox'
- *
- * const value = Base64.toHex('aGVsbG8gd29ybGQ=')
- * // @log: 0x68656c6c6f20776f726c64
- * ```
- *
- * @param value - The string, hex value, or byte array to encode.
- * @returns The Base64 decoded {@link ox#Hex.Hex}.
- */
-export function toHex(value: string): Hex.Hex {
-  return Hex.fromBytes(toBytes(value))
-}
-
-export declare namespace toHex {
-  type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a Base64-encoded string (with optional padding and/or URL-safe characters) to a string.
- *
- * @example
- * ```ts twoslash
- * import { Base64 } from 'ox'
- *
- * const value = Base64.toString('aGVsbG8gd29ybGQ=')
- * // @log: 'hello world'
- * ```
- *
- * @param value - The string, hex value, or byte array to encode.
- * @returns The Base64 decoded string.
- */
-export function toString(value: string): string {
-  return Bytes.toString(toBytes(value))
-}
-
-export declare namespace toString {
-  type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
 }
 
 /** Thrown when a Base64 string contains an invalid character. */

--- a/src/core/Bech32m.ts
+++ b/src/core/Bech32m.ts
@@ -27,7 +27,7 @@ export function encode(
   data: Uint8Array,
   options: encode.Options = {},
 ): string {
-  const { limit = 90 } = options
+  const { limit } = options
 
   hrp = hrp.toLowerCase()
 
@@ -39,7 +39,7 @@ export function encode(
 
   const data5 = convertBits(data, 8, 5, true)
 
-  if (hrp.length + 1 + data5.length + 6 > limit)
+  if (limit !== undefined && hrp.length + 1 + data5.length + 6 > limit)
     throw new ExceedsLengthError({ limit })
 
   const checksum = createChecksum(hrp, data5)
@@ -50,7 +50,11 @@ export function encode(
 
 export declare namespace encode {
   type Options = {
-    /** Maximum length of the encoded string. @default 90 */
+    /**
+     * Maximum length of the encoded string. When `undefined`, no limit is
+     * enforced. Set explicitly (e.g. `90` for BIP-173 segwit addresses) to
+     * cap length.
+     */
     limit?: number | undefined
   }
 
@@ -75,9 +79,10 @@ export function decode(
   str: string,
   options: decode.Options = {},
 ): decode.ReturnType {
-  const { limit = 90 } = options
+  const { limit } = options
 
-  if (str.length > limit) throw new ExceedsLengthError({ limit })
+  if (limit !== undefined && str.length > limit)
+    throw new ExceedsLengthError({ limit })
 
   if (str !== str.toLowerCase() && str !== str.toUpperCase())
     throw new MixedCaseError()
@@ -111,7 +116,11 @@ export function decode(
 
 export declare namespace decode {
   type Options = {
-    /** Maximum length of the encoded string. @default 90 */
+    /**
+     * Maximum length of the encoded string. When `undefined`, no limit is
+     * enforced. Set explicitly (e.g. `90` for BIP-173 segwit addresses) to
+     * cap length.
+     */
     limit?: number | undefined
   }
 

--- a/src/core/CompactSize.ts
+++ b/src/core/CompactSize.ts
@@ -16,17 +16,44 @@ import * as Hex from './Hex.js'
  * ```ts twoslash
  * import { CompactSize } from 'ox'
  *
- * const bytes = CompactSize.toBytes(252)
- * // Uint8Array [252]
+ * CompactSize.encode(252)
+ * // @log: Uint8Array [252]
  *
- * const bytes2 = CompactSize.toBytes(253)
- * // Uint8Array [253, 253, 0]
+ * CompactSize.encode(253, { as: 'Hex' })
+ * // @log: '0xfdfd00'
  * ```
  *
  * @param value - The integer to encode.
- * @returns The CompactSize-encoded bytes.
+ * @param options - Encoding options.
+ * @returns The CompactSize-encoded value.
  */
-export function toBytes(value: bigint | number): Bytes.Bytes {
+export function encode<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  value: bigint | number,
+  options: encode.Options<as> = {},
+): encode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+  const bytes = encodeToBytes(value)
+  if (as === 'Hex') return Hex.fromBytes(bytes) as encode.ReturnType<as>
+  return bytes as encode.ReturnType<as>
+}
+
+export declare namespace encode {
+  type Options<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> = {
+    /** The format to return the encoded value in. @default 'Bytes' */
+    as?: as | 'Bytes' | 'Hex' | undefined
+  }
+
+  type ReturnType<as extends 'Bytes' | 'Hex' = 'Bytes' | 'Hex'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | InvalidValueError
+    | NegativeValueError
+    | Errors.GlobalErrorType
+}
+
+function encodeToBytes(value: bigint | number): Bytes.Bytes {
   if (typeof value === 'number' && !Number.isSafeInteger(value))
     throw new InvalidValueError({ value })
   const n = BigInt(value)
@@ -53,50 +80,25 @@ export function toBytes(value: bigint | number): Bytes.Bytes {
   return buf
 }
 
-export declare namespace toBytes {
-  type ErrorType =
-    | InvalidValueError
-    | NegativeValueError
-    | Errors.GlobalErrorType
-}
-
 /**
- * Encodes an integer using Bitcoin's CompactSize variable-length encoding and returns it as {@link ox#Hex.Hex}.
+ * Decodes a CompactSize-encoded value from {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex}.
  *
  * @example
  * ```ts twoslash
  * import { CompactSize } from 'ox'
  *
- * const hex = CompactSize.toHex(252)
- * // '0xfc'
+ * CompactSize.decode(new Uint8Array([0xfd, 0x00, 0x01]))
+ * // @log: { value: 256n, size: 3 }
+ *
+ * CompactSize.decode('0xfd0001')
+ * // @log: { value: 256n, size: 3 }
  * ```
  *
- * @param value - The integer to encode.
- * @returns The CompactSize-encoded hex string.
- */
-export function toHex(value: bigint | number): Hex.Hex {
-  return Hex.fromBytes(toBytes(value))
-}
-
-export declare namespace toHex {
-  type ErrorType = toBytes.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a CompactSize-encoded value from {@link ox#Bytes.Bytes}.
- *
- * @example
- * ```ts twoslash
- * import { CompactSize } from 'ox'
- *
- * const result = CompactSize.fromBytes(new Uint8Array([0xfd, 0x00, 0x01]))
- * // { value: 256, size: 3 }
- * ```
- *
- * @param data - The bytes to decode from.
+ * @param value - The bytes or hex string to decode from.
  * @returns The decoded value and number of bytes consumed.
  */
-export function fromBytes(data: Bytes.Bytes): fromBytes.ReturnType {
+export function decode(value: Bytes.Bytes | Hex.Hex): decode.ReturnType {
+  const data = value instanceof Uint8Array ? value : Bytes.fromHex(value)
   if (data.length === 0)
     throw new InsufficientBytesError({ expected: 1, actual: 0 })
   const first = data[0]!
@@ -105,28 +107,28 @@ export function fromBytes(data: Bytes.Bytes): fromBytes.ReturnType {
   if (first === 0xfd) {
     if (data.length < 3)
       throw new InsufficientBytesError({ expected: 3, actual: data.length })
-    const value = view.getUint16(1, true)
-    if (value < 0xfd) throw new NonMinimalEncodingError()
-    return { value: BigInt(value), size: 3 }
+    const result = view.getUint16(1, true)
+    if (result < 0xfd) throw new NonMinimalEncodingError()
+    return { value: BigInt(result), size: 3 }
   }
   if (first === 0xfe) {
     if (data.length < 5)
       throw new InsufficientBytesError({ expected: 5, actual: data.length })
-    const value = view.getUint32(1, true)
-    if (value <= 0xffff) throw new NonMinimalEncodingError()
-    return { value: BigInt(value), size: 5 }
+    const result = view.getUint32(1, true)
+    if (result <= 0xffff) throw new NonMinimalEncodingError()
+    return { value: BigInt(result), size: 5 }
   }
   if (data.length < 9)
     throw new InsufficientBytesError({ expected: 9, actual: data.length })
-  const value = view.getBigUint64(1, true)
-  if (value <= 0xffffffffn) throw new NonMinimalEncodingError()
+  const result = view.getBigUint64(1, true)
+  if (result <= 0xffffffffn) throw new NonMinimalEncodingError()
   return {
-    value,
+    value: result,
     size: 9,
   }
 }
 
-export declare namespace fromBytes {
+export declare namespace decode {
   type ReturnType = {
     /** The decoded integer value. */
     value: bigint
@@ -135,31 +137,10 @@ export declare namespace fromBytes {
   }
 
   type ErrorType =
+    | Bytes.fromHex.ErrorType
     | InsufficientBytesError
     | NonMinimalEncodingError
     | Errors.GlobalErrorType
-}
-
-/**
- * Decodes a CompactSize-encoded value from {@link ox#Hex.Hex}.
- *
- * @example
- * ```ts twoslash
- * import { CompactSize } from 'ox'
- *
- * const result = CompactSize.fromHex('0xfd0001')
- * // { value: 256, size: 3 }
- * ```
- *
- * @param data - The hex string to decode from.
- * @returns The decoded value and number of bytes consumed.
- */
-export function fromHex(data: Hex.Hex): fromBytes.ReturnType {
-  return fromBytes(Bytes.fromHex(data))
-}
-
-export declare namespace fromHex {
-  type ErrorType = fromBytes.ErrorType | Errors.GlobalErrorType
 }
 
 /** Thrown when a CompactSize value is negative. */

--- a/src/core/ContractAddress.ts
+++ b/src/core/ContractAddress.ts
@@ -79,7 +79,7 @@ export function fromCreate(options: fromCreate.Options): Address.Address {
   if (nonce[0] === 0) nonce = new Uint8Array([])
 
   return Address.from(
-    `0x${Hash.keccak256(Rlp.fromBytes([from, nonce], { as: 'Hex' })).slice(26)}` as Address.Address,
+    `0x${Hash.keccak256(Rlp.encode([from, nonce], { as: 'Hex' })).slice(26)}` as Address.Address,
   )
 }
 
@@ -96,7 +96,7 @@ export declare namespace fromCreate {
     | Address.from.ErrorType
     | Bytes.fromHex.ErrorType
     | Bytes.fromNumber.ErrorType
-    | Rlp.fromBytes.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/core/Rlp.bench.ts
+++ b/src/core/Rlp.bench.ts
@@ -15,59 +15,59 @@ const nestedList = [
   medium,
 ]
 
-const encodedSmall = Rlp.fromBytes(small)
-const encodedFlat = Rlp.fromBytes(flatList)
-const encodedNested = Rlp.fromBytes(nestedList)
-const encodedMedium = Rlp.fromBytes(medium)
+const encodedSmall = Rlp.encode(small)
+const encodedFlat = Rlp.encode(flatList)
+const encodedNested = Rlp.encode(nestedList)
+const encodedMedium = Rlp.encode(medium)
 
-const encodedSmallHex = Rlp.fromBytes(small, { as: 'Hex' })
-const encodedFlatHex = Rlp.fromBytes(flatList, { as: 'Hex' })
+const encodedSmallHex = Rlp.encode(small, { as: 'Hex' })
+const encodedFlatHex = Rlp.encode(flatList, { as: 'Hex' })
 
-describe('Rlp.fromBytes (encode)', () => {
+describe('Rlp.encode (Bytes input)', () => {
   bench('single 32-byte string', () => {
-    Rlp.fromBytes(small)
+    Rlp.encode(small)
   })
   bench('single 256-byte string', () => {
-    Rlp.fromBytes(medium)
+    Rlp.encode(medium)
   })
   bench('single 4096-byte string', () => {
-    Rlp.fromBytes(large)
+    Rlp.encode(large)
   })
   bench('flat list of 5x 32-byte strings', () => {
-    Rlp.fromBytes(flatList)
+    Rlp.encode(flatList)
   })
   bench('nested list', () => {
-    Rlp.fromBytes(nestedList)
+    Rlp.encode(nestedList)
   })
 })
 
-describe('Rlp.toBytes (decode)', () => {
+describe('Rlp.decode (Bytes input)', () => {
   bench('single 32-byte string', () => {
-    Rlp.toBytes(encodedSmall)
+    Rlp.decode(encodedSmall, { as: 'Bytes' })
   })
   bench('single 256-byte string', () => {
-    Rlp.toBytes(encodedMedium)
+    Rlp.decode(encodedMedium, { as: 'Bytes' })
   })
   bench('flat list of 5x 32-byte strings', () => {
-    Rlp.toBytes(encodedFlat)
+    Rlp.decode(encodedFlat, { as: 'Bytes' })
   })
   bench('nested list', () => {
-    Rlp.toBytes(encodedNested)
+    Rlp.decode(encodedNested, { as: 'Bytes' })
   })
 })
 
-describe('Rlp.fromHex (encode)', () => {
+describe('Rlp.encode (Hex input)', () => {
   const smallHex = Hex.fromBytes(small)
   bench('single 32-byte string', () => {
-    Rlp.fromHex(smallHex)
+    Rlp.encode(smallHex, { as: 'Hex' })
   })
 })
 
-describe('Rlp.toHex (decode)', () => {
+describe('Rlp.decode (Hex input)', () => {
   bench('single 32-byte string', () => {
-    Rlp.toHex(encodedSmallHex)
+    Rlp.decode(encodedSmallHex, { as: 'Hex' })
   })
   bench('flat list of 5x 32-byte strings', () => {
-    Rlp.toHex(encodedFlatHex)
+    Rlp.decode(encodedFlatHex, { as: 'Hex' })
   })
 })

--- a/src/core/Rlp.ts
+++ b/src/core/Rlp.ts
@@ -3,62 +3,109 @@ import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 import * as internal_bytes from './internal/bytes.js'
 import * as Cursor from './internal/cursor.js'
-import type { ExactPartial, RecursiveArray } from './internal/types.js'
+import type { RecursiveArray } from './internal/types.js'
 
 /**
- * Decodes a Recursive-Length Prefix (RLP) value into a {@link ox#Bytes.Bytes} value.
+ * Encodes a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value into a Recursive-Length Prefix (RLP) value.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Bytes, Rlp } from 'ox'
+ *
+ * Rlp.encode('0x68656c6c6f20776f726c64', { as: 'Hex' })
+ * // @log: '0x8b68656c6c6f20776f726c64'
+ *
+ * Rlp.encode(Bytes.from([139, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]))
+ * // @log: Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+ * ```
+ *
+ * @param value - The {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value to encode.
+ * @param options - Options.
+ * @returns The RLP value.
+ */
+export function encode<as extends 'Hex' | 'Bytes' = 'Bytes'>(
+  value: RecursiveArray<Bytes.Bytes> | RecursiveArray<Hex.Hex>,
+  options: encode.Options<as> = {},
+): encode.ReturnType<as> {
+  const { as = 'Bytes' } = options
+
+  // Two-walk encode without the per-node `Encodable` closure tree:
+  // 1. `measure` walks the input once and caches each list's `bodyLength`
+  //    in a side array indexed by visit order. This makes the second walk
+  //    O(N) instead of O(N²) for nested inputs.
+  // 2. `writeEncoded` walks again, reads cached body lengths, and writes
+  //    bytes straight into the pre-sized buffer. Hex leaves are
+  //    nibble-decoded directly into the destination, skipping the per-leaf
+  //    `Bytes.fromHex` allocation.
+  const ctx: EncodeCtx = { lengths: [], cursor: 0 }
+  const totalLength = measure(value, ctx)
+
+  // Hex-output fast path: when the caller asked for hex AND every leaf is
+  // already hex, emit a hex string directly instead of allocating an
+  // intermediate `Uint8Array` and round-tripping through `Hex.fromBytes`.
+  // This is the dominant shape for transaction envelope serialize.
+  if (as === 'Hex' && isAllHex(value)) {
+    const parts: string[] = []
+    writeEncodedHex(parts, value as RecursiveArray<Hex.Hex>, {
+      lengths: ctx.lengths,
+      cursor: 0,
+    })
+    return `0x${parts.join('')}` as encode.ReturnType<as>
+  }
+
+  const bytes = new Uint8Array(totalLength)
+  writeEncoded(bytes, 0, value, { lengths: ctx.lengths, cursor: 0 })
+
+  if (as === 'Hex') return Hex.fromBytes(bytes) as encode.ReturnType<as>
+  return bytes as encode.ReturnType<as>
+}
+
+export declare namespace encode {
+  type Options<as extends 'Hex' | 'Bytes' = 'Bytes'> = {
+    /** The format to return the encoded value in. @default 'Bytes' */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Cursor.create.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Bytes.fromHex.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Decodes a Recursive-Length Prefix (RLP) value into a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
+ *
+ * When `as` is omitted, the output type matches the input type:
+ * - `Bytes` input → `Bytes` tree
+ * - `Hex` input → `Hex` tree
  *
  * @example
  * ```ts twoslash
  * import { Rlp } from 'ox'
- * Rlp.toBytes('0x8b68656c6c6f20776f726c64')
- * // Uint8Array([139, 104, 101, 108, 108, 111,  32, 119, 111, 114, 108, 100])
+ *
+ * Rlp.decode('0x8b68656c6c6f20776f726c64')
+ * // @log: '0x68656c6c6f20776f726c64'
+ *
+ * Rlp.decode('0x8b68656c6c6f20776f726c64', { as: 'Bytes' })
+ * // @log: Uint8Array([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
  * ```
  *
- * @param value - The value to decode.
- * @returns The decoded {@link ox#Bytes.Bytes} value.
+ * @param value - The RLP-encoded value to decode.
+ * @param options - Options.
+ * @returns The decoded value.
  */
-export function toBytes(
-  value: Bytes.Bytes | Hex.Hex,
-): RecursiveArray<Bytes.Bytes> {
-  return to(value, 'Bytes')
-}
-
-export declare namespace toBytes {
-  type ErrorType = to.ErrorType
-}
-
-/**
- * Decodes a Recursive-Length Prefix (RLP) value into a {@link ox#Hex.Hex} value.
- *
- * @example
- * ```ts twoslash
- * import { Rlp } from 'ox'
- * Rlp.toHex('0x8b68656c6c6f20776f726c64')
- * // 0x68656c6c6f20776f726c64
- * ```
- *
- * @param value - The value to decode.
- * @returns The decoded {@link ox#Hex.Hex} value.
- */
-export function toHex(value: Bytes.Bytes | Hex.Hex): RecursiveArray<Hex.Hex> {
-  return to(value, 'Hex')
-}
-
-export declare namespace toHex {
-  type ErrorType = to.ErrorType
-}
-
-/////////////////////////////////////////////////////////////////////////////////
-// Internal
-/////////////////////////////////////////////////////////////////////////////////
-
-/** @internal */
-export function to<
+export function decode<
   value extends Bytes.Bytes | Hex.Hex,
-  to extends 'Hex' | 'Bytes',
->(value: value, to: to | 'Hex' | 'Bytes'): to.ReturnType<to> {
-  const to_ = to ?? (typeof value === 'string' ? 'Hex' : 'Bytes')
+  as extends 'Hex' | 'Bytes' = value extends Bytes.Bytes ? 'Bytes' : 'Hex',
+>(value: value, options: decode.Options<as> = {}): decode.ReturnType<as> {
+  const as_ = (options.as ?? (typeof value === 'string' ? 'Hex' : 'Bytes')) as
+    | 'Hex'
+    | 'Bytes'
 
   const bytes =
     typeof value === 'string' ? Bytes.fromHex(value) : (value as Bytes.Bytes)
@@ -66,16 +113,23 @@ export function to<
   const cursor = Cursor.create(bytes, {
     recursiveReadLimit: Number.POSITIVE_INFINITY,
   })
-  const result = decodeRlpCursor(cursor, to_)
+  const result = decodeRlpCursor(cursor, as_)
 
-  return result as to.ReturnType<to>
+  return result as decode.ReturnType<as>
 }
 
-/** @internal */
-export declare namespace to {
-  type ReturnType<to extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> =
-    | (to extends 'Bytes' ? RecursiveArray<Bytes.Bytes> : never)
-    | (to extends 'Hex' ? RecursiveArray<Hex.Hex> : never)
+export declare namespace decode {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> = {
+    /**
+     * The format to return the decoded value in. Defaults to matching the
+     * input type (`'Hex'` for hex strings, `'Bytes'` for byte arrays).
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? RecursiveArray<Bytes.Bytes> : never)
+    | (as extends 'Hex' ? RecursiveArray<Hex.Hex> : never)
 
   type ErrorType =
     | Bytes.fromHex.ErrorType
@@ -85,7 +139,9 @@ export declare namespace to {
     | Errors.GlobalErrorType
 }
 
-/** @internal */
+/////////////////////////////////////////////////////////////////////////////////
+// Internal
+/////////////////////////////////////////////////////////////////////////////////
 
 /** @internal */
 export function decodeRlpCursor<to extends 'Hex' | 'Bytes' = 'Hex'>(
@@ -116,7 +172,9 @@ export function decodeRlpCursor<to extends 'Hex' | 'Bytes' = 'Hex'>(
 
 /** @internal */
 export declare namespace decodeRlpCursor {
-  type ReturnType<to extends 'Hex' | 'Bytes' = 'Hex'> = to.ReturnType<to>
+  type ReturnType<to extends 'Hex' | 'Bytes' = 'Hex'> =
+    | (to extends 'Bytes' ? RecursiveArray<Bytes.Bytes> : never)
+    | (to extends 'Hex' ? RecursiveArray<Hex.Hex> : never)
   type ErrorType =
     | Hex.fromBytes.ErrorType
     | readLength.ErrorType
@@ -161,148 +219,6 @@ export function readList<to extends 'Hex' | 'Bytes'>(
 export declare namespace readList {
   type ErrorType = Errors.GlobalErrorType
 }
-
-/**
- * Encodes a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value into a Recursive-Length Prefix (RLP) value.
- *
- * @example
- * ```ts twoslash
- * import { Bytes, Rlp } from 'ox'
- *
- * Rlp.from('0x68656c6c6f20776f726c64', { as: 'Hex' })
- * // @log: 0x8b68656c6c6f20776f726c64
- *
- * Rlp.from(Bytes.from([139, 104, 101, 108, 108, 111,  32, 119, 111, 114, 108, 100]), { as: 'Bytes' })
- * // @log: Uint8Array([104, 101, 108, 108, 111,  32, 119, 111, 114, 108, 100])
- * ```
- *
- * @param value - The {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value to encode.
- * @param options - Options.
- * @returns The RLP value.
- */
-export function from<as extends 'Hex' | 'Bytes'>(
-  value: RecursiveArray<Bytes.Bytes> | RecursiveArray<Hex.Hex>,
-  options: from.Options<as>,
-): from.ReturnType<as> {
-  const { as } = options
-
-  // Two-walk encode without the per-node `Encodable` closure tree:
-  // 1. `measure` walks the input once and caches each list's `bodyLength`
-  //    in a side array indexed by visit order. This makes the second walk
-  //    O(N) instead of O(N²) for nested inputs.
-  // 2. `writeEncoded` walks again, reads cached body lengths, and writes
-  //    bytes straight into the pre-sized buffer. Hex leaves are
-  //    nibble-decoded directly into the destination, skipping the per-leaf
-  //    `Bytes.fromHex` allocation.
-  const ctx: EncodeCtx = { lengths: [], cursor: 0 }
-  const totalLength = measure(value, ctx)
-
-  // Hex-output fast path: when the caller asked for hex AND every leaf is
-  // already hex, emit a hex string directly instead of allocating an
-  // intermediate `Uint8Array` and round-tripping through `Hex.fromBytes`.
-  // This is the dominant shape for transaction envelope serialize.
-  if (as === 'Hex' && isAllHex(value)) {
-    const parts: string[] = []
-    writeEncodedHex(parts, value as RecursiveArray<Hex.Hex>, {
-      lengths: ctx.lengths,
-      cursor: 0,
-    })
-    return `0x${parts.join('')}` as from.ReturnType<as>
-  }
-
-  const bytes = new Uint8Array(totalLength)
-  writeEncoded(bytes, 0, value, { lengths: ctx.lengths, cursor: 0 })
-
-  if (as === 'Hex') return Hex.fromBytes(bytes) as from.ReturnType<as>
-  return bytes as from.ReturnType<as>
-}
-
-export declare namespace from {
-  type Options<as extends 'Hex' | 'Bytes'> = {
-    /** The type to convert the RLP value to. */
-    as: as | 'Hex' | 'Bytes'
-  }
-
-  type ReturnType<as extends 'Hex' | 'Bytes'> =
-    | (as extends 'Bytes' ? Bytes.Bytes : never)
-    | (as extends 'Hex' ? Hex.Hex : never)
-
-  type ErrorType =
-    | Cursor.create.ErrorType
-    | Hex.fromBytes.ErrorType
-    | Bytes.fromHex.ErrorType
-    | Errors.GlobalErrorType
-}
-
-/**
- * Encodes a {@link ox#Bytes.Bytes} value into a Recursive-Length Prefix (RLP) value.
- *
- * @example
- * ```ts twoslash
- * import { Bytes, Rlp } from 'ox'
- *
- * Rlp.fromBytes(Bytes.from([139, 104, 101, 108, 108, 111,  32, 119, 111, 114, 108, 100]))
- * // @log: Uint8Array([104, 101, 108, 108, 111,  32, 119, 111, 114, 108, 100])
- * ```
- *
- * @param bytes - The {@link ox#Bytes.Bytes} value to encode.
- * @param options - Options.
- * @returns The RLP value.
- */
-export function fromBytes<as extends 'Hex' | 'Bytes' = 'Bytes'>(
-  bytes: RecursiveArray<Bytes.Bytes>,
-  options: fromBytes.Options<as> = {},
-): fromBytes.ReturnType<as> {
-  const { as = 'Bytes' } = options
-  return from(bytes, { as }) as never
-}
-
-export declare namespace fromBytes {
-  type Options<as extends 'Hex' | 'Bytes' = 'Bytes'> = ExactPartial<
-    from.Options<as>
-  >
-
-  type ReturnType<as extends 'Hex' | 'Bytes' = 'Bytes'> = from.ReturnType<as>
-
-  type ErrorType = from.ErrorType | Errors.GlobalErrorType
-}
-
-/**
- * Encodes a {@link ox#Hex.Hex} value into a Recursive-Length Prefix (RLP) value.
- *
- * @example
- * ```ts twoslash
- * import { Rlp } from 'ox'
- *
- * Rlp.fromHex('0x68656c6c6f20776f726c64')
- * // @log: 0x8b68656c6c6f20776f726c64
- * ```
- *
- * @param hex - The {@link ox#Hex.Hex} value to encode.
- * @param options - Options.
- * @returns The RLP value.
- */
-export function fromHex<as extends 'Hex' | 'Bytes' = 'Hex'>(
-  hex: RecursiveArray<Hex.Hex>,
-  options: fromHex.Options<as> = {},
-): fromHex.ReturnType<as> {
-  const { as = 'Hex' } = options
-  return from(hex, { as }) as never
-}
-
-export declare namespace fromHex {
-  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = ExactPartial<
-    from.Options<as>
-  >
-
-  type ReturnType<as extends 'Hex' | 'Bytes' = 'Hex'> = from.ReturnType<as>
-
-  type ErrorType = from.ErrorType | Errors.GlobalErrorType
-}
-
-/////////////////////////////////////////////////////////////////////////////////
-// Internal
-/////////////////////////////////////////////////////////////////////////////////
 
 /**
  * Returns the byte length needed to encode `length` itself (1-4 bytes per
@@ -512,7 +428,7 @@ function writeBytesLeaf(
 
 /**
  * Returns true if every leaf in the (possibly nested) input is a hex string.
- * Used to gate the hex-output fast path in `from`.
+ * Used to gate the hex-output fast path in `encode`.
  *
  * @internal
  */

--- a/src/core/Rlp_tx.bench.ts
+++ b/src/core/Rlp_tx.bench.ts
@@ -23,7 +23,7 @@ const eip1559Tuple = [
   '0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0',
 ] as const
 
-const eip1559TupleHex = Rlp.fromHex(eip1559Tuple as never, { as: 'Hex' })
+const eip1559TupleHex = Rlp.encode(eip1559Tuple as never, { as: 'Hex' })
 
 // Larger 7702-shaped tuple with an access list and authorization list of
 // modest size (2 entries each).
@@ -60,35 +60,35 @@ const eip7702Tuple = [
   '0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0',
 ] as const
 
-const eip7702TupleHex = Rlp.fromHex(eip7702Tuple as never, { as: 'Hex' })
+const eip7702TupleHex = Rlp.encode(eip7702Tuple as never, { as: 'Hex' })
 
-describe('Rlp.fromHex (transaction-shaped)', () => {
+describe('Rlp.encode (transaction-shaped)', () => {
   bench('eip1559 tuple', () => {
-    Rlp.fromHex(eip1559Tuple as never, { as: 'Hex' })
+    Rlp.encode(eip1559Tuple as never, { as: 'Hex' })
   })
 
   bench('eip7702 tuple (with access + authorization lists)', () => {
-    Rlp.fromHex(eip7702Tuple as never, { as: 'Hex' })
+    Rlp.encode(eip7702Tuple as never, { as: 'Hex' })
   })
 })
 
-describe('Rlp.toHex (transaction-shaped)', () => {
+describe('Rlp.decode (transaction-shaped)', () => {
   bench('eip1559 tuple', () => {
-    Rlp.toHex(eip1559TupleHex)
+    Rlp.decode(eip1559TupleHex, { as: 'Hex' })
   })
 
   bench('eip7702 tuple (with access + authorization lists)', () => {
-    Rlp.toHex(eip7702TupleHex)
+    Rlp.decode(eip7702TupleHex, { as: 'Hex' })
   })
 })
 
-describe('Rlp.toBytes (transaction-shaped)', () => {
+describe('Rlp.decode (transaction-shaped)', () => {
   bench('eip1559 tuple', () => {
-    Rlp.toBytes(eip1559TupleHex)
+    Rlp.decode(eip1559TupleHex, { as: 'Bytes' })
   })
 
   bench('eip7702 tuple (with access + authorization lists)', () => {
-    Rlp.toBytes(eip7702TupleHex)
+    Rlp.decode(eip7702TupleHex, { as: 'Bytes' })
   })
 })
 

--- a/src/core/TxEnvelopeEip1559.ts
+++ b/src/core/TxEnvelopeEip1559.ts
@@ -119,7 +119,7 @@ export declare namespace assert {
 export function deserialize(
   serialized: Serialized,
 ): Compute<TxEnvelopeEip1559> {
-  const transactionArray = Rlp.toBytes(Hex.slice(serialized, 1))
+  const transactionArray = Rlp.decode(Hex.slice(serialized, 1), { as: 'Bytes' })
 
   const [
     chainId,
@@ -523,7 +523,10 @@ export function serialize(
     ...(signature ? Signature.toTuple(signature) : []),
   ]
 
-  return Hex.concat(serializedType, Rlp.fromHex(serialized)) as Serialized
+  return Hex.concat(
+    serializedType,
+    Rlp.encode(serialized, { as: 'Hex' }),
+  ) as Serialized
 }
 
 export declare namespace serialize {
@@ -537,7 +540,7 @@ export declare namespace serialize {
     | Hex.fromNumber.ErrorType
     | Signature.toTuple.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/core/TxEnvelopeEip2930.ts
+++ b/src/core/TxEnvelopeEip2930.ts
@@ -105,7 +105,7 @@ export declare namespace assert {
  * @returns Deserialized Transaction Envelope.
  */
 export function deserialize(serialized: Serialized): TxEnvelopeEip2930 {
-  const transactionArray = Rlp.toBytes(Hex.slice(serialized, 1))
+  const transactionArray = Rlp.decode(Hex.slice(serialized, 1), { as: 'Bytes' })
 
   const [
     chainId,
@@ -490,7 +490,7 @@ export function serialize(
     ...(signature ? Signature.toTuple(signature) : []),
   ] as const
 
-  return Hex.concat('0x01', Rlp.fromHex(serialized)) as Serialized
+  return Hex.concat('0x01', Rlp.encode(serialized, { as: 'Hex' })) as Serialized
 }
 
 export declare namespace serialize {
@@ -504,7 +504,7 @@ export declare namespace serialize {
     | Hex.fromNumber.ErrorType
     | Signature.toTuple.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/core/TxEnvelopeEip4844.ts
+++ b/src/core/TxEnvelopeEip4844.ts
@@ -134,7 +134,9 @@ export declare namespace assert {
 export function deserialize(
   serialized: Serialized,
 ): Compute<TxEnvelopeEip4844> {
-  const transactionOrWrapperArray = Rlp.toBytes(Hex.slice(serialized, 1))
+  const transactionOrWrapperArray = Rlp.decode(Hex.slice(serialized, 1), {
+    as: 'Bytes',
+  })
 
   const hasNetworkWrapper = transactionOrWrapperArray.length === 4
 
@@ -655,9 +657,9 @@ export function serialize(
     '0x03',
     sidecars
       ? // If sidecars are provided, envelope turns into a "network wrapper":
-        Rlp.fromHex([serialized, blobs, commitments, proofs])
+        Rlp.encode([serialized, blobs, commitments, proofs], { as: 'Hex' })
       : // Otherwise, standard envelope is used:
-        Rlp.fromHex(serialized),
+        Rlp.encode(serialized, { as: 'Hex' }),
   ) as Serialized
 }
 
@@ -674,7 +676,7 @@ export declare namespace serialize {
     | Hex.fromNumber.ErrorType
     | Signature.toTuple.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/core/TxEnvelopeEip7702.ts
+++ b/src/core/TxEnvelopeEip7702.ts
@@ -120,7 +120,7 @@ export declare namespace assert {
 export function deserialize(
   serialized: Serialized,
 ): Compute<TxEnvelopeEip7702> {
-  const transactionArray = Rlp.toBytes(Hex.slice(serialized, 1))
+  const transactionArray = Rlp.decode(Hex.slice(serialized, 1), { as: 'Bytes' })
 
   const [
     chainId,
@@ -570,7 +570,10 @@ export function serialize(
     ...(signature ? Signature.toTuple(signature) : []),
   ]
 
-  return Hex.concat(serializedType, Rlp.fromHex(serialized)) as Serialized
+  return Hex.concat(
+    serializedType,
+    Rlp.encode(serialized, { as: 'Hex' }),
+  ) as Serialized
 }
 
 export declare namespace serialize {
@@ -584,7 +587,7 @@ export declare namespace serialize {
     | Hex.fromNumber.ErrorType
     | Signature.toTuple.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/core/TxEnvelopeLegacy.ts
+++ b/src/core/TxEnvelopeLegacy.ts
@@ -103,7 +103,7 @@ export declare namespace assert {
  * @returns Deserialized Transaction Envelope.
  */
 export function deserialize(serialized: Hex.Hex): Compute<TxEnvelopeLegacy> {
-  const tuple = Rlp.toBytes(serialized)
+  const tuple = Rlp.decode(serialized, { as: 'Bytes' })
 
   const [nonce, gasPrice, gas, to, value, data, chainIdOrV_, r, s] =
     tuple as readonly Bytes.Bytes[]
@@ -523,7 +523,7 @@ export function serialize(
   } else if (chainId > 0)
     serialized = [...serialized, Hex.fromNumber(chainId), '0x', '0x']
 
-  return Rlp.fromHex(serialized) as never
+  return Rlp.encode(serialized, { as: 'Hex' }) as never
 }
 
 export declare namespace serialize {
@@ -536,7 +536,7 @@ export declare namespace serialize {
     | assert.ErrorType
     | Hex.fromNumber.ErrorType
     | Hex.trimLeft.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Signature.InvalidVError
     | Errors.GlobalErrorType
 }

--- a/src/core/_test/Base.fuzz.ts
+++ b/src/core/_test/Base.fuzz.ts
@@ -10,7 +10,7 @@ describe('Base32 round-trip', () => {
   test.prop({ bytes: arbitraryBytes() }, { numRuns })(
     'toBytes(fromBytes(b)) ≡ b',
     ({ bytes }) => {
-      expect(Base32.toBytes(Base32.fromBytes(bytes))).toEqual(bytes)
+      expect(Base32.decode(Base32.encode(bytes))).toEqual(bytes)
     },
   )
 })
@@ -19,7 +19,7 @@ describe('Base58 round-trip', () => {
   test.prop({ bytes: arbitraryBytes() }, { numRuns })(
     'toBytes(fromBytes(b)) ≡ b',
     ({ bytes }) => {
-      expect(Base58.toBytes(Base58.fromBytes(bytes))).toEqual(bytes)
+      expect(Base58.decode(Base58.encode(bytes))).toEqual(bytes)
     },
   )
 })
@@ -28,16 +28,14 @@ describe('Base64 round-trip', () => {
   test.prop({ bytes: arbitraryBytes() }, { numRuns })(
     'toBytes(fromBytes(b)) ≡ b',
     ({ bytes }) => {
-      expect(Base64.toBytes(Base64.fromBytes(bytes))).toEqual(bytes)
+      expect(Base64.decode(Base64.encode(bytes))).toEqual(bytes)
     },
   )
 
   test.prop({ bytes: arbitraryBytes() }, { numRuns })(
     'toBytes(fromBytes(b, { url: true })) ≡ b',
     ({ bytes }) => {
-      expect(Base64.toBytes(Base64.fromBytes(bytes, { url: true }))).toEqual(
-        bytes,
-      )
+      expect(Base64.decode(Base64.encode(bytes, { url: true }))).toEqual(bytes)
     },
   )
 })

--- a/src/core/_test/Base32.test.ts
+++ b/src/core/_test/Base32.test.ts
@@ -1,65 +1,63 @@
 import { Base32 } from 'ox'
 import { describe, expect, test } from 'vitest'
 
-describe('fromBytes', () => {
+describe('encode', () => {
   test('default', () => {
     expect(
-      Base32.fromBytes(new Uint8Array([0x00, 0xff, 0x00])),
+      Base32.encode(new Uint8Array([0x00, 0xff, 0x00])),
     ).toMatchInlineSnapshot(`"qrlsq"`)
   })
 
   test('single byte', () => {
-    expect(Base32.fromBytes(new Uint8Array([0x00]))).toMatchInlineSnapshot(
-      `"qq"`,
-    )
+    expect(Base32.encode(new Uint8Array([0x00]))).toMatchInlineSnapshot(`"qq"`)
   })
 
   test('20 bytes (address-like)', () => {
     const bytes = new Uint8Array(20).fill(0xab)
-    const encoded = Base32.fromBytes(bytes)
-    const decoded = Base32.toBytes(encoded)
+    const encoded = Base32.encode(bytes)
+    const decoded = Base32.decode(encoded)
     expect(decoded.slice(0, 20)).toEqual(bytes)
   })
 })
 
-describe('fromHex', () => {
+describe('encode', () => {
   test('default', () => {
-    expect(Base32.fromHex('0x00ff00')).toMatchInlineSnapshot(`"qrlsq"`)
+    expect(Base32.encode('0x00ff00')).toMatchInlineSnapshot(`"qrlsq"`)
   })
 })
 
-describe('toBytes', () => {
+describe('decode', () => {
   test('round-trip', () => {
     const original = new Uint8Array([
       0x74, 0x2d, 0x35, 0xcc, 0x66, 0x34, 0xc0, 0x53, 0x29, 0x25, 0xa3, 0xb8,
       0x44, 0xbc, 0x9e, 0x75, 0x95, 0xf2, 0xbd, 0x28,
     ])
-    const encoded = Base32.fromBytes(original)
-    const decoded = Base32.toBytes(encoded)
+    const encoded = Base32.encode(original)
+    const decoded = Base32.decode(encoded)
     expect(decoded.slice(0, original.length)).toEqual(original)
   })
 
   test('error: invalid character', () => {
-    expect(() => Base32.toBytes('b!')).toThrowErrorMatchingInlineSnapshot(
+    expect(() => Base32.decode('b!')).toThrowErrorMatchingInlineSnapshot(
       `[Base32.InvalidCharacterError: Invalid bech32 base32 character: "b".]`,
     )
   })
 })
 
-describe('toHex', () => {
+describe('decode', () => {
   test('round-trip', () => {
-    const encoded = Base32.fromHex('0x00ff00')
-    expect(Base32.toHex(encoded)).toMatchInlineSnapshot(`"0x00ff00"`)
+    const encoded = Base32.encode('0x00ff00')
+    expect(Base32.decode(encoded, { as: 'Hex' })).toMatchInlineSnapshot(
+      `"0x00ff00"`,
+    )
   })
 })
 
 test('exports', () => {
   expect(Object.keys(Base32)).toMatchInlineSnapshot(`
     [
-      "fromBytes",
-      "fromHex",
-      "toBytes",
-      "toHex",
+      "encode",
+      "decode",
       "InvalidCharacterError",
       "InvalidPaddingError",
     ]

--- a/src/core/_test/Base58.test.ts
+++ b/src/core/_test/Base58.test.ts
@@ -1,10 +1,10 @@
 import { Base58 } from 'ox'
 import { describe, expect, test } from 'vitest'
 
-describe('fromBytes', () => {
+describe('encode', () => {
   test('default', () => {
     expect(
-      Base58.fromBytes(
+      Base58.encode(
         new Uint8Array([
           72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
         ]),
@@ -13,24 +13,24 @@ describe('fromBytes', () => {
   })
 })
 
-describe('fromHex', () => {
+describe('encode', () => {
   test('default', () => {
-    expect(Base58.fromHex('0x00000000287fb4cd')).toBe('1111233QC4')
+    expect(Base58.encode('0x00000000287fb4cd')).toBe('1111233QC4')
   })
 })
 
-describe('fromString', () => {
+describe('encode', () => {
   test('default', () => {
-    expect(Base58.fromString('Hello World!')).toBe('2NEpo7TZRRrLZSi2U')
-    expect(
-      Base58.fromString('The quick brown fox jumps over the lazy dog.'),
-    ).toBe('USm3fpXnKG5EUBx2ndxBDMPVciP5hGey2Jh4NDv6gmeo1LkMeiKrLJUUBk6Z')
+    expect(Base58.encode('Hello World!')).toBe('2NEpo7TZRRrLZSi2U')
+    expect(Base58.encode('The quick brown fox jumps over the lazy dog.')).toBe(
+      'USm3fpXnKG5EUBx2ndxBDMPVciP5hGey2Jh4NDv6gmeo1LkMeiKrLJUUBk6Z',
+    )
   })
 })
 
-describe('toBytes', () => {
+describe('decode', () => {
   test('default', () => {
-    expect(Base58.toBytes('2NEpo7TZRRrLZSi2U')).toMatchInlineSnapshot(`
+    expect(Base58.decode('2NEpo7TZRRrLZSi2U')).toMatchInlineSnapshot(`
       Uint8Array [
         72,
         101,
@@ -49,22 +49,27 @@ describe('toBytes', () => {
   })
 })
 
-describe('toHex', () => {
+describe('decode', () => {
   test('default', () => {
-    expect(Base58.toHex('233QC4')).toBe('0x287fb4cd')
-    expect(Base58.toHex('11233QC4')).toBe('0x0000287fb4cd')
-    expect(() => Base58.toHex('233QC4I')).toThrowErrorMatchingInlineSnapshot(
+    expect(Base58.decode('233QC4', { as: 'Hex' })).toBe('0x287fb4cd')
+    expect(Base58.decode('11233QC4', { as: 'Hex' })).toBe('0x0000287fb4cd')
+    expect(() =>
+      Base58.decode('233QC4I', { as: 'Hex' }),
+    ).toThrowErrorMatchingInlineSnapshot(
       `[Base58.InvalidCharacterError: Invalid Base58 character: "I".]`,
     )
   })
 })
 
-describe('toString', () => {
+describe('decode', () => {
   test('default', () => {
-    expect(Base58.toString('2NEpo7TZRRrLZSi2U')).toBe('Hello World!')
+    expect(Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'String' })).toBe(
+      'Hello World!',
+    )
     expect(
-      Base58.toString(
+      Base58.decode(
         'USm3fpXnKG5EUBx2ndxBDMPVciP5hGey2Jh4NDv6gmeo1LkMeiKrLJUUBk6Z',
+        { as: 'String' },
       ),
     ).toBe('The quick brown fox jumps over the lazy dog.')
   })
@@ -73,12 +78,8 @@ describe('toString', () => {
 test('exports', () => {
   expect(Object.keys(Base58)).toMatchInlineSnapshot(`
     [
-      "fromBytes",
-      "fromHex",
-      "fromString",
-      "toBytes",
-      "toHex",
-      "toString",
+      "encode",
+      "decode",
       "InvalidCharacterError",
     ]
   `)

--- a/src/core/_test/Base64.test.ts
+++ b/src/core/_test/Base64.test.ts
@@ -1,103 +1,105 @@
 import { Base64, Bytes, Hex } from 'ox'
 import { describe, expect, test } from 'vitest'
 
-describe('fromBytes', () => {
+describe('encode', () => {
   test('default', () => {
-    expect(Base64.fromBytes(Bytes.fromString('hello wo�d'))).toBe(
+    expect(Base64.encode(Bytes.fromString('hello wo�d'))).toBe(
       'aGVsbG8gd29/77+9ZA==',
     )
-    expect(
-      Base64.fromBytes(Bytes.fromString('hello wo�d'), { url: true }),
-    ).toBe('aGVsbG8gd29_77-9ZA==')
-    expect(
-      Base64.fromBytes(Bytes.fromString('hhello wo�d'), { url: true }),
-    ).toBe('aGhlbGxvIHdvf--_vWQ=')
-    expect(
-      Base64.fromBytes(Bytes.fromString('hello wo�d'), { pad: false }),
-    ).toBe('aGVsbG8gd29/77+9ZA')
-  })
-})
-
-describe('fromHex', () => {
-  test('default', () => {
-    expect(Base64.fromHex(Hex.fromString('hello wo�d'))).toBe(
-      'aGVsbG8gd29/77+9ZA==',
-    )
-    expect(Base64.fromHex(Hex.fromString('hello wo�d'), { url: true })).toBe(
+    expect(Base64.encode(Bytes.fromString('hello wo�d'), { url: true })).toBe(
       'aGVsbG8gd29_77-9ZA==',
     )
-    expect(Base64.fromHex(Hex.fromString('hello wo�d'), { pad: false })).toBe(
+    expect(Base64.encode(Bytes.fromString('hhello wo�d'), { url: true })).toBe(
+      'aGhlbGxvIHdvf--_vWQ=',
+    )
+    expect(Base64.encode(Bytes.fromString('hello wo�d'), { pad: false })).toBe(
       'aGVsbG8gd29/77+9ZA',
     )
   })
 })
 
-describe('fromString', () => {
+describe('encode', () => {
   test('default', () => {
-    expect(Base64.fromString('hello wo�d')).toBe('aGVsbG8gd29/77+9ZA==')
-    expect(Base64.fromString('hello wo�d', { url: true })).toBe(
+    expect(Base64.encode(Hex.fromString('hello wo�d'))).toBe(
+      'aGVsbG8gd29/77+9ZA==',
+    )
+    expect(Base64.encode(Hex.fromString('hello wo�d'), { url: true })).toBe(
       'aGVsbG8gd29_77-9ZA==',
     )
-    expect(Base64.fromString('hello wo�d', { pad: false })).toBe(
+    expect(Base64.encode(Hex.fromString('hello wo�d'), { pad: false })).toBe(
       'aGVsbG8gd29/77+9ZA',
     )
   })
 })
 
-describe('toBytes', () => {
+describe('encode', () => {
+  test('default', () => {
+    expect(Base64.encode('hello wo�d')).toBe('aGVsbG8gd29/77+9ZA==')
+    expect(Base64.encode('hello wo�d', { url: true })).toBe(
+      'aGVsbG8gd29_77-9ZA==',
+    )
+    expect(Base64.encode('hello wo�d', { pad: false })).toBe(
+      'aGVsbG8gd29/77+9ZA',
+    )
+  })
+})
+
+describe('decode', () => {
   test('default', () => {
     // pad
-    expect(Base64.toBytes('aGVsbG8gd29/77+9ZA==')).toStrictEqual(
+    expect(Base64.decode('aGVsbG8gd29/77+9ZA==')).toStrictEqual(
       Bytes.fromString('hello wo�d'),
     )
     // no pad
-    expect(Base64.toBytes('aGVsbG8gd29/77+9ZA')).toStrictEqual(
+    expect(Base64.decode('aGVsbG8gd29/77+9ZA')).toStrictEqual(
       Bytes.fromString('hello wo�d'),
     )
     // url
-    expect(Base64.toBytes('aGVsbG8gd29_77-9ZA==')).toStrictEqual(
+    expect(Base64.decode('aGVsbG8gd29_77-9ZA==')).toStrictEqual(
       Bytes.fromString('hello wo�d'),
     )
   })
 })
 
-describe('toHex', () => {
+describe('decode', () => {
   test('default', () => {
     // pad
-    expect(Base64.toHex('aGVsbG8gd29/77+9ZA==')).toStrictEqual(
+    expect(Base64.decode('aGVsbG8gd29/77+9ZA==', { as: 'Hex' })).toStrictEqual(
       Hex.fromString('hello wo�d'),
     )
     // no pad
-    expect(Base64.toHex('aGVsbG8gd29/77+9ZA')).toStrictEqual(
+    expect(Base64.decode('aGVsbG8gd29/77+9ZA', { as: 'Hex' })).toStrictEqual(
       Hex.fromString('hello wo�d'),
     )
     // url
-    expect(Base64.toHex('aGVsbG8gd29_77-9ZA==')).toStrictEqual(
+    expect(Base64.decode('aGVsbG8gd29_77-9ZA==', { as: 'Hex' })).toStrictEqual(
       Hex.fromString('hello wo�d'),
     )
   })
 })
 
-describe('toString', () => {
+describe('decode', () => {
   test('default', () => {
     // pad
-    expect(Base64.toString('aGVsbG8gd29/77+9ZA==')).toStrictEqual('hello wo�d')
+    expect(
+      Base64.decode('aGVsbG8gd29/77+9ZA==', { as: 'String' }),
+    ).toStrictEqual('hello wo�d')
     // no pad
-    expect(Base64.toString('aGVsbG8gd29/77+9ZA')).toStrictEqual('hello wo�d')
+    expect(Base64.decode('aGVsbG8gd29/77+9ZA', { as: 'String' })).toStrictEqual(
+      'hello wo�d',
+    )
     // url
-    expect(Base64.toString('aGVsbG8gd29_77-9ZA==')).toStrictEqual('hello wo�d')
+    expect(
+      Base64.decode('aGVsbG8gd29_77-9ZA==', { as: 'String' }),
+    ).toStrictEqual('hello wo�d')
   })
 })
 
 test('exports', () => {
   expect(Object.keys(Base64)).toMatchInlineSnapshot(`
     [
-      "fromBytes",
-      "fromHex",
-      "fromString",
-      "toBytes",
-      "toHex",
-      "toString",
+      "encode",
+      "decode",
       "InvalidCharacterError",
       "InvalidLengthError",
       "InvalidPaddingError",

--- a/src/core/_test/Bech32m.test.ts
+++ b/src/core/_test/Bech32m.test.ts
@@ -48,14 +48,19 @@ describe('encode', () => {
   })
 
   test('error: exceeds length limit', () => {
-    expect(() => Bech32m.encode('test', new Uint8Array(100))).toThrow(
-      Bech32m.ExceedsLengthError,
-    )
+    expect(() =>
+      Bech32m.encode('test', new Uint8Array(100), { limit: 90 }),
+    ).toThrow(Bech32m.ExceedsLengthError)
   })
 
   test('custom limit', () => {
     const data = new Uint8Array(100)
     expect(() => Bech32m.encode('test', data, { limit: 200 })).not.toThrow()
+  })
+
+  test('no limit by default', () => {
+    // No `limit` option means no enforced cap — large payloads encode fine.
+    expect(() => Bech32m.encode('test', new Uint8Array(100))).not.toThrow()
   })
 })
 
@@ -109,8 +114,14 @@ describe('decode', () => {
     expect(() =>
       Bech32m.decode(
         'an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4',
+        { limit: 90 },
       ),
     ).toThrow(Bech32m.ExceedsLengthError)
+  })
+
+  test('no limit by default on decode', () => {
+    const long = Bech32m.encode('test', new Uint8Array(100))
+    expect(() => Bech32m.decode(long)).not.toThrow()
   })
 
   test('custom limit', () => {
@@ -181,6 +192,7 @@ describe('BIP-350 invalid bech32m vectors', () => {
     expect(() =>
       Bech32m.decode(
         'an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4',
+        { limit: 90 },
       ),
     ).toThrow(Bech32m.ExceedsLengthError)
   })

--- a/src/core/_test/CompactSize.test.ts
+++ b/src/core/_test/CompactSize.test.ts
@@ -1,19 +1,19 @@
 import { CompactSize } from 'ox'
 import { describe, expect, test } from 'vitest'
 
-describe('toBytes', () => {
+describe('decode', () => {
   test('single byte (0-252)', () => {
-    expect(CompactSize.toBytes(0n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(0n)).toMatchInlineSnapshot(`
       Uint8Array [
         0,
       ]
     `)
-    expect(CompactSize.toBytes(1n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(1n)).toMatchInlineSnapshot(`
       Uint8Array [
         1,
       ]
     `)
-    expect(CompactSize.toBytes(252n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(252n)).toMatchInlineSnapshot(`
       Uint8Array [
         252,
       ]
@@ -21,14 +21,14 @@ describe('toBytes', () => {
   })
 
   test('3 bytes (253-65535)', () => {
-    expect(CompactSize.toBytes(253n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(253n)).toMatchInlineSnapshot(`
       Uint8Array [
         253,
         253,
         0,
       ]
     `)
-    expect(CompactSize.toBytes(65535n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(65535n)).toMatchInlineSnapshot(`
       Uint8Array [
         253,
         255,
@@ -38,7 +38,7 @@ describe('toBytes', () => {
   })
 
   test('5 bytes (65536-4294967295)', () => {
-    expect(CompactSize.toBytes(65536n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(65536n)).toMatchInlineSnapshot(`
       Uint8Array [
         254,
         0,
@@ -47,7 +47,7 @@ describe('toBytes', () => {
         0,
       ]
     `)
-    expect(CompactSize.toBytes(4294967295n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(4294967295n)).toMatchInlineSnapshot(`
       Uint8Array [
         254,
         255,
@@ -59,7 +59,7 @@ describe('toBytes', () => {
   })
 
   test('9 bytes (> 4294967295)', () => {
-    expect(CompactSize.toBytes(4294967296n)).toMatchInlineSnapshot(`
+    expect(CompactSize.encode(4294967296n)).toMatchInlineSnapshot(`
       Uint8Array [
         255,
         0,
@@ -75,24 +75,28 @@ describe('toBytes', () => {
   })
 
   test('error: negative value', () => {
-    expect(() => CompactSize.toBytes(-1n)).toThrowErrorMatchingInlineSnapshot(
+    expect(() => CompactSize.encode(-1n)).toThrowErrorMatchingInlineSnapshot(
       `[CompactSize.NegativeValueError: CompactSize value must be non-negative, got -1.]`,
     )
   })
 })
 
-describe('toHex', () => {
+describe('decode', () => {
   test('default', () => {
-    expect(CompactSize.toHex(252n)).toMatchInlineSnapshot(`"0xfc"`)
-    expect(CompactSize.toHex(253n)).toMatchInlineSnapshot(`"0xfdfd00"`)
+    expect(CompactSize.encode(252n, { as: 'Hex' })).toMatchInlineSnapshot(
+      `"0xfc"`,
+    )
+    expect(CompactSize.encode(253n, { as: 'Hex' })).toMatchInlineSnapshot(
+      `"0xfdfd00"`,
+    )
   })
 })
 
-describe('fromBytes', () => {
+describe('encode', () => {
   test('round-trip (single byte)', () => {
     for (const n of [0n, 1n, 100n, 252n]) {
-      const encoded = CompactSize.toBytes(n)
-      const { value, size } = CompactSize.fromBytes(encoded)
+      const encoded = CompactSize.encode(n)
+      const { value, size } = CompactSize.decode(encoded)
       expect(value).toBe(n)
       expect(size).toBe(1)
     }
@@ -100,8 +104,8 @@ describe('fromBytes', () => {
 
   test('round-trip (3 bytes)', () => {
     for (const n of [253n, 1000n, 65535n]) {
-      const encoded = CompactSize.toBytes(n)
-      const { value, size } = CompactSize.fromBytes(encoded)
+      const encoded = CompactSize.encode(n)
+      const { value, size } = CompactSize.decode(encoded)
       expect(value).toBe(n)
       expect(size).toBe(3)
     }
@@ -109,8 +113,8 @@ describe('fromBytes', () => {
 
   test('round-trip (5 bytes)', () => {
     for (const n of [65536n, 1000000n, 4294967295n]) {
-      const encoded = CompactSize.toBytes(n)
-      const { value, size } = CompactSize.fromBytes(encoded)
+      const encoded = CompactSize.encode(n)
+      const { value, size } = CompactSize.decode(encoded)
       expect(value).toBe(n)
       expect(size).toBe(5)
     }
@@ -118,23 +122,23 @@ describe('fromBytes', () => {
 
   test('round-trip (9 bytes)', () => {
     const n = BigInt('18446744073709551615')
-    const encoded = CompactSize.toBytes(n)
-    const { value, size } = CompactSize.fromBytes(encoded)
+    const encoded = CompactSize.encode(n)
+    const { value, size } = CompactSize.decode(encoded)
     expect(value).toBe(n)
     expect(size).toBe(9)
   })
 
   test('large value returns bigint', () => {
     const n = BigInt('4294967296')
-    const encoded = CompactSize.toBytes(n)
-    const { value } = CompactSize.fromBytes(encoded)
+    const encoded = CompactSize.encode(n)
+    const { value } = CompactSize.decode(encoded)
     expect(typeof value).toBe('bigint')
     expect(value).toBe(4294967296n)
   })
 
   test('error: empty bytes', () => {
     expect(() =>
-      CompactSize.fromBytes(new Uint8Array()),
+      CompactSize.decode(new Uint8Array()),
     ).toThrowErrorMatchingInlineSnapshot(
       `[CompactSize.InsufficientBytesError: Insufficient bytes for CompactSize decoding. Expected at least 1, got 0.]`,
     )
@@ -142,16 +146,16 @@ describe('fromBytes', () => {
 
   test('error: insufficient bytes (3-byte encoding)', () => {
     expect(() =>
-      CompactSize.fromBytes(new Uint8Array([0xfd, 0x00])),
+      CompactSize.decode(new Uint8Array([0xfd, 0x00])),
     ).toThrowErrorMatchingInlineSnapshot(
       `[CompactSize.InsufficientBytesError: Insufficient bytes for CompactSize decoding. Expected at least 3, got 2.]`,
     )
   })
 })
 
-describe('fromHex', () => {
+describe('encode', () => {
   test('default', () => {
-    expect(CompactSize.fromHex('0xfc')).toMatchInlineSnapshot(`
+    expect(CompactSize.decode('0xfc')).toMatchInlineSnapshot(`
       {
         "size": 1,
         "value": 252n,
@@ -163,10 +167,8 @@ describe('fromHex', () => {
 test('exports', () => {
   expect(Object.keys(CompactSize)).toMatchInlineSnapshot(`
     [
-      "toBytes",
-      "toHex",
-      "fromBytes",
-      "fromHex",
+      "encode",
+      "decode",
       "NegativeValueError",
       "InsufficientBytesError",
       "InvalidValueError",

--- a/src/core/_test/Rlp.fuzz.ts
+++ b/src/core/_test/Rlp.fuzz.ts
@@ -14,8 +14,8 @@ describe('Rlp round-trip', () => {
   test.prop({ tree: arbitraryRecursiveRlpHex() }, { numRuns })(
     'toHex(from(tree, { as: "Hex" })) ≡ tree (Hex leaves)',
     ({ tree }) => {
-      const encoded = Rlp.from(tree, { as: 'Hex' })
-      const decoded = Rlp.toHex(encoded)
+      const encoded = Rlp.encode(tree, { as: 'Hex' })
+      const decoded = Rlp.decode(encoded, { as: 'Hex' })
       expect(normalizeHex(decoded)).toEqual(normalizeHex(tree))
     },
   )
@@ -23,8 +23,8 @@ describe('Rlp round-trip', () => {
   test.prop({ tree: arbitraryRecursiveRlpBytes() }, { numRuns })(
     'toBytes(from(tree, { as: "Bytes" })) ≡ tree (Bytes leaves)',
     ({ tree }) => {
-      const encoded = Rlp.from(tree, { as: 'Bytes' })
-      const decoded = Rlp.toBytes(encoded)
+      const encoded = Rlp.encode(tree, { as: 'Bytes' })
+      const decoded = Rlp.decode(encoded, { as: 'Bytes' })
       expect(normalizeBytes(decoded)).toEqual(normalizeBytes(tree))
     },
   )
@@ -32,8 +32,8 @@ describe('Rlp round-trip', () => {
   test.prop({ tree: arbitraryRecursiveRlpHex() }, { numRuns })(
     'hex and bytes encode paths agree',
     ({ tree }) => {
-      const asHex = Rlp.from(tree, { as: 'Hex' })
-      const asBytes = Rlp.from(tree, { as: 'Bytes' })
+      const asHex = Rlp.encode(tree, { as: 'Hex' })
+      const asBytes = Rlp.encode(tree, { as: 'Bytes' })
       expect(asHex).toEqual(Hex.fromBytes(asBytes))
     },
   )

--- a/src/core/_test/Rlp.test-d.ts
+++ b/src/core/_test/Rlp.test-d.ts
@@ -2,20 +2,22 @@ import { Bytes, type Hex, Rlp } from 'ox'
 import { describe, expectTypeOf, test } from 'vitest'
 import type { RecursiveArray } from '../internal/types.js'
 
-describe('Rlp.to', () => {
+describe('Rlp.decode', () => {
   test('default', () => {
-    expectTypeOf(Rlp.toHex('0x')).toEqualTypeOf<RecursiveArray<Hex.Hex>>()
-    expectTypeOf(Rlp.toBytes(Bytes.fromArray([]))).toEqualTypeOf<
-      RecursiveArray<Bytes.Bytes>
+    expectTypeOf(Rlp.decode('0x', { as: 'Hex' })).toEqualTypeOf<
+      RecursiveArray<Hex.Hex>
     >()
+    expectTypeOf(
+      Rlp.decode(Bytes.fromArray([]), { as: 'Bytes' }),
+    ).toEqualTypeOf<RecursiveArray<Bytes.Bytes>>()
   })
 })
 
-describe('Rlp.from', () => {
+describe('Rlp.encode', () => {
   test('default', () => {
-    expectTypeOf(Rlp.fromHex('0x')).toEqualTypeOf<Hex.Hex>()
+    expectTypeOf(Rlp.encode('0x', { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
     expectTypeOf(
-      Rlp.fromBytes(Bytes.fromArray([])),
+      Rlp.encode(Bytes.fromArray([]), { as: 'Bytes' }),
     ).toEqualTypeOf<Bytes.Bytes>()
   })
 })

--- a/src/core/_test/Rlp.test.ts
+++ b/src/core/_test/Rlp.test.ts
@@ -4,15 +4,11 @@ import { describe, expect, test } from 'vitest'
 test('exports', () => {
   expect(Object.keys(Rlp)).toMatchInlineSnapshot(`
     [
-      "toBytes",
-      "toHex",
-      "to",
+      "encode",
+      "decode",
       "decodeRlpCursor",
       "readLength",
       "readList",
-      "from",
-      "fromBytes",
-      "fromHex",
     ]
   `)
 })
@@ -29,151 +25,257 @@ const generateList = (length: number) => {
   return bytes
 }
 
-describe('Rlp.to', () => {
+describe('Rlp.decode', () => {
   test('no bytes', () => {
     const rlpHex = '0x'
     const rlpBytes = Uint8Array.from([])
 
     // hex -> bytes
-    expect(Rlp.toBytes(rlpHex)).toStrictEqual(new Uint8Array([]))
+    expect(Rlp.decode(rlpHex, { as: 'Bytes' })).toStrictEqual(
+      new Uint8Array([]),
+    )
     // hex -> hex
-    expect(Rlp.toHex(rlpHex)).toEqual('0x')
+    expect(Rlp.decode(rlpHex, { as: 'Hex' })).toEqual('0x')
     // bytes -> bytes
-    expect(Rlp.toBytes(rlpBytes)).toStrictEqual(new Uint8Array([]))
+    expect(Rlp.decode(rlpBytes, { as: 'Bytes' })).toStrictEqual(
+      new Uint8Array([]),
+    )
     // bytes -> hex
-    expect(Rlp.toHex(rlpBytes)).toEqual('0x')
+    expect(Rlp.decode(rlpBytes, { as: 'Hex' })).toEqual('0x')
   })
 
   describe('prefix < 0x80', () => {
     test('bytes -> bytes', () => {
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromHex('0x00')))).toEqual(
-        Bytes.fromHex('0x00'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromHex('0x01')))).toEqual(
-        Bytes.fromHex('0x01'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromHex('0x42')))).toEqual(
-        Bytes.fromHex('0x42'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromHex('0x7f')))).toEqual(
-        Bytes.fromHex('0x7f'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromString('!')))).toEqual(
-        Bytes.fromHex('0x21'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromString('a')))).toEqual(
-        Bytes.fromHex('0x61'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromString('~')))).toEqual(
-        Bytes.fromHex('0x7e'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromBoolean(true)))).toEqual(
-        Bytes.fromHex('0x01'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromBoolean(false)))).toEqual(
-        Bytes.fromHex('0x00'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromNumber(0)))).toEqual(
-        Bytes.fromHex('0x00'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromNumber(69)))).toEqual(
-        Bytes.fromHex('0x45'),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(Bytes.fromNumber(127)))).toEqual(
-        Bytes.fromHex('0x7f'),
-      )
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x00'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x00'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x01'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x01'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x42'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x42'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x7f'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x7f'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromString('!'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x21'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromString('a'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x61'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromString('~'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x7e'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromBoolean(true), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x01'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromBoolean(false), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x00'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromNumber(0), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x00'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromNumber(69), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x45'))
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromNumber(127), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x7f'))
     })
 
     test('bytes -> hex', () => {
-      expect(Rlp.toHex(Rlp.from(Bytes.fromHex('0x00'), { as: 'Hex' }))).toEqual(
-        '0x00',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromHex('0x01'), { as: 'Hex' }))).toEqual(
-        '0x01',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromHex('0x42'), { as: 'Hex' }))).toEqual(
-        '0x42',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromHex('0x7f'), { as: 'Hex' }))).toEqual(
-        '0x7f',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromString('!'), { as: 'Hex' }))).toEqual(
-        '0x21',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromString('a'), { as: 'Hex' }))).toEqual(
-        '0x61',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromString('~'), { as: 'Hex' }))).toEqual(
-        '0x7e',
-      )
       expect(
-        Rlp.toHex(Rlp.from(Bytes.fromBoolean(true), { as: 'Hex' })),
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x00'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x00')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x01'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
       ).toEqual('0x01')
       expect(
-        Rlp.toHex(Rlp.from(Bytes.fromBoolean(false), { as: 'Hex' })),
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x42'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x42')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromHex('0x7f'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x7f')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromString('!'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x21')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromString('a'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x61')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromString('~'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x7e')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromBoolean(true), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x01')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromBoolean(false), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
       ).toEqual('0x00')
-      expect(Rlp.toHex(Rlp.from(Bytes.fromNumber(0), { as: 'Hex' }))).toEqual(
-        '0x00',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromNumber(69), { as: 'Hex' }))).toEqual(
-        '0x45',
-      )
-      expect(Rlp.toHex(Rlp.from(Bytes.fromNumber(127), { as: 'Hex' }))).toEqual(
-        '0x7f',
-      )
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromNumber(0), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x00')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromNumber(69), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x45')
+      expect(
+        Rlp.decode(Rlp.encode(Bytes.fromNumber(127), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x7f')
     })
 
     test('hex -> hex', () => {
-      expect(Rlp.toHex(Rlp.from('0x00', { as: 'Hex' }))).toEqual('0x00')
-      expect(Rlp.toHex(Rlp.from('0x01', { as: 'Hex' }))).toEqual('0x01')
-      expect(Rlp.toHex(Rlp.from('0x42', { as: 'Hex' }))).toEqual('0x42')
-      expect(Rlp.toHex(Rlp.fromHex('0x7f'))).toEqual('0x7f')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromString('!')))).toEqual('0x21')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromString('a')))).toEqual('0x61')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromString('~')))).toEqual('0x7e')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromBoolean(true)))).toEqual('0x01')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromBoolean(false)))).toEqual('0x00')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromNumber(0)))).toEqual('0x00')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromNumber(69)))).toEqual('0x45')
-      expect(Rlp.toHex(Rlp.fromHex(Hex.fromNumber(127)))).toEqual('0x7f')
+      expect(
+        Rlp.decode(Rlp.encode('0x00', { as: 'Hex' }), { as: 'Hex' }),
+      ).toEqual('0x00')
+      expect(
+        Rlp.decode(Rlp.encode('0x01', { as: 'Hex' }), { as: 'Hex' }),
+      ).toEqual('0x01')
+      expect(
+        Rlp.decode(Rlp.encode('0x42', { as: 'Hex' }), { as: 'Hex' }),
+      ).toEqual('0x42')
+      expect(
+        Rlp.decode(Rlp.encode('0x7f', { as: 'Hex' }), { as: 'Hex' }),
+      ).toEqual('0x7f')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromString('!'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x21')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromString('a'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x61')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromString('~'), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x7e')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromBoolean(true), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x01')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromBoolean(false), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x00')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromNumber(0), { as: 'Hex' }), { as: 'Hex' }),
+      ).toEqual('0x00')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromNumber(69), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x45')
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromNumber(127), { as: 'Hex' }), {
+          as: 'Hex',
+        }),
+      ).toEqual('0x7f')
     })
 
     test('hex -> bytes', () => {
-      expect(Rlp.toBytes(Rlp.from('0x00', { as: 'Bytes' }))).toEqual(
-        Bytes.fromHex('0x00'),
-      )
-      expect(Rlp.toBytes(Rlp.from('0x01', { as: 'Bytes' }))).toEqual(
-        Bytes.fromHex('0x01'),
-      )
-      expect(Rlp.toBytes(Rlp.from('0x42', { as: 'Bytes' }))).toEqual(
-        Bytes.fromHex('0x42'),
-      )
-      expect(Rlp.toBytes(Rlp.from('0x7f', { as: 'Bytes' }))).toEqual(
-        Bytes.fromHex('0x7f'),
-      )
       expect(
-        Rlp.toBytes(Rlp.from(Hex.fromString('!'), { as: 'Bytes' })),
-      ).toEqual(Bytes.fromHex('0x21'))
+        Rlp.decode(Rlp.encode('0x00', { as: 'Bytes' }), { as: 'Bytes' }),
+      ).toEqual(Bytes.fromHex('0x00'))
       expect(
-        Rlp.toBytes(Rlp.from(Hex.fromString('a'), { as: 'Bytes' })),
-      ).toEqual(Bytes.fromHex('0x61'))
-      expect(
-        Rlp.toBytes(Rlp.from(Hex.fromString('~'), { as: 'Bytes' })),
-      ).toEqual(Bytes.fromHex('0x7e'))
-      expect(
-        Rlp.toBytes(Rlp.from(Hex.fromBoolean(true), { as: 'Bytes' })),
+        Rlp.decode(Rlp.encode('0x01', { as: 'Bytes' }), { as: 'Bytes' }),
       ).toEqual(Bytes.fromHex('0x01'))
       expect(
-        Rlp.toBytes(Rlp.from(Hex.fromBoolean(false), { as: 'Bytes' })),
-      ).toEqual(Bytes.fromHex('0x00'))
-      expect(Rlp.toBytes(Rlp.from(Hex.fromNumber(0), { as: 'Bytes' }))).toEqual(
-        Bytes.fromHex('0x00'),
-      )
+        Rlp.decode(Rlp.encode('0x42', { as: 'Bytes' }), { as: 'Bytes' }),
+      ).toEqual(Bytes.fromHex('0x42'))
       expect(
-        Rlp.toBytes(Rlp.from(Hex.fromNumber(69), { as: 'Bytes' })),
+        Rlp.decode(Rlp.encode('0x7f', { as: 'Bytes' }), { as: 'Bytes' }),
+      ).toEqual(Bytes.fromHex('0x7f'))
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromString('!'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x21'))
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromString('a'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x61'))
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromString('~'), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x7e'))
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromBoolean(true), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x01'))
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromBoolean(false), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x00'))
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromNumber(0), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(Bytes.fromHex('0x00'))
+      expect(
+        Rlp.decode(Rlp.encode(Hex.fromNumber(69), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
       ).toEqual(Bytes.fromHex('0x45'))
       expect(
-        Rlp.toBytes(Rlp.from(Hex.fromNumber(127), { as: 'Bytes' })),
+        Rlp.decode(Rlp.encode(Hex.fromNumber(127), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
       ).toEqual(Bytes.fromHex('0x7f'))
     })
   })
@@ -181,43 +283,69 @@ describe('Rlp.to', () => {
   describe('list', () => {
     test('no bytes', () => {
       // bytes -> bytes
-      expect(Rlp.toBytes(Rlp.fromBytes([]))).toEqual([])
+      expect(
+        Rlp.decode(Rlp.encode([], { as: 'Bytes' }), { as: 'Bytes' }),
+      ).toEqual([])
       // bytes -> hex
-      expect(Rlp.toHex(Rlp.fromBytes([]))).toEqual([])
+      expect(
+        Rlp.decode(Rlp.encode([], { as: 'Bytes' }), { as: 'Hex' }),
+      ).toEqual([])
       // hex -> hex
-      expect(Rlp.toHex(Rlp.fromHex([]))).toEqual([])
+      expect(Rlp.decode(Rlp.encode([], { as: 'Hex' }), { as: 'Hex' })).toEqual(
+        [],
+      )
       // hex -> bytes
-      expect(Rlp.toBytes(Rlp.fromHex([]))).toEqual([])
+      expect(
+        Rlp.decode(Rlp.encode([], { as: 'Hex' }), { as: 'Bytes' }),
+      ).toEqual([])
     })
 
     test('inner no bytes', () => {
       // bytes -> bytes
-      expect(Rlp.toBytes(Rlp.fromBytes([[]]))).toEqual([[]])
+      expect(
+        Rlp.decode(Rlp.encode([[]], { as: 'Bytes' }), { as: 'Bytes' }),
+      ).toEqual([[]])
       // bytes -> hex
-      expect(Rlp.toHex(Rlp.fromBytes([[]]))).toEqual([[]])
+      expect(
+        Rlp.decode(Rlp.encode([[]], { as: 'Bytes' }), { as: 'Hex' }),
+      ).toEqual([[]])
       // hex -> hex
-      expect(Rlp.toHex(Rlp.fromHex([[]]))).toEqual([[]])
+      expect(
+        Rlp.decode(Rlp.encode([[]], { as: 'Hex' }), { as: 'Hex' }),
+      ).toEqual([[]])
       // hex -> bytes
-      expect(Rlp.toBytes(Rlp.fromHex([[]]))).toEqual([[]])
+      expect(
+        Rlp.decode(Rlp.encode([[]], { as: 'Hex' }), { as: 'Bytes' }),
+      ).toEqual([[]])
     })
 
     describe('prefix < 0xf8', () => {
       test('bytes -> bytes', () => {
-        expect(Rlp.toBytes(Rlp.fromBytes([Bytes.fromHex('0x00')]))).toEqual([
-          Bytes.fromHex('0x00'),
-        ])
-        expect(Rlp.toBytes(Rlp.fromBytes([Bytes.fromHex('0x80')]))).toEqual([
-          Bytes.fromHex('0x80'),
-        ])
-        expect(Rlp.toBytes(Rlp.fromBytes(generateList(14)))).toEqual(
-          generateList(14),
-        )
         expect(
-          Rlp.toBytes(
-            Rlp.fromBytes([
-              generateList(4),
-              [generateList(8), [generateList(3), generateBytes(1)]],
-            ]),
+          Rlp.decode(Rlp.encode([Bytes.fromHex('0x00')], { as: 'Bytes' }), {
+            as: 'Bytes',
+          }),
+        ).toEqual([Bytes.fromHex('0x00')])
+        expect(
+          Rlp.decode(Rlp.encode([Bytes.fromHex('0x80')], { as: 'Bytes' }), {
+            as: 'Bytes',
+          }),
+        ).toEqual([Bytes.fromHex('0x80')])
+        expect(
+          Rlp.decode(Rlp.encode(generateList(14), { as: 'Bytes' }), {
+            as: 'Bytes',
+          }),
+        ).toEqual(generateList(14))
+        expect(
+          Rlp.decode(
+            Rlp.encode(
+              [
+                generateList(4),
+                [generateList(8), [generateList(3), generateBytes(1)]],
+              ],
+              { as: 'Bytes' },
+            ),
+            { as: 'Bytes' },
           ),
         ).toEqual([
           generateList(4),
@@ -226,20 +354,27 @@ describe('Rlp.to', () => {
       })
 
       test('bytes -> hex', () => {
-        expect(Rlp.toHex(Rlp.from(['0x00'], { as: 'Bytes' }))).toEqual(['0x00'])
-        expect(Rlp.toHex(Rlp.from(['0x80'], { as: 'Bytes' }))).toEqual(['0x80'])
-        expect(Rlp.toHex(Rlp.from(generateList(14), { as: 'Bytes' }))).toEqual(
-          generateList(14).map((x) => Hex.fromBytes(x)),
-        )
         expect(
-          Rlp.toHex(
-            Rlp.from(
+          Rlp.decode(Rlp.encode(['0x00'], { as: 'Bytes' }), { as: 'Hex' }),
+        ).toEqual(['0x00'])
+        expect(
+          Rlp.decode(Rlp.encode(['0x80'], { as: 'Bytes' }), { as: 'Hex' }),
+        ).toEqual(['0x80'])
+        expect(
+          Rlp.decode(Rlp.encode(generateList(14), { as: 'Bytes' }), {
+            as: 'Hex',
+          }),
+        ).toEqual(generateList(14).map((x) => Hex.fromBytes(x)))
+        expect(
+          Rlp.decode(
+            Rlp.encode(
               [
                 generateList(4),
                 [generateList(8), [generateList(3), generateBytes(1)]],
               ],
               { as: 'Bytes' },
             ),
+            { as: 'Hex' },
           ),
         ).toEqual([
           generateList(4).map((x) => Hex.fromBytes(x)),
@@ -254,23 +389,37 @@ describe('Rlp.to', () => {
       })
 
       test('hex -> hex', () => {
-        expect(Rlp.toHex(Rlp.fromHex(['0x00']))).toEqual(['0x00'])
-        expect(Rlp.toHex(Rlp.fromHex(['0x80']))).toEqual(['0x80'])
         expect(
-          Rlp.toHex(Rlp.fromHex(generateList(14).map((x) => Hex.fromBytes(x)))),
+          Rlp.decode(Rlp.encode(['0x00'], { as: 'Hex' }), { as: 'Hex' }),
+        ).toEqual(['0x00'])
+        expect(
+          Rlp.decode(Rlp.encode(['0x80'], { as: 'Hex' }), { as: 'Hex' }),
+        ).toEqual(['0x80'])
+        expect(
+          Rlp.decode(
+            Rlp.encode(
+              generateList(14).map((x) => Hex.fromBytes(x)),
+              { as: 'Hex' },
+            ),
+            { as: 'Hex' },
+          ),
         ).toEqual(generateList(14).map((x) => Hex.fromBytes(x)))
         expect(
-          Rlp.toHex(
-            Rlp.fromHex([
-              generateList(4).map((x) => Hex.fromBytes(x)),
+          Rlp.decode(
+            Rlp.encode(
               [
-                generateList(8).map((x) => Hex.fromBytes(x)),
+                generateList(4).map((x) => Hex.fromBytes(x)),
                 [
-                  generateList(3).map((x) => Hex.fromBytes(x)),
-                  Hex.fromBytes(generateBytes(1)),
+                  generateList(8).map((x) => Hex.fromBytes(x)),
+                  [
+                    generateList(3).map((x) => Hex.fromBytes(x)),
+                    Hex.fromBytes(generateBytes(1)),
+                  ],
                 ],
               ],
-            ]),
+              { as: 'Hex' },
+            ),
+            { as: 'Hex' },
           ),
         ).toEqual([
           generateList(4).map((x) => Hex.fromBytes(x)),
@@ -285,24 +434,27 @@ describe('Rlp.to', () => {
       })
 
       test('hex -> bytes', () => {
-        expect(Rlp.toBytes(Rlp.from(['0x00'], { as: 'Hex' }))).toEqual([
-          Bytes.fromHex('0x00'),
-        ])
-        expect(Rlp.toBytes(Rlp.from(['0x80'], { as: 'Hex' }))).toEqual([
-          Bytes.fromHex('0x80'),
-        ])
-        expect(Rlp.toBytes(Rlp.from(generateList(14), { as: 'Hex' }))).toEqual(
-          generateList(14),
-        )
         expect(
-          Rlp.toBytes(
-            Rlp.from(
+          Rlp.decode(Rlp.encode(['0x00'], { as: 'Hex' }), { as: 'Bytes' }),
+        ).toEqual([Bytes.fromHex('0x00')])
+        expect(
+          Rlp.decode(Rlp.encode(['0x80'], { as: 'Hex' }), { as: 'Bytes' }),
+        ).toEqual([Bytes.fromHex('0x80')])
+        expect(
+          Rlp.decode(Rlp.encode(generateList(14), { as: 'Hex' }), {
+            as: 'Bytes',
+          }),
+        ).toEqual(generateList(14))
+        expect(
+          Rlp.decode(
+            Rlp.encode(
               [
                 generateList(4),
                 [generateList(8), [generateList(3), generateBytes(1)]],
               ],
               { as: 'Hex' },
             ),
+            { as: 'Bytes' },
           ),
         ).toEqual([
           generateList(4),
@@ -312,23 +464,31 @@ describe('Rlp.to', () => {
     })
 
     test('prefix === 0xf9', () => {
-      expect(Rlp.toBytes(Rlp.fromBytes(generateList(61)))).toEqual(
-        generateList(61),
-      )
-      expect(Rlp.toBytes(Rlp.fromBytes(generateList(12_000)))).toEqual(
-        generateList(12_000),
-      )
+      expect(
+        Rlp.decode(Rlp.encode(generateList(61), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(generateList(61))
+      expect(
+        Rlp.decode(Rlp.encode(generateList(12_000), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(generateList(12_000))
     })
 
     test('prefix === 0xfa', () => {
-      expect(Rlp.toBytes(Rlp.fromBytes(generateList(60_000)))).toEqual(
-        generateList(60_000),
-      )
+      expect(
+        Rlp.decode(Rlp.encode(generateList(60_000), { as: 'Bytes' }), {
+          as: 'Bytes',
+        }),
+      ).toEqual(generateList(60_000))
     })
   })
 
   test('error: invalid hex value', () => {
-    expect(() => Rlp.toHex('0x010')).toThrowErrorMatchingInlineSnapshot(
+    expect(() =>
+      Rlp.decode('0x010', { as: 'Hex' }),
+    ).toThrowErrorMatchingInlineSnapshot(
       `
     [Hex.InvalidLengthError: Hex value \`"0x010"\` is an odd length (3 nibbles).
 

--- a/src/core/_test/TransactionEnvelopeEip1559.test.ts
+++ b/src/core/_test/TransactionEnvelopeEip1559.test.ts
@@ -135,17 +135,20 @@ describe('deserialize', () => {
 
   describe('raw', () => {
     test('default', () => {
-      const serialized = `0x02${Rlp.fromHex([
-        Hex.fromNumber(1), // chainId
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // maxPriorityFeePerGas
-        Hex.fromNumber(1), // maxFeePerGas
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x', // accessList
-      ]).slice(2)}` as const
+      const serialized = `0x02${Rlp.encode(
+        [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x', // accessList
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeEip1559.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "chainId": 1,
@@ -161,20 +164,23 @@ describe('deserialize', () => {
     })
 
     test('empty sig', () => {
-      const serialized = `0x02${Rlp.fromHex([
-        Hex.fromNumber(1), // chainId
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // maxPriorityFeePerGas
-        Hex.fromNumber(1), // maxFeePerGas
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x', // accessList
-        '0x', // r
-        '0x', // v
-        '0x', // s
-      ]).slice(2)}` as const
+      const serialized = `0x02${Rlp.encode(
+        [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x', // accessList
+          '0x', // r
+          '0x', // v
+          '0x', // s
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeEip1559.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "chainId": 1,
@@ -193,20 +199,23 @@ describe('deserialize', () => {
     })
 
     test('low sig coords', () => {
-      const serialized = `0x02${Rlp.fromHex([
-        Hex.fromNumber(1), // chainId
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // maxPriorityFeePerGas
-        Hex.fromNumber(1), // maxFeePerGas
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x', // accessList
-        '0x', // r
-        Hex.fromNumber(69), // v
-        Hex.fromNumber(420), // s
-      ]).slice(2)}` as const
+      const serialized = `0x02${Rlp.encode(
+        [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x', // accessList
+          '0x', // r
+          Hex.fromNumber(69), // v
+          Hex.fromNumber(420), // s
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeEip1559.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "chainId": 1,
@@ -229,24 +238,27 @@ describe('deserialize', () => {
     test('invalid access list (invalid address)', () => {
       expect(() =>
         TxEnvelopeEip1559.deserialize(
-          `0x02${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
+          `0x02${Rlp.encode(
             [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
               [
-                '0x',
                 [
-                  '0x0000000000000000000000000000000000000000000000000000000000000001',
+                  '0x',
+                  [
+                    '0x0000000000000000000000000000000000000000000000000000000000000001',
+                  ],
                 ],
-              ],
-            ], // accessList
-          ]).slice(2)}`,
+              ], // accessList
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [Address.InvalidAddressError: Address "0x" is invalid.
@@ -256,17 +268,20 @@ describe('deserialize', () => {
 
       expect(() =>
         TxEnvelopeEip1559.deserialize(
-          `0x02${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
-            [['0x123456', ['0x0']]], // accessList
-          ]).slice(2)}`,
+          `0x02${Rlp.encode(
+            [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
+              [['0x123456', ['0x0']]], // accessList
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [Address.InvalidAddressError: Address "0x123456" is invalid.
@@ -277,7 +292,9 @@ describe('deserialize', () => {
 
     test('invalid transaction (all missing)', () => {
       expect(() =>
-        TxEnvelopeEip1559.deserialize(`0x02${Rlp.fromHex([]).slice(2)}`),
+        TxEnvelopeEip1559.deserialize(
+          `0x02${Rlp.encode([], { as: 'Hex' }).slice(2)}`,
+        ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip1559" was provided.
 
@@ -289,7 +306,7 @@ describe('deserialize', () => {
     test('invalid transaction (some missing)', () => {
       expect(() =>
         TxEnvelopeEip1559.deserialize(
-          `0x02${Rlp.fromHex(['0x00', '0x01']).slice(2)}`,
+          `0x02${Rlp.encode(['0x00', '0x01'], { as: 'Hex' }).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip1559" was provided.
@@ -302,18 +319,10 @@ describe('deserialize', () => {
     test('invalid transaction (missing signature)', () => {
       expect(() =>
         TxEnvelopeEip1559.deserialize(
-          `0x02${Rlp.fromHex([
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-          ]).slice(2)}`,
+          `0x02${Rlp.encode(
+            ['0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x'],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip1559" was provided.

--- a/src/core/_test/TransactionEnvelopeEip2930.test.ts
+++ b/src/core/_test/TransactionEnvelopeEip2930.test.ts
@@ -120,7 +120,9 @@ describe('deserialize', () => {
   describe('errors', () => {
     test('invalid transaction (all missing)', () => {
       expect(() =>
-        TxEnvelopeEip2930.deserialize(`0x01${Rlp.fromHex([]).slice(2)}`),
+        TxEnvelopeEip2930.deserialize(
+          `0x01${Rlp.encode([], { as: 'Hex' }).slice(2)}`,
+        ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip2930" was provided.
 
@@ -132,7 +134,7 @@ describe('deserialize', () => {
     test('invalid transaction (some missing)', () => {
       expect(() =>
         TxEnvelopeEip2930.deserialize(
-          `0x01${Rlp.fromHex(['0x00', '0x01']).slice(2)}`,
+          `0x01${Rlp.encode(['0x00', '0x01'], { as: 'Hex' }).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip2930" was provided.
@@ -145,17 +147,10 @@ describe('deserialize', () => {
     test('invalid transaction (missing signature)', () => {
       expect(() =>
         TxEnvelopeEip2930.deserialize(
-          `0x01${Rlp.fromHex([
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-          ]).slice(2)}`,
+          `0x01${Rlp.encode(
+            ['0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x'],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip2930" was provided.

--- a/src/core/_test/TransactionEnvelopeEip4844.test.ts
+++ b/src/core/_test/TransactionEnvelopeEip4844.test.ts
@@ -168,26 +168,29 @@ describe('deserialize', () => {
     test('invalid access list (invalid address)', () => {
       expect(() =>
         TxEnvelopeEip4844.deserialize(
-          `0x03${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
+          `0x03${Rlp.encode(
             [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
               [
-                '0x',
                 [
-                  '0x0000000000000000000000000000000000000000000000000000000000000001',
+                  '0x',
+                  [
+                    '0x0000000000000000000000000000000000000000000000000000000000000001',
+                  ],
                 ],
-              ],
-            ], // accessList
-            '0x', // maxFeePerBlobGas,
-            ['0x'], // blobVersionedHashes
-          ]).slice(2)}`,
+              ], // accessList
+              '0x', // maxFeePerBlobGas,
+              ['0x'], // blobVersionedHashes
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [Address.InvalidAddressError: Address "0x" is invalid.
@@ -197,19 +200,22 @@ describe('deserialize', () => {
 
       expect(() =>
         TxEnvelopeEip4844.deserialize(
-          `0x03${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
-            [['0x123456', ['0x0']]], // accessList
-            '0x', // maxFeePerBlobGas,
-            ['0x'], // blobVersionedHashes
-          ]).slice(2)}`,
+          `0x03${Rlp.encode(
+            [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
+              [['0x123456', ['0x0']]], // accessList
+              '0x', // maxFeePerBlobGas,
+              ['0x'], // blobVersionedHashes
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [Address.InvalidAddressError: Address "0x123456" is invalid.
@@ -220,7 +226,9 @@ describe('deserialize', () => {
 
     test('invalid transaction (all missing)', () => {
       expect(() =>
-        TxEnvelopeEip4844.deserialize(`0x03${Rlp.fromHex([]).slice(2)}`),
+        TxEnvelopeEip4844.deserialize(
+          `0x03${Rlp.encode([], { as: 'Hex' }).slice(2)}`,
+        ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip4844" was provided.
 
@@ -232,7 +240,7 @@ describe('deserialize', () => {
     test('invalid transaction (some missing)', () => {
       expect(() =>
         TxEnvelopeEip4844.deserialize(
-          `0x03${Rlp.fromHex(['0x00', '0x01']).slice(2)}`,
+          `0x03${Rlp.encode(['0x00', '0x01'], { as: 'Hex' }).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip4844" was provided.
@@ -245,20 +253,23 @@ describe('deserialize', () => {
     test('invalid transaction (missing signature)', () => {
       expect(() =>
         TxEnvelopeEip4844.deserialize(
-          `0x03${Rlp.fromHex([
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-          ]).slice(2)}`,
+          `0x03${Rlp.encode(
+            [
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+              '0x',
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip4844" was provided.

--- a/src/core/_test/TransactionEnvelopeEip7702.test.ts
+++ b/src/core/_test/TransactionEnvelopeEip7702.test.ts
@@ -183,18 +183,21 @@ describe('deserialize', () => {
 
   describe('raw', () => {
     test('default', () => {
-      const serialized = `0x04${Rlp.fromHex([
-        Hex.fromNumber(1), // chainId
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // maxPriorityFeePerGas
-        Hex.fromNumber(1), // maxFeePerGas
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x', // accessList
-        '0x', // authorizationList
-      ]).slice(2)}` as const
+      const serialized = `0x04${Rlp.encode(
+        [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x', // accessList
+          '0x', // authorizationList
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeEip7702.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "chainId": 1,
@@ -210,21 +213,24 @@ describe('deserialize', () => {
     })
 
     test('empty sig', () => {
-      const serialized = `0x04${Rlp.fromHex([
-        Hex.fromNumber(1), // chainId
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // maxPriorityFeePerGas
-        Hex.fromNumber(1), // maxFeePerGas
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x', // accessList
-        '0x', // authorizationList
-        '0x', // r
-        '0x', // v
-        '0x', // s
-      ]).slice(2)}` as const
+      const serialized = `0x04${Rlp.encode(
+        [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x', // accessList
+          '0x', // authorizationList
+          '0x', // r
+          '0x', // v
+          '0x', // s
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeEip7702.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "chainId": 1,
@@ -243,21 +249,24 @@ describe('deserialize', () => {
     })
 
     test('low sig coords', () => {
-      const serialized = `0x04${Rlp.fromHex([
-        Hex.fromNumber(1), // chainId
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // maxPriorityFeePerGas
-        Hex.fromNumber(1), // maxFeePerGas
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x', // accessList
-        '0x', // authorizationList
-        '0x', // r
-        Hex.fromNumber(69), // v
-        Hex.fromNumber(420), // s
-      ]).slice(2)}` as const
+      const serialized = `0x04${Rlp.encode(
+        [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x', // accessList
+          '0x', // authorizationList
+          '0x', // r
+          Hex.fromNumber(69), // v
+          Hex.fromNumber(420), // s
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeEip7702.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "chainId": 1,
@@ -280,25 +289,28 @@ describe('deserialize', () => {
     test('invalid access list (invalid address)', () => {
       expect(() =>
         TxEnvelopeEip7702.deserialize(
-          `0x04${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
+          `0x04${Rlp.encode(
             [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
               [
-                '0x',
                 [
-                  '0x0000000000000000000000000000000000000000000000000000000000000001',
+                  '0x',
+                  [
+                    '0x0000000000000000000000000000000000000000000000000000000000000001',
+                  ],
                 ],
-              ],
-            ], // accessList
-            '0x', // authorizationList
-          ]).slice(2)}`,
+              ], // accessList
+              '0x', // authorizationList
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [Address.InvalidAddressError: Address "0x" is invalid.
@@ -308,18 +320,21 @@ describe('deserialize', () => {
 
       expect(() =>
         TxEnvelopeEip7702.deserialize(
-          `0x04${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
-            [['0x123456', ['0x0']]], // accessList
-            '0x', // authorizationList
-          ]).slice(2)}`,
+          `0x04${Rlp.encode(
+            [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
+              [['0x123456', ['0x0']]], // accessList
+              '0x', // authorizationList
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [Address.InvalidAddressError: Address "0x123456" is invalid.
@@ -330,7 +345,9 @@ describe('deserialize', () => {
 
     test('invalid transaction (all missing)', () => {
       expect(() =>
-        TxEnvelopeEip7702.deserialize(`0x04${Rlp.fromHex([]).slice(2)}`),
+        TxEnvelopeEip7702.deserialize(
+          `0x04${Rlp.encode([], { as: 'Hex' }).slice(2)}`,
+        ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip7702" was provided.
 
@@ -342,7 +359,7 @@ describe('deserialize', () => {
     test('invalid transaction (some missing)', () => {
       expect(() =>
         TxEnvelopeEip7702.deserialize(
-          `0x04${Rlp.fromHex(['0x00', '0x01']).slice(2)}`,
+          `0x04${Rlp.encode(['0x00', '0x01'], { as: 'Hex' }).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip7702" was provided.
@@ -355,19 +372,10 @@ describe('deserialize', () => {
     test('invalid transaction (missing signature)', () => {
       expect(() =>
         TxEnvelopeEip7702.deserialize(
-          `0x04${Rlp.fromHex([
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-          ]).slice(2)}`,
+          `0x04${Rlp.encode(
+            ['0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x'],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "eip7702" was provided.

--- a/src/core/_test/TransactionEnvelopeLegacy.test.ts
+++ b/src/core/_test/TransactionEnvelopeLegacy.test.ts
@@ -196,14 +196,17 @@ describe('deserialize', () => {
 
   describe('raw', () => {
     test('default', () => {
-      const serialized = Rlp.fromHex([
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // gasPrice
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-      ])
+      const serialized = Rlp.encode(
+        [
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // gasPrice
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+        ],
+        { as: 'Hex' },
+      )
       expect(TxEnvelopeLegacy.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "gas": 1n,
@@ -217,17 +220,20 @@ describe('deserialize', () => {
     })
 
     test('empty sig', () => {
-      const serialized = Rlp.fromHex([
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // gasPrice
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x', // v
-        '0x', // r
-        '0x', // s
-      ])
+      const serialized = Rlp.encode(
+        [
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // gasPrice
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x', // v
+          '0x', // r
+          '0x', // s
+        ],
+        { as: 'Hex' },
+      )
       expect(TxEnvelopeLegacy.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "gas": 1n,
@@ -241,17 +247,20 @@ describe('deserialize', () => {
     })
 
     test('low sig coords', () => {
-      const serialized = Rlp.fromHex([
-        Hex.fromNumber(0), // nonce
-        Hex.fromNumber(1), // gasPrice
-        Hex.fromNumber(1), // gas
-        '0x0000000000000000000000000000000000000000', // to
-        Hex.fromNumber(0), // value
-        '0x', // data
-        '0x1b', // v
-        Hex.fromNumber(69), // r
-        Hex.fromNumber(420), // s
-      ])
+      const serialized = Rlp.encode(
+        [
+          Hex.fromNumber(0), // nonce
+          Hex.fromNumber(1), // gasPrice
+          Hex.fromNumber(1), // gas
+          '0x0000000000000000000000000000000000000000', // to
+          Hex.fromNumber(0), // value
+          '0x', // data
+          '0x1b', // v
+          Hex.fromNumber(69), // r
+          Hex.fromNumber(420), // s
+        ],
+        { as: 'Hex' },
+      )
       expect(TxEnvelopeLegacy.deserialize(serialized)).toMatchInlineSnapshot(`
       {
         "gas": 1n,
@@ -272,7 +281,7 @@ describe('deserialize', () => {
   describe('errors', () => {
     test('invalid transaction (all missing)', () => {
       expect(() =>
-        TxEnvelopeLegacy.deserialize(Rlp.fromHex([])),
+        TxEnvelopeLegacy.deserialize(Rlp.encode([], { as: 'Hex' })),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "legacy" was provided.
 
@@ -283,7 +292,9 @@ describe('deserialize', () => {
 
     test('invalid transaction (some missing)', () => {
       expect(() =>
-        TxEnvelopeLegacy.deserialize(Rlp.fromHex(['0x00', '0x01'])),
+        TxEnvelopeLegacy.deserialize(
+          Rlp.encode(['0x00', '0x01'], { as: 'Hex' }),
+        ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "legacy" was provided.
 
@@ -295,7 +306,7 @@ describe('deserialize', () => {
     test('invalid transaction (missing signature)', () => {
       expect(() =>
         TxEnvelopeLegacy.deserialize(
-          Rlp.fromHex(['0x', '0x', '0x', '0x', '0x', '0x', '0x']),
+          Rlp.encode(['0x', '0x', '0x', '0x', '0x', '0x', '0x'], { as: 'Hex' }),
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "legacy" was provided.
@@ -308,18 +319,10 @@ describe('deserialize', () => {
     test('invalid transaction (attribute overload)', () => {
       expect(() =>
         TxEnvelopeLegacy.deserialize(
-          Rlp.fromHex([
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-            '0x',
-          ]),
+          Rlp.encode(
+            ['0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x', '0x'],
+            { as: 'Hex' },
+          ),
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
       [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "legacy" was provided.
@@ -331,17 +334,20 @@ describe('deserialize', () => {
     test('invalid v', () => {
       expect(() =>
         TxEnvelopeLegacy.deserialize(
-          Rlp.fromHex([
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // gasPrice
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
-            '0x', // v
-            Hex.fromNumber(69), // r
-            Hex.fromNumber(420), // s
-          ]),
+          Rlp.encode(
+            [
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // gasPrice
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
+              '0x', // v
+              Hex.fromNumber(69), // r
+              Hex.fromNumber(420), // s
+            ],
+            { as: 'Hex' },
+          ),
         ),
       ).toThrowErrorMatchingInlineSnapshot(
         '[Signature.InvalidVError: Value `0` is an invalid v value. v must be 27, 28 or >=35.]',
@@ -349,17 +355,20 @@ describe('deserialize', () => {
 
       expect(() =>
         TxEnvelopeLegacy.deserialize(
-          Rlp.fromHex([
-            Hex.fromNumber(0), // nonce
-            Hex.fromNumber(1), // gasPrice
-            Hex.fromNumber(1), // gas
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
-            Hex.fromNumber(35), // v
-            Hex.fromNumber(69), // r
-            Hex.fromNumber(420), // s
-          ]),
+          Rlp.encode(
+            [
+              Hex.fromNumber(0), // nonce
+              Hex.fromNumber(1), // gasPrice
+              Hex.fromNumber(1), // gas
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
+              Hex.fromNumber(35), // v
+              Hex.fromNumber(69), // r
+              Hex.fromNumber(420), // s
+            ],
+            { as: 'Hex' },
+          ),
         ),
       ).toThrowErrorMatchingInlineSnapshot(
         '[Signature.InvalidVError: Value `35` is an invalid v value. v must be 27, 28 or >=35.]',

--- a/src/core/internal/tx.ts
+++ b/src/core/internal/tx.ts
@@ -84,7 +84,7 @@ export function hexToHexOrUndefined(
 
 /**
  * Decodes a `Bytes` scalar (typically a `Uint8Array.subarray` view returned
- * by `Rlp.toBytes`) into `bigint`, or `undefined` when the field is absent
+ * by `Rlp.decode`) into `bigint`, or `undefined` when the field is absent
  * or empty.
  *
  * For payloads ≤ 6 bytes (the common case for `chainId`, `nonce`, `gas`,
@@ -129,7 +129,7 @@ export function bytesToNumberOrUndefined(
 /**
  * Encodes a `Bytes` scalar to `Hex`, returning `undefined` when the field is
  * absent or empty. Used for opaque hex fields like `to` / `data` after
- * decoding via `Rlp.toBytes`.
+ * decoding via `Rlp.decode`.
  *
  * @internal
  */
@@ -154,7 +154,7 @@ export function bytesToHex(value: Bytes.Bytes): Hex.Hex {
 
 /**
  * Recursively maps a `RecursiveArray<Bytes>` (e.g. as returned by
- * `Rlp.toBytes`) to a `RecursiveArray<Hex>`. Used by envelope decoders to
+ * `Rlp.decode`) to a `RecursiveArray<Hex>`. Used by envelope decoders to
  * hand the (rarely-large) access list / authorization list sub-trees off to
  * their existing hex-typed `fromTupleList` codecs without re-running RLP.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -847,7 +847,7 @@ export * as Authorization from './core/Authorization.js'
  * ```ts twoslash
  * import { Base32 } from 'ox'
  *
- * const value = Base32.fromHex('0x00ff00')
+ * const value = Base32.encode('0x00ff00')
  * ```
  *
  * @example
@@ -856,7 +856,7 @@ export * as Authorization from './core/Authorization.js'
  * ```ts twoslash
  * import { Base32 } from 'ox'
  *
- * const value = Base32.toBytes('qrlsq')
+ * const value = Base32.decode('qrlsq')
  * ```
  *
  * @category Data
@@ -868,48 +868,36 @@ export * as Base32 from './core/Base32.js'
  * @example
  * ### Encoding to Base58
  *
- * Values can be encoded to Base58 with:
- *
- * - {@link ox#Base58.(fromString:function)}, or
- *
- * - {@link ox#Base58.(fromBytes:function)}, or
- *
- * - {@link ox#Base58.(fromHex:function)}
+ * Values can be encoded to Base58 with {@link ox#Base58.(encode:function)}:
  *
  * ```ts twoslash
  * import { Base58 } from 'ox'
  *
- * const value_string = Base58.fromString('Hello World!')
+ * const value_string = Base58.encode('Hello World!')
  * // @log: '2NEpo7TZRRrLZSi2U'
  *
- * const value_bytes = Base58.fromBytes(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]))
+ * const value_bytes = Base58.encode(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]))
  * // @log: '2NEpo7TZRRrLZSi2U'
  *
- * const value_hex = Base58.fromHex('0x48656c6c6f20576f726c6421')
+ * const value_hex = Base58.encode('0x48656c6c6f20576f726c6421')
  * // @log: '2NEpo7TZRRrLZSi2U'
  * ```
  *
  * @example
  * ### Decoding Base58
  *
- * Values can be decoded from Base58 with:
- *
- * - {@link ox#Base58.(toString:function)}, or
- *
- * - {@link ox#Base58.(toBytes:function)}, or
- *
- * - {@link ox#Base58.(toHex:function)}
+ * Values can be decoded from Base58 with {@link ox#Base58.(decode:function)}:
  *
  * ```ts twoslash
  * import { Base58 } from 'ox'
  *
- * const value_string = Base58.toString('2NEpo7TZRRrLZSi2U')
+ * const value_string = Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'String' })
  * // @log: 'Hello World!'
  *
- * const value_bytes = Base58.toBytes('2NEpo7TZRRrLZSi2U')
+ * const value_bytes = Base58.decode('2NEpo7TZRRrLZSi2U')
  * // @log: Uint8Array [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]
  *
- * const value_hex = Base58.toHex('2NEpo7TZRRrLZSi2U')
+ * const value_hex = Base58.decode('2NEpo7TZRRrLZSi2U', { as: 'Hex' })
  * // @log: '0x48656c6c6f20576f726c6421'
  * ```
  *
@@ -922,47 +910,35 @@ export * as Base58 from './core/Base58.js'
  * @example
  * ### Encoding to Base64
  *
- * Values can be encoded to Base64 with:
- *
- * - {@link ox#Base64.(fromString:function)}, or
- *
- * - {@link ox#Base64.(fromBytes:function)}, or
- *
- * - {@link ox#Base64.(fromHex:function)}
+ * Values can be encoded to Base64 with {@link ox#Base64.(encode:function)}:
  *
  * ```ts twoslash
  * import { Base64 } from 'ox'
  *
- * const value_string = Base64.fromString('Hello World!')
+ * const value_string = Base64.encode('Hello World!')
  * // @log: 'SGVsbG8gV29ybGQh=='
  *
- * const value_bytes = Base64.fromBytes(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]))
+ * const value_bytes = Base64.encode(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]))
  * // @log: 'SGVsbG8gV29ybGQh=='
  *
- * const value_hex = Base64.fromHex('0x48656c6c6f20576f726c6421')
+ * const value_hex = Base64.encode('0x48656c6c6f20576f726c6421')
  * // @log: 'SGVsbG8gV29ybGQh=='
  * ```
  *
  * ### Decoding Base64
  *
- * Values can be decoded from Base64 with:
- *
- * - {@link ox#Base64.(toString:function)}, or
- *
- * - {@link ox#Base64.(toBytes:function)}, or
- *
- * - {@link ox#Base64.(toHex:function)}
+ * Values can be decoded from Base64 with {@link ox#Base64.(decode:function)}:
  *
  * ```ts twoslash
  * import { Base64 } from 'ox'
  *
- * const value_string = Base64.toString('SGVsbG8gV29ybGQh==')
+ * const value_string = Base64.decode('SGVsbG8gV29ybGQh==', { as: 'String' })
  * // @log: 'Hello World!'
  *
- * const value_bytes = Base64.toBytes('SGVsbG8gV29ybGQh==')
+ * const value_bytes = Base64.decode('SGVsbG8gV29ybGQh==')
  * // @log: Uint8Array [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]
  *
- * const value_hex = Base64.toHex('SGVsbG8gV29ybGQh==')
+ * const value_hex = Base64.decode('SGVsbG8gV29ybGQh==', { as: 'Hex' })
  * // @log: '0x48656c6c6f20576f726c6421'
  * ```
  *
@@ -1387,7 +1363,7 @@ export * as Cbor from './core/Cbor.js'
  * ```ts twoslash
  * import { CompactSize } from 'ox'
  *
- * const bytes = CompactSize.toBytes(65535)
+ * const bytes = CompactSize.encode(65535)
  * ```
  *
  * @example
@@ -1396,7 +1372,7 @@ export * as Cbor from './core/Cbor.js'
  * ```ts twoslash
  * import { CompactSize } from 'ox'
  *
- * const { value, size } = CompactSize.fromBytes(new Uint8Array([0xfd, 0xff, 0xff]))
+ * const { value, size } = CompactSize.decode(new Uint8Array([0xfd, 0xff, 0xff]))
  * ```
  *
  * @category Data
@@ -2133,10 +2109,10 @@ export * as PublicKey from './core/PublicKey.js'
  * ```ts twoslash
  * import { Hex, Rlp } from 'ox'
  *
- * const data = Rlp.fromHex([Hex.fromString('hello'), Hex.fromString('world')])
+ * const data = Rlp.encode([Hex.fromString('hello'), Hex.fromString('world')], { as: 'Hex' })
  * // @log: '0xcc8568656c6c6f85776f726c64'
  *
- * const values = Rlp.toHex(data)
+ * const values = Rlp.decode(data, { as: 'Hex' })
  * // @log: [Hex.fromString('hello'), Hex.fromString('world')]
  * ```
  *

--- a/src/tempo/AuthorizationTempo.ts
+++ b/src/tempo/AuthorizationTempo.ts
@@ -683,7 +683,7 @@ export function hash(
   return Hash.keccak256(
     Hex.concat(
       '0x05',
-      Rlp.fromHex(
+      Rlp.encode(
         toTuple(
           presign
             ? {
@@ -693,6 +693,7 @@ export function hash(
               }
             : authorization,
         ),
+        { as: 'Hex' },
       ),
     ),
   )
@@ -703,7 +704,7 @@ export declare namespace hash {
     | toTuple.ErrorType
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 
   type Options = {

--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -1663,8 +1663,8 @@ describe('toTuple', () => {
     `)
 
     const [authorizationTuple] = tuple
-    const rlpEncoded = Rlp.fromHex(authorizationTuple)
-    const rlpDecoded = Rlp.toHex(rlpEncoded)
+    const rlpEncoded = Rlp.encode(authorizationTuple, { as: 'Hex' })
+    const rlpDecoded = Rlp.decode(rlpEncoded, { as: 'Hex' })
     expect(rlpDecoded).toEqual(authorizationTuple)
 
     const restored = KeyAuthorization.fromTuple(tuple)
@@ -1704,8 +1704,8 @@ describe('toTuple', () => {
     `)
 
     const [authorizationTuple] = tuple
-    const rlpEncoded = Rlp.fromHex(authorizationTuple)
-    const rlpDecoded = Rlp.toHex(rlpEncoded)
+    const rlpEncoded = Rlp.encode(authorizationTuple, { as: 'Hex' })
+    const rlpDecoded = Rlp.decode(rlpEncoded, { as: 'Hex' })
     expect(rlpDecoded).toEqual(authorizationTuple)
 
     const restored = KeyAuthorization.fromTuple(tuple)

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -683,13 +683,13 @@ export declare namespace getSignPayload {
  * @returns The {@link ox#KeyAuthorization.KeyAuthorization}.
  */
 export function deserialize(serialized: Hex.Hex): KeyAuthorization {
-  const tuple = Rlp.toHex(serialized) as unknown as Tuple
+  const tuple = Rlp.decode(serialized, { as: 'Hex' }) as unknown as Tuple
   return fromTuple(tuple)
 }
 
 export declare namespace deserialize {
   type ErrorType =
-    | Rlp.toHex.ErrorType
+    | Rlp.decode.ErrorType
     | fromTuple.ErrorType
     | Errors.GlobalErrorType
 }
@@ -721,7 +721,7 @@ export declare namespace deserialize {
  */
 export function hash(authorization: KeyAuthorization): Hex.Hex {
   const [authorizationTuple] = toTuple(authorization)
-  const serialized = Rlp.fromHex(authorizationTuple)
+  const serialized = Rlp.encode(authorizationTuple, { as: 'Hex' })
   return Hash.keccak256(serialized)
 }
 
@@ -730,7 +730,7 @@ export declare namespace hash {
     | toTuple.ErrorType
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 
@@ -761,13 +761,13 @@ export declare namespace hash {
  */
 export function serialize(authorization: KeyAuthorization): Hex.Hex {
   const tuple = toTuple(authorization)
-  return Rlp.fromHex(tuple as any)
+  return Rlp.encode(tuple as any, { as: 'Hex' })
 }
 
 export declare namespace serialize {
   type ErrorType =
     | toTuple.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/tempo/TxEnvelopeTempo.test.ts
+++ b/src/tempo/TxEnvelopeTempo.test.ts
@@ -439,65 +439,8 @@ describe('deserialize', () => {
   })
 
   test('feePayerSignature with address', () => {
-    const serialized = `0x76${Rlp.fromHex([
-      Hex.fromNumber(1), // chainId
-      Hex.fromNumber(1), // maxPriorityFeePerGas
-      Hex.fromNumber(1), // maxFeePerGas
-      Hex.fromNumber(1), // gas
+    const serialized = `0x76${Rlp.encode(
       [
-        [
-          '0x0000000000000000000000000000000000000000', // to
-          Hex.fromNumber(0), // value
-          '0x', // data
-        ],
-      ], // calls
-      '0x', // accessList
-      Hex.fromNumber(0), // nonceKey
-      Hex.fromNumber(0), // nonce
-      '0x', // validBefore
-      '0x', // validAfter
-      '0x', // feeToken
-      '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // feePayerSignatureOrSender (address)
-      [], // authorizationList
-    ]).slice(2)}` as const
-    const deserialized = TxEnvelopeTempo.deserialize(serialized)
-    expect(deserialized.feePayerSignature).toBe(null)
-    expect(deserialized.from).toBe('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
-  })
-
-  test('feePayerSignature with signature tuple', () => {
-    const serialized = `0x76${Rlp.fromHex([
-      Hex.fromNumber(1), // chainId
-      Hex.fromNumber(1), // maxPriorityFeePerGas
-      Hex.fromNumber(1), // maxFeePerGas
-      Hex.fromNumber(1), // gas
-      [
-        [
-          '0x0000000000000000000000000000000000000000', // to
-          Hex.fromNumber(0), // value
-          '0x', // data
-        ],
-      ], // calls
-      '0x', // accessList
-      Hex.fromNumber(0), // nonceKey
-      Hex.fromNumber(0), // nonce
-      '0x', // validBefore
-      '0x', // validAfter
-      '0x', // feeToken
-      [Hex.fromNumber(0), Hex.fromNumber(1), Hex.fromNumber(2)], // feePayerSignatureOrSender (signature tuple)
-      [], // authorizationList
-    ]).slice(2)}` as const
-    const deserialized = TxEnvelopeTempo.deserialize(serialized)
-    expect(deserialized.feePayerSignature).toEqual({
-      yParity: 0,
-      r: 1n,
-      s: 2n,
-    })
-  })
-
-  describe('raw', () => {
-    test('default', () => {
-      const serialized = `0x76${Rlp.fromHex([
         Hex.fromNumber(1), // chainId
         Hex.fromNumber(1), // maxPriorityFeePerGas
         Hex.fromNumber(1), // maxFeePerGas
@@ -515,9 +458,75 @@ describe('deserialize', () => {
         '0x', // validBefore
         '0x', // validAfter
         '0x', // feeToken
-        '0x', // feePayerSignature
+        '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // feePayerSignatureOrSender (address)
         [], // authorizationList
-      ]).slice(2)}` as const
+      ],
+      { as: 'Hex' },
+    ).slice(2)}` as const
+    const deserialized = TxEnvelopeTempo.deserialize(serialized)
+    expect(deserialized.feePayerSignature).toBe(null)
+    expect(deserialized.from).toBe('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  })
+
+  test('feePayerSignature with signature tuple', () => {
+    const serialized = `0x76${Rlp.encode(
+      [
+        Hex.fromNumber(1), // chainId
+        Hex.fromNumber(1), // maxPriorityFeePerGas
+        Hex.fromNumber(1), // maxFeePerGas
+        Hex.fromNumber(1), // gas
+        [
+          [
+            '0x0000000000000000000000000000000000000000', // to
+            Hex.fromNumber(0), // value
+            '0x', // data
+          ],
+        ], // calls
+        '0x', // accessList
+        Hex.fromNumber(0), // nonceKey
+        Hex.fromNumber(0), // nonce
+        '0x', // validBefore
+        '0x', // validAfter
+        '0x', // feeToken
+        [Hex.fromNumber(0), Hex.fromNumber(1), Hex.fromNumber(2)], // feePayerSignatureOrSender (signature tuple)
+        [], // authorizationList
+      ],
+      { as: 'Hex' },
+    ).slice(2)}` as const
+    const deserialized = TxEnvelopeTempo.deserialize(serialized)
+    expect(deserialized.feePayerSignature).toEqual({
+      yParity: 0,
+      r: 1n,
+      s: 2n,
+    })
+  })
+
+  describe('raw', () => {
+    test('default', () => {
+      const serialized = `0x76${Rlp.encode(
+        [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
+          [
+            [
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
+            ],
+          ], // calls
+          '0x', // accessList
+          Hex.fromNumber(0), // nonceKey
+          Hex.fromNumber(0), // nonce
+          '0x', // validBefore
+          '0x', // validAfter
+          '0x', // feeToken
+          '0x', // feePayerSignature
+          [], // authorizationList
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeTempo.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "calls": [
@@ -538,27 +547,30 @@ describe('deserialize', () => {
     })
 
     test('empty sig', () => {
-      const serialized = `0x76${Rlp.fromHex([
-        Hex.fromNumber(1), // chainId
-        Hex.fromNumber(1), // maxPriorityFeePerGas
-        Hex.fromNumber(1), // maxFeePerGas
-        Hex.fromNumber(1), // gas
+      const serialized = `0x76${Rlp.encode(
         [
+          Hex.fromNumber(1), // chainId
+          Hex.fromNumber(1), // maxPriorityFeePerGas
+          Hex.fromNumber(1), // maxFeePerGas
+          Hex.fromNumber(1), // gas
           [
-            '0x0000000000000000000000000000000000000000', // to
-            Hex.fromNumber(0), // value
-            '0x', // data
-          ],
-        ], // calls
-        '0x', // accessList
-        Hex.fromNumber(0), // nonceKey
-        Hex.fromNumber(0), // nonce
-        '0x', // validBefore
-        '0x', // validAfter
-        '0x', // feeToken
-        '0x', // feePayerSignature
-        [], // authorizationList
-      ]).slice(2)}` as const
+            [
+              '0x0000000000000000000000000000000000000000', // to
+              Hex.fromNumber(0), // value
+              '0x', // data
+            ],
+          ], // calls
+          '0x', // accessList
+          Hex.fromNumber(0), // nonceKey
+          Hex.fromNumber(0), // nonce
+          '0x', // validBefore
+          '0x', // validAfter
+          '0x', // feeToken
+          '0x', // feePayerSignature
+          [], // authorizationList
+        ],
+        { as: 'Hex' },
+      ).slice(2)}` as const
       expect(TxEnvelopeTempo.deserialize(serialized)).toMatchInlineSnapshot(`
         {
           "calls": [
@@ -582,7 +594,9 @@ describe('deserialize', () => {
   describe('errors', () => {
     test('invalid transaction (all missing)', () => {
       expect(() =>
-        TxEnvelopeTempo.deserialize(`0x76${Rlp.fromHex([]).slice(2)}`),
+        TxEnvelopeTempo.deserialize(
+          `0x76${Rlp.encode([], { as: 'Hex' }).slice(2)}`,
+        ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "tempo" was provided.
 
@@ -594,7 +608,7 @@ describe('deserialize', () => {
     test('invalid transaction (some missing)', () => {
       expect(() =>
         TxEnvelopeTempo.deserialize(
-          `0x76${Rlp.fromHex(['0x00', '0x01']).slice(2)}`,
+          `0x76${Rlp.encode(['0x00', '0x01'], { as: 'Hex' }).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "tempo" was provided.
@@ -607,21 +621,24 @@ describe('deserialize', () => {
     test('invalid transaction (empty calls)', () => {
       expect(() =>
         TxEnvelopeTempo.deserialize(
-          `0x76${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
-            [], // calls (empty)
-            '0x', // accessList
-            Hex.fromNumber(0), // nonceKey
-            Hex.fromNumber(0), // nonce
-            '0x', // validBefore
-            '0x', // validAfter
-            '0x', // feeToken
-            '0x', // feePayerSignature
-            [], // authorizationList
-          ]).slice(2)}`,
+          `0x76${Rlp.encode(
+            [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
+              [], // calls (empty)
+              '0x', // accessList
+              Hex.fromNumber(0), // nonceKey
+              Hex.fromNumber(0), // nonce
+              '0x', // validBefore
+              '0x', // validAfter
+              '0x', // feeToken
+              '0x', // feePayerSignature
+              [], // authorizationList
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(
         `[TxEnvelopeTempo.CallsEmptyError: Calls list cannot be empty.]`,
@@ -632,7 +649,7 @@ describe('deserialize', () => {
       // EIP-1559 prefix byte (0x02) instead of Tempo's 0x76.
       expect(() =>
         TxEnvelopeTempo.deserialize(
-          `0x02${Rlp.fromHex([]).slice(2)}` as TxEnvelopeTempo.Serialized,
+          `0x02${Rlp.encode([], { as: 'Hex' }).slice(2)}` as TxEnvelopeTempo.Serialized,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "tempo" was provided.
@@ -644,30 +661,33 @@ describe('deserialize', () => {
     test('invalid transaction (too many fields with signature)', () => {
       expect(() =>
         TxEnvelopeTempo.deserialize(
-          `0x76${Rlp.fromHex([
-            Hex.fromNumber(1), // chainId
-            Hex.fromNumber(1), // maxPriorityFeePerGas
-            Hex.fromNumber(1), // maxFeePerGas
-            Hex.fromNumber(1), // gas
+          `0x76${Rlp.encode(
             [
+              Hex.fromNumber(1), // chainId
+              Hex.fromNumber(1), // maxPriorityFeePerGas
+              Hex.fromNumber(1), // maxFeePerGas
+              Hex.fromNumber(1), // gas
               [
-                '0x0000000000000000000000000000000000000000',
-                Hex.fromNumber(0),
-                '0x',
-              ],
-            ], // calls
-            '0x', // accessList
-            Hex.fromNumber(0), // nonceKey
-            Hex.fromNumber(0), // nonce
-            '0x', // validBefore
-            '0x', // validAfter
-            '0x', // feeToken
-            '0x', // feePayerSignature
-            [], // authorizationList
-            [], // keyAuthorization
-            '0x1234', // signature
-            '0x5678', // extra field
-          ]).slice(2)}`,
+                [
+                  '0x0000000000000000000000000000000000000000',
+                  Hex.fromNumber(0),
+                  '0x',
+                ],
+              ], // calls
+              '0x', // accessList
+              Hex.fromNumber(0), // nonceKey
+              Hex.fromNumber(0), // nonce
+              '0x', // validBefore
+              '0x', // validAfter
+              '0x', // feeToken
+              '0x', // feePayerSignature
+              [], // authorizationList
+              [], // keyAuthorization
+              '0x1234', // signature
+              '0x5678', // extra field
+            ],
+            { as: 'Hex' },
+          ).slice(2)}`,
         ),
       ).toThrowErrorMatchingInlineSnapshot(`
         [TransactionEnvelope.InvalidSerializedError: Invalid serialized transaction of type "tempo" was provided.

--- a/src/tempo/TxEnvelopeTempo.ts
+++ b/src/tempo/TxEnvelopeTempo.ts
@@ -261,7 +261,7 @@ export function deserialize(serialized: Serialized): Compute<TxEnvelopeTempo> {
       type,
     })
 
-  const transactionArray = Rlp.toHex(Hex.slice(serialized, 1))
+  const transactionArray = Rlp.decode(Hex.slice(serialized, 1), { as: 'Hex' })
 
   const [
     chainId,
@@ -737,7 +737,7 @@ export function serialize(
 
   return Hex.concat(
     options.format === 'feePayer' ? feePayerMagic : serializedType,
-    Rlp.fromHex(serialized),
+    Rlp.encode(serialized, { as: 'Hex' }),
   ) as Serialized
 }
 
@@ -781,7 +781,7 @@ export declare namespace serialize {
     | Hex.fromNumber.ErrorType
     | Signature.toTuple.ErrorType
     | Hex.concat.ErrorType
-    | Rlp.fromHex.ErrorType
+    | Rlp.encode.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/webauthn/Authentication.ts
+++ b/src/webauthn/Authentication.ts
@@ -69,7 +69,7 @@ export function deserializeOptions(
       ...(allowCredentials && {
         allowCredentials: allowCredentials.map(({ id, ...rest }) => ({
           ...rest,
-          id: Base64.toBytes(id),
+          id: Base64.decode(id),
         })),
       }),
       ...(extensions && {
@@ -80,7 +80,7 @@ export function deserializeOptions(
 }
 
 export declare namespace deserializeOptions {
-  type ErrorType = Base64.toBytes.ErrorType | Errors.GlobalErrorType
+  type ErrorType = Base64.decode.ErrorType | Errors.GlobalErrorType
 }
 
 /**
@@ -118,7 +118,7 @@ export function deserializeResponse(response: Response<true>): Response {
 
   const rawResponse: Record<string, ArrayBuffer> = {}
   for (const [key, value] of Object.entries(raw.response))
-    rawResponse[key] = bytesToArrayBuffer(Base64.toBytes(value))
+    rawResponse[key] = bytesToArrayBuffer(Base64.decode(value))
 
   return {
     id,
@@ -127,7 +127,7 @@ export function deserializeResponse(response: Response<true>): Response {
       id: raw.id,
       type: raw.type,
       authenticatorAttachment: raw.authenticatorAttachment,
-      rawId: bytesToArrayBuffer(Base64.toBytes(raw.rawId)),
+      rawId: bytesToArrayBuffer(Base64.decode(raw.rawId)),
       response: rawResponse as unknown as Types.AuthenticatorResponse,
       getClientExtensionResults: () => ({}),
     },
@@ -137,7 +137,7 @@ export function deserializeResponse(response: Response<true>): Response {
 
 export declare namespace deserializeResponse {
   type ErrorType =
-    | Base64.toBytes.ErrorType
+    | Base64.decode.ErrorType
     | Signature.from.ErrorType
     | Errors.GlobalErrorType
 }
@@ -175,12 +175,12 @@ export function getOptions(
         ? {
             allowCredentials: Array.isArray(credentialId)
               ? credentialId.map((id) => ({
-                  id: Base64.toBytes(id),
+                  id: Base64.decode(id),
                   type: 'public-key',
                 }))
               : [
                   {
-                    id: Base64.toBytes(credentialId),
+                    id: Base64.decode(credentialId),
                     type: 'public-key',
                   },
                 ],
@@ -214,7 +214,7 @@ export declare namespace getOptions {
 
   type ErrorType =
     | Bytes.fromHex.ErrorType
-    | Base64.toBytes.ErrorType
+    | Base64.decode.ErrorType
     | Errors.GlobalErrorType
 }
 
@@ -371,7 +371,7 @@ export function serializeOptions(
       ...(allowCredentials && {
         allowCredentials: allowCredentials.map(({ id, ...rest }) => ({
           ...rest,
-          id: Base64.fromBytes(bufferSourceToBytes(id), base64UrlOptions),
+          id: Base64.encode(bufferSourceToBytes(id), base64UrlOptions),
         })),
       }),
       ...(extensions && {
@@ -382,7 +382,7 @@ export function serializeOptions(
 }
 
 export declare namespace serializeOptions {
-  type ErrorType = Base64.fromBytes.ErrorType | Errors.GlobalErrorType
+  type ErrorType = Base64.encode.ErrorType | Errors.GlobalErrorType
 }
 
 /**
@@ -421,7 +421,7 @@ export function serializeResponse(response: Response): Response<true> {
       id: raw.id,
       type: raw.type,
       authenticatorAttachment: raw.authenticatorAttachment,
-      rawId: Base64.fromBytes(bufferSourceToBytes(raw.rawId), base64UrlOptions),
+      rawId: Base64.encode(bufferSourceToBytes(raw.rawId), base64UrlOptions),
       response: rawResponse as unknown as Types.AuthenticatorResponse<true>,
     },
     signature: Signature.toHex(signature),
@@ -430,7 +430,7 @@ export function serializeResponse(response: Response): Response<true> {
 
 export declare namespace serializeResponse {
   type ErrorType =
-    | Base64.fromBytes.ErrorType
+    | Base64.encode.ErrorType
     | Signature.toHex.ErrorType
     | Errors.GlobalErrorType
 }
@@ -635,7 +635,7 @@ export function verify(options: verify.Options): boolean {
   // Validate the challenge in the clientDataJSON.
   if (
     !clientData.challenge ||
-    Hex.fromBytes(Base64.toBytes(clientData.challenge)) !== challenge
+    Hex.fromBytes(Base64.decode(clientData.challenge)) !== challenge
   )
     return false
 
@@ -675,7 +675,7 @@ export declare namespace verify {
   }
 
   type ErrorType =
-    | Base64.toBytes.ErrorType
+    | Base64.decode.ErrorType
     | Bytes.concat.ErrorType
     | Bytes.fromHex.ErrorType
     | Bytes.isEqual.ErrorType

--- a/src/webauthn/Authenticator.ts
+++ b/src/webauthn/Authenticator.ts
@@ -166,9 +166,7 @@ export declare namespace getAuthenticatorData {
  * @param authenticatorData - The authenticator data hex string.
  * @returns The signature counter.
  */
-export function getSignCount(
-  authenticatorData: Hex.Hex | Uint8Array,
-): number {
+export function getSignCount(authenticatorData: Hex.Hex | Uint8Array): number {
   const bytes =
     typeof authenticatorData === 'string'
       ? Bytes.fromHex(authenticatorData)
@@ -226,7 +224,7 @@ export function getClientDataJSON(options: getClientDataJSON.Options): string {
 
   return JSON.stringify({
     type,
-    challenge: Base64.fromHex(challenge, { url: true, pad: false }),
+    challenge: Base64.encode(challenge, { url: true, pad: false }),
     origin,
     crossOrigin,
     ...extraClientData,

--- a/src/webauthn/Credential.ts
+++ b/src/webauthn/Credential.ts
@@ -65,18 +65,18 @@ export function serialize(credential: Credential): Credential<true> {
       new Uint8Array(attestationObject),
     )
     if (attestation.authData)
-      response.authenticatorData = Base64.fromBytes(
+      response.authenticatorData = Base64.encode(
         attestation.authData,
         base64UrlOptions,
       )
   }
 
   return {
-    attestationObject: Base64.fromBytes(
+    attestationObject: Base64.encode(
       new Uint8Array(attestationObject),
       base64UrlOptions,
     ),
-    clientDataJSON: Base64.fromBytes(
+    clientDataJSON: Base64.encode(
       new Uint8Array(clientDataJSON),
       base64UrlOptions,
     ),
@@ -86,7 +86,7 @@ export function serialize(credential: Credential): Credential<true> {
       id: raw.id,
       type: raw.type,
       authenticatorAttachment: raw.authenticatorAttachment,
-      rawId: Base64.fromBytes(bufferSourceToBytes(raw.rawId), base64UrlOptions),
+      rawId: Base64.encode(bufferSourceToBytes(raw.rawId), base64UrlOptions),
       response: response as unknown as Types.AuthenticatorResponse<true>,
     },
   }
@@ -94,7 +94,7 @@ export function serialize(credential: Credential): Credential<true> {
 
 export declare namespace serialize {
   type ErrorType =
-    | Base64.fromBytes.ErrorType
+    | Base64.encode.ErrorType
     | PublicKey.toHex.ErrorType
     | Errors.GlobalErrorType
 }
@@ -132,19 +132,19 @@ export function deserialize(credential: Credential<true>): Credential {
   const response = Object.create(null) as Record<string, ArrayBuffer>
   for (const key of responseKeys) {
     const value = (raw.response as unknown as Record<string, string>)[key]
-    if (value) response[key] = bytesToArrayBuffer(Base64.toBytes(value))
+    if (value) response[key] = bytesToArrayBuffer(Base64.decode(value))
   }
 
   return {
-    attestationObject: bytesToArrayBuffer(Base64.toBytes(attestationObject)),
-    clientDataJSON: bytesToArrayBuffer(Base64.toBytes(clientDataJSON)),
+    attestationObject: bytesToArrayBuffer(Base64.decode(attestationObject)),
+    clientDataJSON: bytesToArrayBuffer(Base64.decode(clientDataJSON)),
     id,
     publicKey: PublicKey.from(publicKey),
     raw: {
       id: raw.id,
       type: raw.type,
       authenticatorAttachment: raw.authenticatorAttachment,
-      rawId: bytesToArrayBuffer(Base64.toBytes(raw.rawId)),
+      rawId: bytesToArrayBuffer(Base64.decode(raw.rawId)),
       response: response as unknown as Types.AuthenticatorResponse,
       getClientExtensionResults: () => ({}),
     },
@@ -153,7 +153,7 @@ export function deserialize(credential: Credential<true>): Credential {
 
 export declare namespace deserialize {
   type ErrorType =
-    | Base64.toBytes.ErrorType
+    | Base64.decode.ErrorType
     | PublicKey.from.ErrorType
     | Errors.GlobalErrorType
 }

--- a/src/webauthn/Registration.bench.ts
+++ b/src/webauthn/Registration.bench.ts
@@ -32,7 +32,7 @@ const authData = Authenticator.getAuthenticatorData({
 const clientDataJSONBytes = Bytes.fromString(
   JSON.stringify({
     type: 'webauthn.create',
-    challenge: Base64.fromHex(challenge, { url: true, pad: false }),
+    challenge: Base64.encode(challenge, { url: true, pad: false }),
     origin,
     crossOrigin: false,
   }),
@@ -50,7 +50,7 @@ const attestationObjectBytes = Hex.toBytes(
 const credential = await Registration.create({
   createFn: () =>
     Promise.resolve({
-      id: Base64.fromBytes(credentialId, { url: true, pad: false }),
+      id: Base64.encode(credentialId, { url: true, pad: false }),
       type: 'public-key',
       authenticatorAttachment: 'platform',
       rawId: credentialId.buffer,
@@ -92,7 +92,7 @@ describe('Registration.verify (none)', () => {
   const noneCredential = {
     attestationObject: noneAttestationObject.buffer as ArrayBuffer,
     clientDataJSON: clientDataJSONBytes.buffer as ArrayBuffer,
-    id: Base64.fromBytes(credentialId, { url: true, pad: false }),
+    id: Base64.encode(credentialId, { url: true, pad: false }),
     publicKey,
     raw: credential.raw,
   }

--- a/src/webauthn/Registration.ts
+++ b/src/webauthn/Registration.ts
@@ -169,7 +169,7 @@ export function getOptions(
       ...(excludeCredentialIds
         ? {
             excludeCredentials: excludeCredentialIds?.map((id) => ({
-              id: Base64.toBytes(id),
+              id: Base64.decode(id),
               type: 'public-key',
             })),
           }
@@ -265,7 +265,7 @@ export declare namespace getOptions {
   >
 
   type ErrorType =
-    | Base64.toBytes.ErrorType
+    | Base64.decode.ErrorType
     | Hash.keccak256.ErrorType
     | Bytes.fromString.ErrorType
     | Errors.GlobalErrorType
@@ -307,11 +307,11 @@ export function serializeResponse(response: Response): Response<true> {
   return {
     ...rest,
     credential: {
-      attestationObject: Base64.fromBytes(
+      attestationObject: Base64.encode(
         new Uint8Array(credential.attestationObject),
         base64UrlOptions,
       ),
-      clientDataJSON: Base64.fromBytes(
+      clientDataJSON: Base64.encode(
         new Uint8Array(credential.clientDataJSON),
         base64UrlOptions,
       ),
@@ -321,7 +321,7 @@ export function serializeResponse(response: Response): Response<true> {
         id: credential.raw.id,
         type: credential.raw.type,
         authenticatorAttachment: credential.raw.authenticatorAttachment,
-        rawId: Base64.fromBytes(
+        rawId: Base64.encode(
           bufferSourceToBytes(credential.raw.rawId),
           base64UrlOptions,
         ),
@@ -333,7 +333,7 @@ export function serializeResponse(response: Response): Response<true> {
 
 export declare namespace serializeResponse {
   type ErrorType =
-    | Base64.fromBytes.ErrorType
+    | Base64.encode.ErrorType
     | PublicKey.toHex.ErrorType
     | Errors.GlobalErrorType
 }
@@ -372,7 +372,7 @@ export function serializeOptions(
       ...(excludeCredentials && {
         excludeCredentials: excludeCredentials.map(({ id, ...rest }) => ({
           ...rest,
-          id: Base64.fromBytes(bufferSourceToBytes(id), base64UrlOptions),
+          id: Base64.encode(bufferSourceToBytes(id), base64UrlOptions),
         })),
       }),
       ...(extensions && {
@@ -380,14 +380,14 @@ export function serializeOptions(
       }),
       user: {
         ...user,
-        id: Base64.fromBytes(bufferSourceToBytes(user.id), base64UrlOptions),
+        id: Base64.encode(bufferSourceToBytes(user.id), base64UrlOptions),
       },
     },
   }
 }
 
 export declare namespace serializeOptions {
-  type ErrorType = Base64.fromBytes.ErrorType | Errors.GlobalErrorType
+  type ErrorType = Base64.encode.ErrorType | Errors.GlobalErrorType
 }
 
 /**
@@ -425,7 +425,7 @@ export function deserializeOptions(
       ...(excludeCredentials && {
         excludeCredentials: excludeCredentials.map(({ id, ...rest }) => ({
           ...rest,
-          id: Base64.toBytes(id),
+          id: Base64.decode(id),
         })),
       }),
       ...(extensions && {
@@ -433,14 +433,14 @@ export function deserializeOptions(
       }),
       user: {
         ...user,
-        id: Base64.toBytes(user.id),
+        id: Base64.decode(user.id),
       },
     },
   }
 }
 
 export declare namespace deserializeOptions {
-  type ErrorType = Base64.toBytes.ErrorType | Errors.GlobalErrorType
+  type ErrorType = Base64.decode.ErrorType | Errors.GlobalErrorType
 }
 
 /**
@@ -470,16 +470,16 @@ export function deserializeResponse(response: Response<true>): Response {
 
   const rawResponse: Record<string, ArrayBuffer> = {}
   for (const [key, value] of Object.entries(credential.raw.response))
-    rawResponse[key] = bytesToArrayBuffer(Base64.toBytes(value))
+    rawResponse[key] = bytesToArrayBuffer(Base64.decode(value))
 
   return {
     ...rest,
     credential: {
       attestationObject: bytesToArrayBuffer(
-        Base64.toBytes(credential.attestationObject),
+        Base64.decode(credential.attestationObject),
       ),
       clientDataJSON: bytesToArrayBuffer(
-        Base64.toBytes(credential.clientDataJSON),
+        Base64.decode(credential.clientDataJSON),
       ),
       id: credential.id,
       publicKey: PublicKey.from(credential.publicKey),
@@ -487,7 +487,7 @@ export function deserializeResponse(response: Response<true>): Response {
         id: credential.raw.id,
         type: credential.raw.type,
         authenticatorAttachment: credential.raw.authenticatorAttachment,
-        rawId: bytesToArrayBuffer(Base64.toBytes(credential.raw.rawId)),
+        rawId: bytesToArrayBuffer(Base64.decode(credential.raw.rawId)),
         response: rawResponse as unknown as Types.AuthenticatorResponse,
         getClientExtensionResults: () => ({}),
       },
@@ -497,7 +497,7 @@ export function deserializeResponse(response: Response<true>): Response {
 
 export declare namespace deserializeResponse {
   type ErrorType =
-    | Base64.toBytes.ErrorType
+    | Base64.decode.ErrorType
     | PublicKey.from.ErrorType
     | Errors.GlobalErrorType
 }
@@ -559,7 +559,7 @@ export function verify(options: verify.Options): verify.ReturnType {
       typeof options.challenge === 'string'
         ? Bytes.fromHex(options.challenge)
         : options.challenge
-    const challenge = Base64.fromBytes(challengeBytes, base64UrlOptions)
+    const challenge = Base64.encode(challengeBytes, base64UrlOptions)
     return clientData.challenge === challenge
   })()
   if (!challengeResult) throw new VerifyError('Challenge mismatch')
@@ -627,7 +627,7 @@ export function verify(options: verify.Options): verify.ReturnType {
 
   // Verify credential ID consistency if caller-supplied id is present
   if (credential.id !== undefined) {
-    const expectedId = Base64.fromBytes(credentialId, base64UrlOptions)
+    const expectedId = Base64.encode(credentialId, base64UrlOptions)
     if (credential.id !== expectedId)
       throw new VerifyError(
         `Credential ID mismatch: supplied "${credential.id}" does not match authData "${expectedId}"`,
@@ -709,7 +709,7 @@ export function verify(options: verify.Options): verify.ReturnType {
   }
 
   // 6. Build credential ID string
-  const id = credential.id ?? Base64.fromBytes(credentialId, base64UrlOptions)
+  const id = credential.id ?? Base64.encode(credentialId, base64UrlOptions)
 
   // 7. Build raw credential
   const raw = credential.raw ?? {
@@ -777,8 +777,8 @@ export declare namespace verify {
   type ReturnType = Response
 
   type ErrorType =
-    | Base64.toBytes.ErrorType
-    | Base64.fromBytes.ErrorType
+    | Base64.decode.ErrorType
+    | Base64.encode.ErrorType
     | Bytes.fromHex.ErrorType
     | Bytes.isEqual.ErrorType
     | Cbor.decode.ErrorType

--- a/src/webauthn/_test/Registration.browser.test.ts
+++ b/src/webauthn/_test/Registration.browser.test.ts
@@ -491,7 +491,7 @@ describe('vulnerability: tampered clientDataJSON', () => {
     const json = JSON.parse(
       Bytes.toString(new Uint8Array(credential.clientDataJSON)),
     )
-    json.challenge = Base64.fromBytes(new Uint8Array(32), {
+    json.challenge = Base64.encode(new Uint8Array(32), {
       url: true,
       pad: false,
     })
@@ -637,7 +637,7 @@ describe('vulnerability: replay attacks', () => {
     const json = JSON.parse(
       Bytes.toString(new Uint8Array(credential.clientDataJSON)),
     )
-    json.challenge = Base64.fromHex(challengeB, { url: true, pad: false })
+    json.challenge = Base64.encode(challengeB, { url: true, pad: false })
     credential.clientDataJSON = Bytes.fromString(JSON.stringify(json))
       .buffer as ArrayBuffer
 
@@ -660,7 +660,7 @@ describe('vulnerability: replay attacks', () => {
     const json = JSON.parse(
       Bytes.toString(new Uint8Array(credential.clientDataJSON)),
     )
-    json.challenge = Base64.fromHex(challengeB, { url: true, pad: false })
+    json.challenge = Base64.encode(challengeB, { url: true, pad: false })
     credential.clientDataJSON = Bytes.fromString(JSON.stringify(json))
       .buffer as ArrayBuffer
 
@@ -731,7 +731,7 @@ describe('challenge formats', () => {
     const challenge = Hex.random(32)
     const { credential } = await createCredential(challenge)
 
-    const expectedB64 = Base64.fromHex(challenge, { url: true, pad: false })
+    const expectedB64 = Base64.encode(challenge, { url: true, pad: false })
 
     const result = Registration.verify({
       credential,
@@ -811,7 +811,7 @@ function buildPackedCredential(options?: {
   const clientDataJSON = Bytes.fromString(
     JSON.stringify({
       type: 'webauthn.create',
-      challenge: Base64.fromHex(challenge, { url: true, pad: false }),
+      challenge: Base64.encode(challenge, { url: true, pad: false }),
       origin: window.location.origin,
       crossOrigin: false,
     }),
@@ -833,7 +833,7 @@ function buildPackedCredential(options?: {
     }),
   )
 
-  const id = Base64.fromBytes(credentialId, { url: true, pad: false })
+  const id = Base64.encode(credentialId, { url: true, pad: false })
   const credential: Credential.Credential = {
     id,
     publicKey,
@@ -869,7 +869,7 @@ function buildNoneCredential(flagOverride?: number) {
   const clientDataJSON = Bytes.fromString(
     JSON.stringify({
       type: 'webauthn.create',
-      challenge: Base64.fromHex(challenge, { url: true, pad: false }),
+      challenge: Base64.encode(challenge, { url: true, pad: false }),
       origin: window.location.origin,
       crossOrigin: false,
     }),
@@ -877,7 +877,7 @@ function buildNoneCredential(flagOverride?: number) {
   const attestationObject = Hex.toBytes(
     Authenticator.getAttestationObject({ authData, fmt: 'none' }),
   )
-  const id = Base64.fromBytes(credentialId, { url: true, pad: false })
+  const id = Base64.encode(credentialId, { url: true, pad: false })
   const credential: Credential.Credential = {
     id,
     publicKey,

--- a/src/webauthn/_test/Registration.test.ts
+++ b/src/webauthn/_test/Registration.test.ts
@@ -738,7 +738,7 @@ describe('verify', () => {
     const clientDataJSON = Bytes.fromString(
       JSON.stringify({
         type: 'webauthn.create',
-        challenge: Base64.fromHex(challenge, { url: true, pad: false }),
+        challenge: Base64.encode(challenge, { url: true, pad: false }),
         origin,
         crossOrigin: false,
       }),
@@ -767,7 +767,7 @@ describe('verify', () => {
     const credential = await Registration.create({
       createFn: () =>
         Promise.resolve({
-          id: Base64.fromBytes(credentialId, { url: true, pad: false }),
+          id: Base64.encode(credentialId, { url: true, pad: false }),
           type: 'public-key',
           authenticatorAttachment: 'platform',
           rawId: credentialId.buffer,
@@ -822,8 +822,7 @@ describe('verify', () => {
     const result = Registration.verify({
       credential,
       challenge: (c) =>
-        c ===
-        Base64.fromBytes(Hex.toBytes(challenge), { url: true, pad: false }),
+        c === Base64.encode(Hex.toBytes(challenge), { url: true, pad: false }),
       origin,
       rpId,
     })
@@ -866,7 +865,7 @@ describe('verify', () => {
 
     const tamperedClientDataJSON = JSON.stringify({
       type: 'webauthn.get',
-      challenge: Base64.fromHex(challenge, { url: true, pad: false }),
+      challenge: Base64.encode(challenge, { url: true, pad: false }),
       origin,
     })
     credential.clientDataJSON = new TextEncoder().encode(tamperedClientDataJSON)

--- a/src/webauthn/internal/utils.ts
+++ b/src/webauthn/internal/utils.ts
@@ -109,7 +109,7 @@ export function serializeResponseFields(
       if (typeof fn === 'function') value = (fn as () => unknown).call(response)
     }
     if (value instanceof ArrayBuffer)
-      out[key] = Base64.fromBytes(new Uint8Array(value), base64UrlOptions)
+      out[key] = Base64.encode(new Uint8Array(value), base64UrlOptions)
   }
   return out
 }
@@ -124,7 +124,7 @@ export function serializeExtensions(
     ...(prf && {
       prf: {
         eval: {
-          first: Base64.fromBytes(prf.eval.first, base64UrlOptions),
+          first: Base64.encode(prf.eval.first, base64UrlOptions),
         },
       },
     }),
@@ -141,7 +141,7 @@ export function deserializeExtensions(
     ...(prf && {
       prf: {
         eval: {
-          first: Base64.toBytes(prf.eval.first),
+          first: Base64.decode(prf.eval.first),
         },
       },
     }),

--- a/vectors/src/rlp.ts
+++ b/vectors/src/rlp.ts
@@ -42,7 +42,7 @@ export async function generateRlpVectors() {
     )
     const vector = {
       decoded: bytes,
-      encoded: Rlp.from(bytes, { as: 'Hex' }),
+      encoded: Rlp.encode(bytes, { as: 'Hex' }),
     }
     writer.write(JSON.stringify(vector, null, 2))
   }
@@ -93,7 +93,7 @@ export async function generateRlpVectors() {
     })()
     const vector = {
       decoded: bytes,
-      encoded: Rlp.from(bytes, { as: 'Hex' }),
+      encoded: Rlp.encode(bytes, { as: 'Hex' }),
     }
     writer.write(JSON.stringify(vector, null, 2))
   }

--- a/vectors/src/rlp.vectors.test.ts
+++ b/vectors/src/rlp.vectors.test.ts
@@ -8,18 +8,18 @@ import { readGzippedJson } from '../utils.js'
 
 const vectors = await readGzippedJson(join(import.meta.dir, './rlp.json.gz'))
 
-describe('Rlp.from', () => {
+describe('Rlp.encode', () => {
   vectors.forEach((v: any, i: number) => {
     test(`${i}`, () => {
-      expect(Rlp.fromHex(v.decoded)).toEqual(v.encoded)
+      expect(Rlp.encode(v.decoded, { as: 'Hex' })).toEqual(v.encoded)
     })
   })
 })
 
-describe('Rlp.to', () => {
+describe('Rlp.decode', () => {
   vectors.forEach((v: any, i: number) => {
     test(`${i}`, () => {
-      expect(Rlp.toHex(v.encoded)).toEqual(v.decoded)
+      expect(Rlp.decode(v.encoded, { as: 'Hex' })).toEqual(v.decoded)
     })
   })
 })


### PR DESCRIPTION
Unifies the `Base32`, `Base58`, `Base64`, `CompactSize`, and `Rlp` codec modules around a single canonical pair of entrypoints — `encode` and `decode` — replacing the per-shape `from*` / `to*` exports. `encode` accepts `Bytes`/`Hex` (and `string` for Base58/Base64). `decode` returns `Bytes` by default and gates the output shape via an `as` option.

`Rlp.encode` and `Rlp.decode` follow the same shape, replacing `Rlp.from`, `Rlp.fromBytes`, `Rlp.fromHex`, `Rlp.toBytes`, and `Rlp.toHex`. `CompactSize` mirrors the same pattern.

Also flipped the default `limit` for `Bech32m.encode` / `Bech32m.decode` from `90` to `undefined`. Pass `{ limit: 90 }` explicitly to restore BIP-173 segwit-style length capping.

```diff
-Base32.fromBytes(bytes); Base32.fromHex(hex)
-Base32.toBytes(str); Base32.toHex(str)
+Base32.encode(bytesOrHex)
+Base32.decode(str)              // -> Bytes
+Base32.decode(str, { as: 'Hex' })

-Base58.fromBytes(bytes); Base58.fromHex(hex); Base58.fromString(str)
-Base58.toBytes(str); Base58.toHex(str); Base58.toString(str)
+Base58.encode(bytesOrHexOrString)
+Base58.decode(str)              // -> Bytes
+Base58.decode(str, { as: 'Hex' | 'String' })

-Base64.fromBytes(bytes, opts); Base64.fromHex(hex, opts); Base64.fromString(str, opts)
-Base64.toBytes(str); Base64.toHex(str); Base64.toString(str)
+Base64.encode(bytesOrHexOrString, opts)
+Base64.decode(str)              // -> Bytes
+Base64.decode(str, { as: 'Hex' | 'String' })

-CompactSize.toBytes(n); CompactSize.toHex(n)
-CompactSize.fromBytes(bytes); CompactSize.fromHex(hex)
+CompactSize.encode(n)           // -> Bytes
+CompactSize.encode(n, { as: 'Hex' })
+CompactSize.decode(bytesOrHex)

-Rlp.from(value, { as }); Rlp.fromBytes(value); Rlp.fromHex(value)
-Rlp.toBytes(value); Rlp.toHex(value)
+Rlp.encode(value)               // -> Bytes
+Rlp.encode(value, { as: 'Hex' })
+Rlp.decode(value)               // -> RecursiveArray<Bytes>
+Rlp.decode(value, { as: 'Hex' })
```
