### PR TITLE
feat(tempo): expose transaction encoding for signing

### DIFF
--- a/.changeset/tempo-encode-for-signing.md
+++ b/.changeset/tempo-encode-for-signing.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Added `TxEnvelopeTempo.encodeForSigning` to expose the raw Tempo sender-signing preimage bytes.

--- a/src/tempo/TxEnvelopeTempo.test.ts
+++ b/src/tempo/TxEnvelopeTempo.test.ts
@@ -1,4 +1,13 @@
-import { Address, Hex, P256, Rlp, Secp256k1, Value, WebAuthnP256 } from 'ox'
+import {
+  Address,
+  Hash,
+  Hex,
+  P256,
+  Rlp,
+  Secp256k1,
+  Value,
+  WebAuthnP256,
+} from 'ox'
 import { describe, expect, test } from 'vitest'
 import * as AuthorizationTempo from './AuthorizationTempo.js'
 import { SignatureEnvelope } from './index.js'
@@ -1429,6 +1438,67 @@ describe('hash', () => {
       TxEnvelopeTempo.hash(transaction, { presign: true }),
     ).toMatchInlineSnapshot(
       `"0xe1222a45806457acbe3a13940aae4c34f3180659fa16613b5a45dc183adae07c"`,
+    )
+  })
+})
+
+describe('encodeForSigning', () => {
+  test('matches getSignPayload preimage', () => {
+    const transaction = TxEnvelopeTempo.from({
+      chainId: 1,
+      calls: [
+        {
+          to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+        },
+      ],
+      nonce: 0n,
+    })
+
+    const encoded = TxEnvelopeTempo.encodeForSigning(transaction)
+
+    expect(Hash.keccak256(encoded)).toBe(
+      TxEnvelopeTempo.getSignPayload(transaction),
+    )
+    expect(encoded).toMatchInlineSnapshot(
+      `"0x76e501808080d8d79470997970c51812dc3a010c7d01b50e0d17dc79c88080c0808080808080c0"`,
+    )
+  })
+
+  test('normalizes signatures and fee payer-selected fee token', () => {
+    const transaction = TxEnvelopeTempo.from({
+      chainId: 1,
+      calls: [
+        {
+          to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+        },
+      ],
+      feePayerSignature: null,
+      feeToken: 1n,
+      nonce: 0n,
+    })
+    const signature = Secp256k1.sign({
+      payload: TxEnvelopeTempo.getSignPayload(transaction),
+      privateKey,
+    })
+    const signed = TxEnvelopeTempo.from(transaction, {
+      signature: SignatureEnvelope.from(signature),
+    })
+    const feePayerSignature = Secp256k1.sign({
+      payload: TxEnvelopeTempo.getFeePayerSignPayload(signed, {
+        sender: address,
+      }),
+      privateKey:
+        '0x59c6995e998f97a5a0044966f094538219447a175e4b9f6d8dae5f4a585d3c55',
+    })
+
+    const sponsored = TxEnvelopeTempo.from({
+      ...signed,
+      feePayerSignature,
+      feeToken: 2n,
+    })
+
+    expect(TxEnvelopeTempo.encodeForSigning(sponsored)).toBe(
+      TxEnvelopeTempo.encodeForSigning(transaction),
     )
   })
 })

