### PR TITLE
feat(tempo): add `Channel` reserve helpers

### DIFF
--- a/.changeset/lucky-tempo-channels.md
+++ b/.changeset/lucky-tempo-channels.md
@@ -1,5 +1,5 @@
 ---
-"ox": minor
+"ox": patch
 ---
 
 Added TIP-20 channel reserve constants, channel id computation, and voucher signing helpers.

--- a/.changeset/lucky-tempo-channels.md
+++ b/.changeset/lucky-tempo-channels.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added TIP-20 channel reserve constants, channel id computation, and voucher signing helpers.

--- a/src/tempo/Channel.test.ts
+++ b/src/tempo/Channel.test.ts
@@ -1,0 +1,121 @@
+import { Hash, Hex, TypedData } from 'ox'
+import { Channel } from 'ox/tempo'
+import { describe, expect, test } from 'vitest'
+
+const descriptor = {
+  authorizedSigner: '0x3333333333333333333333333333333333333333',
+  chainId: 4217,
+  expiringNonceHash:
+    '0x0000000000000000000000000000000000000000000000000000000000000002',
+  operator: '0x0000000000000000000000000000000000000000',
+  payee: '0x2222222222222222222222222222222222222222',
+  payer: '0x1111111111111111111111111111111111111111',
+  salt: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  token: 1n,
+} as const
+
+describe('address', () => {
+  test('default', () => {
+    expect(Channel.address).toMatchInlineSnapshot(
+      `"0x4d50500000000000000000000000000000000000"`,
+    )
+  })
+})
+
+describe('closeGracePeriod', () => {
+  test('default', () => {
+    expect(Channel.closeGracePeriod).toMatchInlineSnapshot(`900n`)
+  })
+})
+
+describe('voucherTypehash', () => {
+  test('default', () => {
+    expect(Channel.voucherTypehash).toBe(
+      Hash.keccak256(
+        Hex.fromString('Voucher(bytes32 channelId,uint96 cumulativeAmount)'),
+      ),
+    )
+    expect(Channel.voucherTypehash).toMatchInlineSnapshot(
+      `"0x4730b4b2fe8de522475e80e010877c5b58ad10eb07fd0436615ee123f743bbe8"`,
+    )
+  })
+})
+
+describe('computeId', () => {
+  test('default', () => {
+    expect(Channel.computeId(descriptor)).toMatchInlineSnapshot(
+      `"0xa392474fdbb5c6753e8789236893343f11200f43ba53cca09c0cda3651946ef2"`,
+    )
+  })
+
+  test('address inputs', () => {
+    expect(
+      Channel.computeId({
+        ...descriptor,
+        payee: 'tempox0x2222222222222222222222222222222222222222',
+        token: 'tempox0x20c0000000000000000000000000000000000001',
+      }),
+    ).toBe(Channel.computeId(descriptor))
+  })
+
+  test('chain id bigint', () => {
+    expect(Channel.computeId({ ...descriptor, chainId: 4217n })).toBe(
+      Channel.computeId(descriptor),
+    )
+  })
+})
+
+describe('domainSeparator', () => {
+  test('default', () => {
+    const separator = Channel.domainSeparator({ chainId: descriptor.chainId })
+
+    expect(separator).toBe(
+      TypedData.domainSeparator({
+        name: 'TIP20 Channel Reserve',
+        version: '1',
+        chainId: descriptor.chainId,
+        verifyingContract: Channel.address,
+      }),
+    )
+    expect(separator).toMatchInlineSnapshot(
+      `"0x6465ffa0b0c1e7cfc1a894ba54d79615bc06fd7cc9cfec558f3df82189d17367"`,
+    )
+  })
+})
+
+describe('getVoucherSignPayload', () => {
+  test('default', () => {
+    const channelId = Channel.computeId(descriptor)
+    const cumulativeAmount = 100n
+    const payload = Channel.getVoucherSignPayload({
+      chainId: descriptor.chainId,
+      channelId,
+      cumulativeAmount,
+    })
+
+    expect(payload).toBe(
+      TypedData.getSignPayload({
+        domain: {
+          name: 'TIP20 Channel Reserve',
+          version: '1',
+          chainId: descriptor.chainId,
+          verifyingContract: Channel.address,
+        },
+        message: {
+          channelId,
+          cumulativeAmount,
+        },
+        primaryType: 'Voucher',
+        types: {
+          Voucher: [
+            { name: 'channelId', type: 'bytes32' },
+            { name: 'cumulativeAmount', type: 'uint96' },
+          ],
+        },
+      }),
+    )
+    expect(payload).toMatchInlineSnapshot(
+      `"0x22bb33a0c0d3e04c9312dd8c70c80154e953fef495dd76ffa14388a9c7f987d3"`,
+    )
+  })
+})