--- a/src/tempo/TxEnvelopeTempo.ts
+++ b/src/tempo/TxEnvelopeTempo.ts
@@ -779,17 +779,60 @@ export declare namespace serialize {
 }
 
 /**
- * Returns the payload to sign for a {@link ox#TxEnvelopeTempo.TxEnvelopeTempo}.
+ * Encodes a {@link ox#TxEnvelopeTempo.TxEnvelopeTempo} for sender signing.
  *
- * Computes the keccak256 hash of the unsigned serialized transaction. Sign this payload
- * with secp256k1, P256, or WebAuthn, then attach the signature via {@link ox#TxEnvelopeTempo.(from:function)}.
- *
- * [Tempo Transaction Specification](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction)
+ * Returns the raw serialized transaction bytes that are hashed by
+ * {@link ox#TxEnvelopeTempo.(getSignPayload:function)}. Sender signatures are
+ * stripped, and fee payer signatures are normalized to the sender pre-sign
+ * marker.
  *
  * @example
- * The example below demonstrates how to compute the sign payload which can be used
- * with ECDSA signing utilities like {@link ox#Secp256k1.(sign:function)}.
+ * ```ts twoslash
+ * // @noErrors
+ * import { Hash } from 'ox'
+ * import { TxEnvelopeTempo } from 'ox/tempo'
  *
+ * const envelope = TxEnvelopeTempo.from({
+ *   chainId: 1,
+ *   calls: [{
+ *     to: 'tempox0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+ *   }],
+ *   nonce: 0n,
+ * })
+ *
+ * const encoded = TxEnvelopeTempo.encodeForSigning(envelope) // [!code focus]
+ * const payload = Hash.keccak256(encoded)
+ * ```
+ *
+ * @param envelope - The transaction envelope to encode for signing.
+ * @returns The serialized transaction bytes used as the sender signing preimage.
+ */
+export function encodeForSigning(
+  envelope: TxEnvelopeTempo,
+): encodeForSigning.ReturnValue {
+  return serialize({
+    ...envelope,
+    signature: undefined,
+    // When a fee payer signature is present, normalize to `null`
+    // (the presign marker).
+    ...(envelope.feePayerSignature !== undefined
+      ? { feePayerSignature: null }
+      : {}),
+  })
+}
+
+export declare namespace encodeForSigning {
+  type ReturnValue = Hex.Hex
+
+  type ErrorType = serialize.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Returns the payload to sign for a {@link ox#TxEnvelopeTempo.TxEnvelopeTempo}.
+ *
+ * Computes the keccak256 hash of {@link ox#TxEnvelopeTempo.(encodeForSigning:function)}.
+ *
+ * @example
  * ```ts twoslash
  * // @noErrors
  * import { Secp256k1 } from 'ox'
@@ -798,54 +841,13 @@ export declare namespace serialize {
  * const envelope = TxEnvelopeTempo.from({
  *   chainId: 1,
  *   calls: [{
- *     data: '0xdeadbeef',
  *     to: 'tempox0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
  *   }],
  *   nonce: 0n,
- *   maxFeePerGas: 1000000000n,
- *   gas: 21000n,
  * })
  *
  * const payload = TxEnvelopeTempo.getSignPayload(envelope) // [!code focus]
- * // @log: '0x...'
- *
  * const signature = Secp256k1.sign({ payload, privateKey: '0x...' })
- * ```
- *
- * @example
- * ### Access Keys
- *
- * When signing as an access key on behalf of a root account, pass the
- * `from` option with the root account address. This computes
- * `keccak256(0x04 || sigHash || from)` which binds the signature to the
- * specific user account (V2 keychain format).
- *
- * ```ts twoslash
- * // @noErrors
- * import { Secp256k1 } from 'ox'
- * import { TxEnvelopeTempo, SignatureEnvelope } from 'ox/tempo'
- *
- * const envelope = TxEnvelopeTempo.from({
- *   chainId: 1,
- *   calls: [{
- *     data: '0xdeadbeef',
- *     to: 'tempox0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
- *   }],
- *   nonce: 0n,
- *   maxFeePerGas: 1000000000n,
- *   gas: 21000n,
- * })
- *
- * const payload = TxEnvelopeTempo.getSignPayload(envelope, { from: '0x...' }) // [!code focus]
- *
- * const signature = Secp256k1.sign({ payload, privateKey: '0x...' })
- *
- * const signed = TxEnvelopeTempo.serialize(envelope, {
- *   signature: SignatureEnvelope.from({
- *     userAddress: from,
- *     inner: SignatureEnvelope.from(signature),
- *   }),
- * })
  * ```
  *
  * @param envelope - The transaction envelope to get the sign payload for.
@@ -918,19 +920,9 @@ export function hash<presign extends boolean = false>(
   envelope: TxEnvelopeTempo<presign extends true ? false : true>,
   options: hash.Options<presign> = {},
 ): hash.ReturnValue {
-  const serialized = serialize({
-    ...envelope,
-    ...(options.presign
-      ? {
-          signature: undefined,
-          // When a fee payer signature is present, normalize to `null`
-          // (the presign marker).
-          ...(envelope.feePayerSignature !== undefined
-            ? { feePayerSignature: null }
-            : {}),
-        }
-      : {}),
-  })
+  const serialized = options.presign
+    ? encodeForSigning(envelope)
+    : serialize(envelope)
   return Hash.keccak256(serialized)
 }
 
@@ -949,6 +941,7 @@ export declare namespace hash {
   type ErrorType =
     | Hash.keccak256.ErrorType
     | serialize.ErrorType
+    | encodeForSigning.ErrorType
     | Errors.GlobalErrorType
 }
 


### PR DESCRIPTION
## Motivation

[Tempo's TIP-1034](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1034.md) channel opens bind channel identity to the tx via an `expiringNonceHash`:

```txt
keccak256(encodeForSigning || sender)
```

this gives the precompile its replay/same-transaction semantics, but it means clients need access to the exact Tempo transaction signing preimage before computing `channelId` and signing the initial voucher.

this differs from the legacy smart-contract MPP flow, where the channel ID is derived only from static open parameters:

```ts
keccak256(abi.encode(payer, payee, token, salt, authorizedSigner, escrowContract, chainId))
```

## Solution

extend the Tempo tx envelope API with:

```ts
TxEnvelopeTempo.encodeForSigning(envelope): Hex
```

this exposes the raw Tempo sender-signing preimage bytes currently only available indirectly through `hash(envelope, { presign: true })` / `getSignPayload`.

`hash(envelope, { presign: true })` now hashes `encodeForSigning(envelope)`, preserving existing behavior.

## Tests

- `keccak256(encodeForSigning(tx))` matches `TxEnvelopeTempo.getSignPayload(tx)`.
- `encodeForSigning` is stable across sender/fee-payer signatures and fee-payer-selected fee token changes when the sender does not commit to the fee token.