--- a/src/tempo/Channel.ts
+++ b/src/tempo/Channel.ts
@@ -1,0 +1,205 @@
+import * as AbiParameters from '../core/AbiParameters.js'
+import type * as Address from '../core/Address.js'
+import * as Hash from '../core/Hash.js'
+import * as Hex from '../core/Hex.js'
+import * as TempoAddress from './TempoAddress.js'
+import * as TokenId from './TokenId.js'
+
+const channelIdParameters = AbiParameters.from(
+  'address, address, address, address, bytes32, address, bytes32, address, uint256',
+)
+const domainSeparatorParameters = AbiParameters.from(
+  'bytes32, bytes32, bytes32, uint256, address',
+)
+const voucherHashParameters = AbiParameters.from('bytes32, bytes32, uint96')
+
+const eip712DomainTypehash = Hash.keccak256(
+  Hex.fromString(
+    'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)',
+  ),
+)
+const nameHash = Hash.keccak256(Hex.fromString('TIP20 Channel Reserve'))
+const versionHash = Hash.keccak256(Hex.fromString('1'))
+
+/**
+ * TIP-20 channel reserve precompile address.
+ */
+export const address =
+  '0x4d50500000000000000000000000000000000000' as const satisfies Address.Address
+
+/**
+ * Delay between payer `requestClose` and `withdraw`, in seconds.
+ */
+export const closeGracePeriod = 900n
+
+/**
+ * EIP-712 type hash for `Voucher(bytes32 channelId,uint96 cumulativeAmount)`.
+ */
+export const voucherTypehash = Hash.keccak256(
+  Hex.fromString('Voucher(bytes32 channelId,uint96 cumulativeAmount)'),
+)
+
+/**
+ * TIP-20 channel descriptor.
+ */
+export type Descriptor = {
+  /** Account that funded the channel and receives refunds. */
+  payer: TempoAddress.Address
+  /** Account that receives settled voucher payments. */
+  payee: TempoAddress.Address
+  /** Optional relayer allowed to submit `settle` for the payee. */
+  operator: TempoAddress.Address
+  /** TIP-20 token address held by the channel. */
+  token: TokenId.TokenIdOrAddress<TempoAddress.Address>
+  /** User-supplied salt to distinguish otherwise identical channels. */
+  salt: Hex.Hex
+  /** Optional signer for vouchers. Zero means `payer` signs. */
+  authorizedSigner: TempoAddress.Address
+  /** Transaction-derived hash assigned when the channel was opened. */
+  expiringNonceHash: Hex.Hex
+}
+
+/**
+ * Computes the canonical TIP-20 channel id for a descriptor.
+ *
+ * Mirrors `computeChannelId` on the TIP-20 channel reserve precompile without
+ * performing an RPC call.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Channel } from 'ox/tempo'
+ *
+ * const channelId = Channel.computeId({
+ *   authorizedSigner: '0x0000000000000000000000000000000000000000',
+ *   chainId: 4217,
+ *   expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+ *   operator: '0x0000000000000000000000000000000000000000',
+ *   payee: '0x2222222222222222222222222222222222222222',
+ *   payer: '0x1111111111111111111111111111111111111111',
+ *   salt: '0x0000000000000000000000000000000000000000000000000000000000000001',
+ *   token: 1n,
+ * })
+ * ```
+ *
+ * @param value - Channel descriptor and chain id.
+ * @returns The channel id.
+ */
+export function computeId(value: computeId.Value): Hex.Hex {
+  return Hash.keccak256(
+    AbiParameters.encode(channelIdParameters, [
+      TempoAddress.resolve(value.payer),
+      TempoAddress.resolve(value.payee),
+      TempoAddress.resolve(value.operator),
+      TokenId.toAddress(value.token),
+      value.salt,
+      TempoAddress.resolve(value.authorizedSigner),
+      value.expiringNonceHash,
+      address,
+      BigInt(value.chainId),
+    ]),
+  )
+}
+
+export declare namespace computeId {
+  type Value = Descriptor & {
+    /** Chain id used by the channel reserve precompile. */
+    chainId: number | bigint
+  }
+
+  type ErrorType =
+    | AbiParameters.encode.ErrorType
+    | Hash.keccak256.ErrorType
+    | TempoAddress.parse.ErrorType
+}
+
+/**
+ * Computes the EIP-712 domain separator for the TIP-20 channel reserve.
+ *
+ * Mirrors `domainSeparator` on the TIP-20 channel reserve precompile without
+ * performing an RPC call.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Channel } from 'ox/tempo'
+ *
+ * const separator = Channel.domainSeparator({ chainId: 4217 })
+ * ```
+ *
+ * @param value - Chain id.
+ * @returns The EIP-712 domain separator.
+ */
+export function domainSeparator(value: domainSeparator.Value): Hex.Hex {
+  return Hash.keccak256(
+    AbiParameters.encode(domainSeparatorParameters, [
+      eip712DomainTypehash,
+      nameHash,
+      versionHash,
+      BigInt(value.chainId),
+      address,
+    ]),
+  )
+}
+
+export declare namespace domainSeparator {
+  type Value = {
+    /** Chain id used by the channel reserve precompile. */
+    chainId: number | bigint
+  }
+
+  type ErrorType = AbiParameters.encode.ErrorType | Hash.keccak256.ErrorType
+}
+
+/**
+ * Computes the EIP-712 sign payload for a TIP-20 channel voucher.
+ *
+ * Mirrors `getVoucherDigest` on the TIP-20 channel reserve precompile without
+ * performing an RPC call.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Channel } from 'ox/tempo'
+ *
+ * const payload = Channel.getVoucherSignPayload({
+ *   chainId: 4217,
+ *   channelId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+ *   cumulativeAmount: 1n,
+ * })
+ * ```
+ *
+ * @param value - Voucher fields and chain id.
+ * @returns The voucher sign payload.
+ */
+export function getVoucherSignPayload(
+  value: getVoucherSignPayload.Value,
+): Hex.Hex {
+  const voucherHash = Hash.keccak256(
+    AbiParameters.encode(voucherHashParameters, [
+      voucherTypehash,
+      value.channelId,
+      value.cumulativeAmount,
+    ]),
+  )
+  return Hash.keccak256(
+    Hex.concat(
+      '0x1901',
+      domainSeparator({ chainId: value.chainId }),
+      voucherHash,
+    ),
+  )
+}
+
+export declare namespace getVoucherSignPayload {
+  type Value = {
+    /** Chain id used by the channel reserve precompile. */
+    chainId: number | bigint
+    /** Channel id. */
+    channelId: Hex.Hex
+    /** Total voucher amount signed for the channel. */
+    cumulativeAmount: bigint
+  }
+
+  type ErrorType =
+    | AbiParameters.encode.ErrorType
+    | domainSeparator.ErrorType
+    | Hash.keccak256.ErrorType
+}

--- a/src/tempo/ZoneRpcAuthentication.test.ts
+++ b/src/tempo/ZoneRpcAuthentication.test.ts
@@ -171,7 +171,7 @@ describe('serialize', () => {
 })
 
 const credentials = import.meta.env.VITE_TEMPO_CREDENTIALS
-const rpcUrl = 'https://rpc-zone-006-private.tempoxyz.dev'
+const rpcUrl = 'https://rpc-zone-b.testnet.tempo.xyz'
 
 describe('e2e', () => {
   test.skipIf(!credentials)('succeeds with auth token', async () => {

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -36,6 +36,32 @@ export type {}
  */
 export * as AuthorizationTempo from './AuthorizationTempo.js'
 /**
+ * TIP-20 channel reserve constants and deterministic hashing utilities.
+ *
+ * The channel reserve precompile exposes helper methods for channel identifiers,
+ * voucher sign payloads, and its EIP-712 domain separator. These utilities compute the
+ * same values locally when the chain id and channel fields are known.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Channel } from 'ox/tempo'
+ *
+ * const channelId = Channel.computeId({
+ *   authorizedSigner: '0x0000000000000000000000000000000000000000',
+ *   chainId: 4217,
+ *   expiringNonceHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+ *   operator: '0x0000000000000000000000000000000000000000',
+ *   payee: '0x2222222222222222222222222222222222222222',
+ *   payer: '0x1111111111111111111111111111111111111111',
+ *   salt: '0x0000000000000000000000000000000000000000000000000000000000000001',
+ *   token: 1n,
+ * })
+ * ```
+ *
+ * @category Reference
+ */
+export * as Channel from './Channel.js'
+/**
  * Tempo key authorization utilities for provisioning and signing access keys.
  *
  * Access keys allow a root key (e.g., a passkey) to delegate transaction signing to secondary


### PR DESCRIPTION
Adds a new `Channel` namespace under `ox/tempo` for TIP-20 channel reserve constants and client-side calculations. The helpers expose the reserve address, close grace period, voucher type hash, channel id computation, domain separator, and voucher sign payload derivation.

These values mirror the precompile methods that do not require channel storage, letting callers prepare channel ids and voucher signatures without an RPC round trip when they already know the chain id and descriptor fields.