### PR TITLE
feat(tempo): TIP-1053 witnesses in key authorizations

### DIFF
--- a/.changeset/tip-1053-witness.md
+++ b/.changeset/tip-1053-witness.md
@@ -2,4 +2,4 @@
 "ox": minor
 ---
 
-Added support for TIP-1053 (witnesses in key authorizations). `KeyAuthorization` and its RPC/tuple representations now accept an optional 32-byte `witness` field that is included in the signing hash, letting a single signature both authorize an access key and bind to an arbitrary application context (e.g. a server-issued challenge).
+Added support for TIP-1053 (witnesses in key authorizations) via an optional 32-byte `witness` field on `KeyAuthorization` that is included in the signing hash.

--- a/.changeset/tip-1053-witness.md
+++ b/.changeset/tip-1053-witness.md
@@ -2,4 +2,4 @@
 "ox": patch
 ---
 
-Added support for TIP-1053 (witnesses in key authorizations) via an optional 32-byte `witness` field on `KeyAuthorization` that is included in the signing hash.
+`ox/tempo`: Added support for TIP-1053 (witnesses in key authorizations) via an optional 32-byte `witness` field on `KeyAuthorization` that is included in the signing hash.

--- a/.changeset/tip-1053-witness.md
+++ b/.changeset/tip-1053-witness.md
@@ -1,5 +1,5 @@
 ---
-"ox": minor
+"ox": patch
 ---
 
 Added support for TIP-1053 (witnesses in key authorizations) via an optional 32-byte `witness` field on `KeyAuthorization` that is included in the signing hash.

--- a/.changeset/tip-1053-witness.md
+++ b/.changeset/tip-1053-witness.md
@@ -1,0 +1,5 @@
+---
+"ox": minor
+---
+
+Added support for TIP-1053 (witnesses in key authorizations). `KeyAuthorization` and its RPC/tuple representations now accept an optional 32-byte `witness` field that is included in the signing hash, letting a single signature both authorize an access key and bind to an arbitrary application context (e.g. a server-issued challenge).

--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -2133,3 +2133,195 @@ describe('toTuple', () => {
     ])
   })
 })
+
+describe('witness (TIP-1053)', () => {
+  const witness =
+    '0x1111111111111111111111111111111111111111111111111111111111111111' as const
+  const witness_other =
+    '0x2222222222222222222222222222222222222222222222222222222222222222' as const
+
+  test('from: preserves witness', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+      witness,
+    })
+    expect(authorization.witness).toBe(witness)
+  })
+
+  test('from: throws on non-32-byte witness', () => {
+    expect(() =>
+      KeyAuthorization.from({
+        address,
+        chainId: 1n,
+        type: 'secp256k1',
+        witness: '0xdeadbeef',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[KeyAuthorization.InvalidWitnessSizeError: Witness \`0xdeadbeef\` must be exactly 32 bytes (got 4 bytes).]`,
+    )
+  })
+
+  test('toTuple: appends witness as trailing field with defaulted earlier fields', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+      witness,
+    })
+    const [authTuple] = KeyAuthorization.toTuple(authorization)
+    expect(authTuple).toEqual([
+      '0x1', // chainId
+      '0x', // keyType (secp256k1)
+      address,
+      '0x', // expiry default (never expires)
+      '0x', // limits absent (RLP null placeholder)
+      '0x', // scopes absent (RLP null placeholder)
+      witness,
+    ])
+  })
+
+  test('toTuple: omits witness when absent (byte-equivalent to pre-TIP-1053)', () => {
+    const withoutWitness = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+    })
+    const [authTuple] = KeyAuthorization.toTuple(withoutWitness)
+    expect((authTuple as unknown as unknown[]).length).toBe(3)
+  })
+
+  test('serialize/deserialize: roundtrip with witness only', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+      witness,
+    })
+    const serialized = KeyAuthorization.serialize(authorization)
+    const restored = KeyAuthorization.deserialize(serialized)
+    expect(restored.witness).toBe(witness)
+    expect(restored.expiry).toBeUndefined()
+    expect(restored.limits).toBeUndefined()
+    expect(restored.scopes).toBeUndefined()
+  })
+
+  test('serialize/deserialize: roundtrip with witness + expiry + limits + scopes', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      expiry,
+      type: 'secp256k1',
+      limits: [{ token, limit: Value.from('10', 6) }],
+      scopes: [
+        {
+          address: token,
+          selector: '0xa9059cbb',
+          recipients: ['0x1111111111111111111111111111111111111111'],
+        },
+      ],
+      witness,
+    })
+    const serialized = KeyAuthorization.serialize(authorization)
+    const restored = KeyAuthorization.deserialize(serialized)
+    expect(restored.witness).toBe(witness)
+    expect(restored.expiry).toBe(expiry)
+    expect(restored.limits?.[0]?.limit).toBe(10000000n)
+    expect(restored.scopes?.[0]?.selector).toBe('0xa9059cbb')
+  })
+
+  test('toRpc/fromRpc: roundtrip with witness', () => {
+    const authorization = KeyAuthorization.from(
+      {
+        address,
+        chainId: 1n,
+        type: 'secp256k1',
+        witness,
+      },
+      { signature: SignatureEnvelope.from(signature_secp256k1) },
+    )
+    const rpc = KeyAuthorization.toRpc(authorization)
+    expect(rpc.witness).toBe(witness)
+    const restored = KeyAuthorization.fromRpc(rpc)
+    expect(restored.witness).toBe(witness)
+  })
+
+  test('hash: changes when witness changes', () => {
+    const a = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+      witness,
+    })
+    const b = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+      witness: witness_other,
+    })
+    expect(KeyAuthorization.hash(a)).not.toBe(KeyAuthorization.hash(b))
+  })
+
+  test('hash: witness-less encoding matches pre-TIP-1053 hash', () => {
+    const before = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+    })
+    // Re-create the same auth (no witness field). Hash must be identical.
+    const again = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+    })
+    expect(KeyAuthorization.hash(before)).toBe(KeyAuthorization.hash(again))
+  })
+
+  test('fromTuple: extracts trailing witness', () => {
+    const restored = KeyAuthorization.fromTuple([
+      [
+        '0x01',
+        '0x',
+        address,
+        '0x',
+        [],
+        [],
+        witness,
+      ],
+    ])
+    expect(restored.witness).toBe(witness)
+  })
+
+  test('fromTuple: throws on non-32-byte witness', () => {
+    expect(() =>
+      KeyAuthorization.fromTuple([
+        ['0x01', '0x', address, '0x', [], [], '0xdeadbeef'],
+      ]),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[KeyAuthorization.InvalidWitnessSizeError: Witness \`0xdeadbeef\` must be exactly 32 bytes (got 4 bytes).]`,
+    )
+  })
+
+  test('signing flow: signature verifies against witness-bearing hash', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+      witness,
+    })
+    const payload = KeyAuthorization.getSignPayload(authorization)
+    const sig = Secp256k1.sign({
+      payload,
+      privateKey: privateKey_secp256k1,
+    })
+    const signed = KeyAuthorization.from(authorization, {
+      signature: SignatureEnvelope.from(sig),
+    })
+    const serialized = KeyAuthorization.serialize(signed)
+    const restored = KeyAuthorization.deserialize(serialized)
+    expect(restored.witness).toBe(witness)
+    // The hash of the restored payload matches what was signed.
+    expect(KeyAuthorization.hash(restored)).toBe(payload)
+  })
+})

--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -2280,15 +2280,7 @@ describe('witness (TIP-1053)', () => {
 
   test('fromTuple: extracts trailing witness', () => {
     const restored = KeyAuthorization.fromTuple([
-      [
-        '0x01',
-        '0x',
-        address,
-        '0x',
-        [],
-        [],
-        witness,
-      ],
+      ['0x01', '0x', address, '0x', [], [], witness],
     ])
     expect(restored.witness).toBe(witness)
   })

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -561,17 +561,8 @@ export function fromTuple<const tuple extends Tuple>(
   tuple: tuple,
 ): fromTuple.ReturnType<tuple> {
   const [authorization, signatureSerialized] = tuple
-  const [chainId, keyType_hex, keyId, expiry, limits, scopes, witness] =
-    authorization as unknown as [
-      Hex.Hex,
-      Hex.Hex,
-      Address.Address,
-      Hex.Hex | undefined,
-      readonly TokenLimitTuple[] | undefined,
-      readonly CallScopeTuple[] | undefined,
-      Hex.Hex | undefined,
-    ]
-  if (witness !== undefined) assertWitness(witness)
+  const [chainId, keyType_hex, keyId, ...trailing] =
+    authorization as unknown as [Hex.Hex, Hex.Hex, Address.Address, ...unknown[]]
   const keyType = (() => {
     switch (keyType_hex) {
       case '0x':
@@ -585,55 +576,52 @@ export function fromTuple<const tuple extends Tuple>(
         throw new Error(`Invalid key type: ${keyType_hex}`)
     }
   })()
+  // Trailing optional fields in wire order. Each entry pulls one slot off the
+  // trailing array and decodes it (treating absent or RLP-null placeholders as
+  // missing). To add a new optional trailing field, append a single entry.
+  const [rawExpiry, rawLimits, rawScopes, rawWitness] = trailing
+  const expiry = isAbsent(rawExpiry)
+    ? undefined
+    : hexToNumber(rawExpiry as Hex.Hex) || undefined
+  const limits = Array.isArray(rawLimits) && rawLimits.length > 0
+    ? rawLimits.map((limitTuple: any) => {
+        const [token, limit, period] = limitTuple
+        return {
+          token,
+          limit: hexToBigint(limit),
+          ...(period !== undefined ? { period: hexToNumber(period) } : {}),
+        }
+      })
+    : undefined
+  const scopes = Array.isArray(rawScopes)
+    ? rawScopes.flatMap((scopeTuple: any) => {
+        const [address, selectorRules] = scopeTuple
+        // If no selector rules, this is an address-only scope.
+        if (!Array.isArray(selectorRules) || selectorRules.length === 0)
+          return [{ address }]
+        // Flatten each selector rule into a separate scope entry.
+        return selectorRules.map((ruleTuple: any) => {
+          const [selector, recipients] = ruleTuple
+          return {
+            address,
+            selector,
+            ...(Array.isArray(recipients) && recipients.length > 0
+              ? { recipients }
+              : {}),
+          }
+        })
+      })
+    : undefined
+  const witness = isAbsent(rawWitness) ? undefined : (rawWitness as Hex.Hex)
+  if (witness !== undefined) assertWitness(witness)
   const args: KeyAuthorization = {
     address: keyId,
-    expiry:
-      typeof expiry !== 'undefined'
-        ? hexToNumber(expiry) || undefined
-        : undefined,
-    type: keyType,
     chainId: chainId === '0x' ? 0n : Hex.toBigInt(chainId),
-    ...(typeof expiry !== 'undefined'
-      ? { expiry: hexToNumber(expiry) || undefined }
-      : {}),
-    ...(typeof limits !== 'undefined' &&
-    Array.isArray(limits) &&
-    limits.length > 0
-      ? {
-          limits: limits.map((limitTuple: any) => {
-            const [token, limit, period] = limitTuple
-            return {
-              token,
-              limit: hexToBigint(limit),
-              ...(typeof period !== 'undefined'
-                ? { period: hexToNumber(period) }
-                : {}),
-            }
-          }),
-        }
-      : {}),
+    type: keyType,
+    ...(expiry !== undefined ? { expiry } : {}),
+    ...(limits !== undefined ? { limits } : {}),
+    ...(scopes !== undefined ? { scopes } : {}),
     ...(witness !== undefined ? { witness } : {}),
-    ...(typeof scopes !== 'undefined' && Array.isArray(scopes)
-      ? {
-          scopes: scopes.flatMap((scopeTuple: any) => {
-            const [address, selectorRules] = scopeTuple
-            // If no selector rules, this is an address-only scope
-            if (!Array.isArray(selectorRules) || selectorRules.length === 0)
-              return [{ address }]
-            // Flatten each selector rule into a separate scope entry
-            return selectorRules.map((ruleTuple: any) => {
-              const [selector, recipients] = ruleTuple
-              return {
-                address,
-                selector,
-                ...(Array.isArray(recipients) && recipients.length > 0
-                  ? { recipients }
-                  : {}),
-              }
-            })
-          }),
-        }
-      : {}),
   }
   if (signatureSerialized)
     args.signature = SignatureEnvelope.deserialize(signatureSerialized)
@@ -837,16 +825,8 @@ export declare namespace serialize {
  * @returns An RPC-formatted Key Authorization.
  */
 export function toRpc(authorization: Signed): Rpc {
-  const {
-    address,
-    scopes,
-    chainId,
-    expiry,
-    limits,
-    type,
-    signature,
-    witness,
-  } = authorization
+  const { address, scopes, chainId, expiry, limits, type, signature, witness } =
+    authorization
   if (witness !== undefined) assertWitness(witness)
 
   // Group flat scopes by address into nested allowedCalls wire format
@@ -975,33 +955,48 @@ export function toTuple<const authorization extends KeyAuthorization>(
       selectorRules.map(([selector, recipients]) => [selector, recipients]),
     ])
   })()
-  // RLP placeholder for absent optional fields when a later field is present.
-  // `'0x'` encodes as RLP null (0x80), which the node decodes as `None` —
-  // semantically distinct from `[]` (empty list) which (for `scopes`) means
-  // "scoped with no calls allowed".
-  const absent = '0x' as const
+  // Optional trailing fields in wire order. Each entry's `placeholder` is
+  // emitted when this field is skipped but a later field is present.
+  //
+  // Placeholder convention:
+  // - `'0x'` (RLP null) is the canonical placeholder for fields added at or
+  //   after TIP-1053. The node decodes it as `None` (unrestricted).
+  // - `limits` keeps `[]` as its skipped placeholder when no witness is
+  //   present — preserving byte-for-byte equivalence with pre-TIP-1053
+  //   signed payloads.
+  //
+  // To add a new optional trailing field (e.g. from a future TIP): append a
+  // single entry to this list with `placeholder: '0x'`.
+  const optionals: readonly { value: unknown; placeholder: unknown }[] = [
+    {
+      value:
+        expiry !== null && expiry !== undefined && expiry !== 0
+          ? numberToHex(expiry)
+          : undefined,
+      placeholder: '0x',
+    },
+    {
+      value: limitsValue,
+      placeholder: witness !== undefined ? '0x' : [],
+    },
+    { value: callsValue, placeholder: '0x' },
+    { value: witness, placeholder: '0x' },
+  ]
+  let lastPresent = -1
+  for (let i = optionals.length - 1; i >= 0; i--)
+    if (optionals[i]!.value !== undefined) {
+      lastPresent = i
+      break
+    }
+  const trailing = optionals
+    .slice(0, lastPresent + 1)
+    .map(({ value, placeholder }) => value ?? placeholder)
   const authorizationTuple = [
     bigintToHex(chainId),
     type,
     address,
-    // expiry is required in the tuple when limits, scopes, or witness are present
-    // expiry=0 is treated the same as undefined (never expires)
-    (expiry !== null && expiry !== undefined && expiry !== 0) ||
-    limitsValue ||
-    callsValue ||
-    witness !== undefined
-      ? numberToHex(expiry ?? 0)
-      : undefined,
-    // limits is required in the tuple when scopes or witness are present
-    limitsValue || callsValue || witness !== undefined
-      ? (limitsValue ?? (witness !== undefined && !callsValue ? absent : []))
-      : undefined,
-    // scopes is required in the tuple when witness is present.
-    // When absent, use the RLP null placeholder so the node interprets it as
-    // "unrestricted" rather than `[]` (scoped, no calls allowed).
-    callsValue || witness !== undefined ? (callsValue ?? absent) : undefined,
-    witness,
-  ].filter((x) => typeof x !== 'undefined')
+    ...trailing,
+  ]
   return [authorizationTuple, ...(signature ? [signature] : [])] as never
 }
 
@@ -1045,6 +1040,19 @@ function resolveSelector(
 
 function assertWitness(witness: Hex.Hex): void {
   if (Hex.size(witness) !== 32) throw new InvalidWitnessSizeError(witness)
+}
+
+/**
+ * Whether a raw RLP-decoded trailing field is absent. A field is absent when
+ * the tuple is shorter than its position, or when the slot holds the RLP-null
+ * placeholder (`'0x'`) used to skip an optional field while still emitting a
+ * later one.
+ *
+ * Callers that need to distinguish a meaningful empty list (`[]`) from an
+ * absent field (e.g. `scopes`) must inspect the raw value directly.
+ */
+function isAbsent(value: unknown): boolean {
+  return value === undefined || value === '0x'
 }
 
 /** Thrown when a `witness` field is not exactly 32 bytes. */

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -55,6 +55,16 @@ export type KeyAuthorization<
   scopes?: readonly Scope<addressType>[] | undefined
   /** Key type. (secp256k1, P256, WebAuthn). */
   type: SignatureEnvelope.Type
+  /**
+   * Optional 32-byte witness bound into the signing hash.
+   *
+   * Applications use this to bind a single signature to an arbitrary offchain
+   * context (e.g. a server-issued challenge), or as a revocation handle that
+   * can be burned onchain to invalidate the authorization before submission.
+   *
+   * [TIP-1053 Specification](https://tips.sh/1053)
+   */
+  witness?: Hex.Hex | undefined
 } & (signed extends true
   ? { signature: SignatureEnvelope.SignatureEnvelope<bigintType, numberType> }
   : {
@@ -87,6 +97,8 @@ export type Rpc = {
   limits?: readonly RpcTokenLimit[] | undefined
   /** Signature envelope. */
   signature: SignatureEnvelope.SignatureEnvelopeRpc
+  /** Optional 32-byte witness (hex). */
+  witness?: Hex.Hex | null | undefined
 }
 
 /** RPC representation of a token limit (matches node's `TokenLimit` serde). */
@@ -144,6 +156,13 @@ type AuthorizationTuple =
       expiry: Hex.Hex,
       limits: readonly TokenLimitTuple[],
       calls: readonly CallScopeTuple[],
+    ]
+  | readonly [
+      ...BaseTuple,
+      expiry: Hex.Hex,
+      limits: readonly TokenLimitTuple[],
+      calls: readonly CallScopeTuple[],
+      witness: Hex.Hex,
     ]
 
 /** Tuple representation of a Key Authorization. */
@@ -362,6 +381,7 @@ export function from<
       recipients?: readonly TempoAddress.Address[]
     }[]
   }
+  if (auth.witness !== undefined) assertWitness(auth.witness)
   const resolved = {
     ...auth,
     address: TempoAddress.resolve(auth.address as TempoAddress.Address),
@@ -455,7 +475,9 @@ export declare namespace from {
 export function fromRpc(authorization: Rpc): Signed {
   const { allowedCalls, chainId, keyId, expiry, limits, keyType } =
     authorization
+  const witness = authorization.witness ?? undefined
   const signature = SignatureEnvelope.fromRpc(authorization.signature)
+  if (witness !== undefined) assertWitness(witness)
 
   // Unflatten nested allowedCalls into flat scopes
   const scopes = allowedCalls
@@ -488,6 +510,7 @@ export function fromRpc(authorization: Rpc): Signed {
     ...(scopes ? { scopes } : {}),
     signature,
     type: keyType,
+    ...(witness !== undefined ? { witness } : {}),
   }
 }
 
@@ -538,7 +561,17 @@ export function fromTuple<const tuple extends Tuple>(
   tuple: tuple,
 ): fromTuple.ReturnType<tuple> {
   const [authorization, signatureSerialized] = tuple
-  const [chainId, keyType_hex, keyId, expiry, limits, scopes] = authorization
+  const [chainId, keyType_hex, keyId, expiry, limits, scopes, witness] =
+    authorization as unknown as [
+      Hex.Hex,
+      Hex.Hex,
+      Address.Address,
+      Hex.Hex | undefined,
+      readonly TokenLimitTuple[] | undefined,
+      readonly CallScopeTuple[] | undefined,
+      Hex.Hex | undefined,
+    ]
+  if (witness !== undefined) assertWitness(witness)
   const keyType = (() => {
     switch (keyType_hex) {
       case '0x':
@@ -579,6 +612,7 @@ export function fromTuple<const tuple extends Tuple>(
           }),
         }
       : {}),
+    ...(witness !== undefined ? { witness } : {}),
     ...(typeof scopes !== 'undefined' && Array.isArray(scopes)
       ? {
           scopes: scopes.flatMap((scopeTuple: any) => {
@@ -803,8 +837,17 @@ export declare namespace serialize {
  * @returns An RPC-formatted Key Authorization.
  */
 export function toRpc(authorization: Signed): Rpc {
-  const { address, scopes, chainId, expiry, limits, type, signature } =
-    authorization
+  const {
+    address,
+    scopes,
+    chainId,
+    expiry,
+    limits,
+    type,
+    signature,
+    witness,
+  } = authorization
+  if (witness !== undefined) assertWitness(witness)
 
   // Group flat scopes by address into nested allowedCalls wire format
   const allowedCalls = (() => {
@@ -842,6 +885,7 @@ export function toRpc(authorization: Signed): Rpc {
     })),
     signature: SignatureEnvelope.toRpc(signature),
     ...(allowedCalls ? { allowedCalls } : {}),
+    ...(witness !== undefined ? { witness } : {}),
   }
 }
 
@@ -883,7 +927,8 @@ export declare namespace toRpc {
 export function toTuple<const authorization extends KeyAuthorization>(
   authorization: authorization,
 ): toTuple.ReturnType<authorization> {
-  const { address, chainId, scopes, expiry, limits } = authorization
+  const { address, chainId, scopes, expiry, limits, witness } = authorization
+  if (witness !== undefined) assertWitness(witness)
   const signature = authorization.signature
     ? SignatureEnvelope.serialize(authorization.signature)
     : undefined
@@ -930,20 +975,32 @@ export function toTuple<const authorization extends KeyAuthorization>(
       selectorRules.map(([selector, recipients]) => [selector, recipients]),
     ])
   })()
+  // RLP placeholder for absent optional fields when a later field is present.
+  // `'0x'` encodes as RLP null (0x80), which the node decodes as `None` —
+  // semantically distinct from `[]` (empty list) which (for `scopes`) means
+  // "scoped with no calls allowed".
+  const absent = '0x' as const
   const authorizationTuple = [
     bigintToHex(chainId),
     type,
     address,
-    // expiry is required in the tuple when limits or scopes are present
+    // expiry is required in the tuple when limits, scopes, or witness are present
     // expiry=0 is treated the same as undefined (never expires)
     (expiry !== null && expiry !== undefined && expiry !== 0) ||
     limitsValue ||
-    callsValue
+    callsValue ||
+    witness !== undefined
       ? numberToHex(expiry ?? 0)
       : undefined,
-    // limits is required in the tuple when scopes are present
-    limitsValue || callsValue ? (limitsValue ?? []) : undefined,
-    callsValue,
+    // limits is required in the tuple when scopes or witness are present
+    limitsValue || callsValue || witness !== undefined
+      ? (limitsValue ?? (witness !== undefined && !callsValue ? absent : []))
+      : undefined,
+    // scopes is required in the tuple when witness is present.
+    // When absent, use the RLP null placeholder so the node interprets it as
+    // "unrestricted" rather than `[]` (scoped, no calls allowed).
+    callsValue || witness !== undefined ? (callsValue ?? absent) : undefined,
+    witness,
   ].filter((x) => typeof x !== 'undefined')
   return [authorizationTuple, ...(signature ? [signature] : [])] as never
 }
@@ -984,4 +1041,18 @@ function resolveSelector(
   if (!selector) return undefined
   if (selector.startsWith('0x')) return selector as Hex.Hex
   return AbiItem.getSelector(selector)
+}
+
+function assertWitness(witness: Hex.Hex): void {
+  if (Hex.size(witness) !== 32) throw new InvalidWitnessSizeError(witness)
+}
+
+/** Thrown when a `witness` field is not exactly 32 bytes. */
+export class InvalidWitnessSizeError extends Error {
+  override readonly name = 'KeyAuthorization.InvalidWitnessSizeError'
+  constructor(witness: Hex.Hex) {
+    super(
+      `Witness \`${witness}\` must be exactly 32 bytes (got ${Hex.size(witness)} bytes).`,
+    )
+  }
 }

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -562,7 +562,12 @@ export function fromTuple<const tuple extends Tuple>(
 ): fromTuple.ReturnType<tuple> {
   const [authorization, signatureSerialized] = tuple
   const [chainId, keyType_hex, keyId, ...trailing] =
-    authorization as unknown as [Hex.Hex, Hex.Hex, Address.Address, ...unknown[]]
+    authorization as unknown as [
+      Hex.Hex,
+      Hex.Hex,
+      Address.Address,
+      ...unknown[],
+    ]
   const keyType = (() => {
     switch (keyType_hex) {
       case '0x':
@@ -583,16 +588,17 @@ export function fromTuple<const tuple extends Tuple>(
   const expiry = isAbsent(rawExpiry)
     ? undefined
     : hexToNumber(rawExpiry as Hex.Hex) || undefined
-  const limits = Array.isArray(rawLimits) && rawLimits.length > 0
-    ? rawLimits.map((limitTuple: any) => {
-        const [token, limit, period] = limitTuple
-        return {
-          token,
-          limit: hexToBigint(limit),
-          ...(period !== undefined ? { period: hexToNumber(period) } : {}),
-        }
-      })
-    : undefined
+  const limits =
+    Array.isArray(rawLimits) && rawLimits.length > 0
+      ? rawLimits.map((limitTuple: any) => {
+          const [token, limit, period] = limitTuple
+          return {
+            token,
+            limit: hexToBigint(limit),
+            ...(period !== undefined ? { period: hexToNumber(period) } : {}),
+          }
+        })
+      : undefined
   const scopes = Array.isArray(rawScopes)
     ? rawScopes.flatMap((scopeTuple: any) => {
         const [address, selectorRules] = scopeTuple
@@ -991,12 +997,7 @@ export function toTuple<const authorization extends KeyAuthorization>(
   const trailing = optionals
     .slice(0, lastPresent + 1)
     .map(({ value, placeholder }) => value ?? placeholder)
-  const authorizationTuple = [
-    bigintToHex(chainId),
-    type,
-    address,
-    ...trailing,
-  ]
+  const authorizationTuple = [bigintToHex(chainId), type, address, ...trailing]
   return [authorizationTuple, ...(signature ? [signature] : [])] as never
 }
 
@@ -1042,15 +1043,6 @@ function assertWitness(witness: Hex.Hex): void {
   if (Hex.size(witness) !== 32) throw new InvalidWitnessSizeError(witness)
 }
 
-/**
- * Whether a raw RLP-decoded trailing field is absent. A field is absent when
- * the tuple is shorter than its position, or when the slot holds the RLP-null
- * placeholder (`'0x'`) used to skip an optional field while still emitting a
- * later one.
- *
- * Callers that need to distinguish a meaningful empty list (`[]`) from an
- * absent field (e.g. `scopes`) must inspect the raw value directly.
- */
 function isAbsent(value: unknown): boolean {
   return value === undefined || value === '0x'
 }

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -2662,4 +2662,167 @@ describe('behavior: keyAuthorization', () => {
       ).rejects.toThrow()
     },
   )
+
+  // TODO: remove skipIf when devnet/testnet have T5 (TIP-1053).
+  test.skipIf(nodeEnv !== 'localnet')(
+    'behavior: TIP-1053 witness round-trips through registration',
+    async () => {
+      const accessPrivateKey = Secp256k1.randomPrivateKey()
+      const accessAddress = Address.fromPublicKey(
+        Secp256k1.getPublicKey({ privateKey: accessPrivateKey }),
+      )
+
+      // Application-defined challenge digest, bound to the authorization.
+      const witness = Hex.random(32)
+
+      const keyAuth = KeyAuthorization.from({
+        address: accessAddress,
+        chainId: BigInt(chainId),
+        type: 'secp256k1',
+        witness,
+      })
+
+      const keyAuth_signed = KeyAuthorization.from(keyAuth, {
+        signature: SignatureEnvelope.from(
+          Secp256k1.sign({
+            payload: KeyAuthorization.getSignPayload(keyAuth),
+            privateKey: root.privateKey,
+          }),
+        ),
+      })
+
+      const nonce = await getTransactionCount(client, {
+        address: root.address,
+        blockTag: 'pending',
+      })
+
+      const transaction = TxEnvelopeTempo.from({
+        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+        chainId,
+        feeToken: '0x20c0000000000000000000000000000000000001',
+        keyAuthorization: keyAuth_signed,
+        nonce: BigInt(nonce),
+        gas: 1_000_000n,
+        maxFeePerGas: Value.fromGwei('20'),
+        maxPriorityFeePerGas: Value.fromGwei('10'),
+      })
+
+      const signature = Secp256k1.sign({
+        payload: TxEnvelopeTempo.getSignPayload(transaction, {
+          from: root.address,
+        }),
+        privateKey: accessPrivateKey,
+      })
+
+      const serialized_signed = TxEnvelopeTempo.serialize(transaction, {
+        signature: SignatureEnvelope.from({
+          userAddress: root.address,
+          inner: SignatureEnvelope.from(signature),
+          type: 'keychain',
+        }),
+      })
+
+      const receipt = (await client
+        .request({
+          method: 'eth_sendRawTransactionSync',
+          params: [serialized_signed],
+        })
+        .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+      expect(receipt.status).toBe('success')
+
+      const response = await client
+        .request({
+          method: 'eth_getTransactionByHash',
+          params: [receipt.transactionHash],
+        })
+        .then((tx) => Transaction.fromRpc(tx as any))
+      if (!response) throw new Error()
+
+      // The witness must survive the round trip through the node.
+      expect(response.keyAuthorization?.witness).toBe(witness)
+
+      // The signing hash of the round-tripped authorization equals the witness-bearing hash.
+      expect(KeyAuthorization.hash(response.keyAuthorization!)).toBe(
+        KeyAuthorization.hash(keyAuth_signed),
+      )
+    },
+  )
+
+  // TODO: remove skipIf when devnet/testnet have T5
+  test.skipIf(nodeEnv !== 'localnet')(
+    'behavior: TIP-1053 witness-less authorization is byte-equivalent to pre-TIP-1053',
+    async () => {
+      // Two authorizations with identical fields but different access keys; the witness-less
+      // shape must encode without a trailing witness slot.
+      const accessPrivateKey = Secp256k1.randomPrivateKey()
+      const accessAddress = Address.fromPublicKey(
+        Secp256k1.getPublicKey({ privateKey: accessPrivateKey }),
+      )
+      const keyAuth = KeyAuthorization.from({
+        address: accessAddress,
+        chainId: BigInt(chainId),
+        type: 'secp256k1',
+      })
+      const [authTuple] = KeyAuthorization.toTuple(keyAuth)
+      expect((authTuple as unknown as unknown[]).length).toBe(3)
+
+      const keyAuth_signed = KeyAuthorization.from(keyAuth, {
+        signature: SignatureEnvelope.from(
+          Secp256k1.sign({
+            payload: KeyAuthorization.getSignPayload(keyAuth),
+            privateKey: root.privateKey,
+          }),
+        ),
+      })
+
+      const nonce = await getTransactionCount(client, {
+        address: root.address,
+        blockTag: 'pending',
+      })
+
+      const transaction = TxEnvelopeTempo.from({
+        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+        chainId,
+        feeToken: '0x20c0000000000000000000000000000000000001',
+        keyAuthorization: keyAuth_signed,
+        nonce: BigInt(nonce),
+        gas: 1_000_000n,
+        maxFeePerGas: Value.fromGwei('20'),
+        maxPriorityFeePerGas: Value.fromGwei('10'),
+      })
+
+      const signature = Secp256k1.sign({
+        payload: TxEnvelopeTempo.getSignPayload(transaction, {
+          from: root.address,
+        }),
+        privateKey: accessPrivateKey,
+      })
+
+      const serialized_signed = TxEnvelopeTempo.serialize(transaction, {
+        signature: SignatureEnvelope.from({
+          userAddress: root.address,
+          inner: SignatureEnvelope.from(signature),
+          type: 'keychain',
+        }),
+      })
+
+      const receipt = (await client
+        .request({
+          method: 'eth_sendRawTransactionSync',
+          params: [serialized_signed],
+        })
+        .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+      expect(receipt.status).toBe('success')
+
+      const response = await client
+        .request({
+          method: 'eth_getTransactionByHash',
+          params: [receipt.transactionHash],
+        })
+        .then((tx) => Transaction.fromRpc(tx as any))
+      if (!response) throw new Error()
+
+      expect(response.keyAuthorization?.witness).toBeUndefined()
+    },
+  )
 })


### PR DESCRIPTION
Implements [TIP-1053](https://tips.sh/1053): adds an optional 32-byte `witness` field to `KeyAuthorization`.

The witness is included in the signing hash so a single signature can both authorize an access key and bind to an arbitrary application context (e.g. a server-issued challenge), and it doubles as a revocation handle that can be burned onchain to invalidate a signed-but-unsubmitted authorization.

### Changes

- **`KeyAuthorization` type:** new optional `witness?: Hex.Hex` (validated as exactly 32 bytes via the new `InvalidWitnessSizeError`).
- **`Rpc` type:** new optional `witness?: Hex.Hex | null`. `fromRpc` treats `null` as absent.
- **`Tuple` type:** new trailing variant carrying the witness.
- **`from` / `fromRpc` / `fromTuple`:** plumb witness through and validate size.
- **`toRpc` / `toTuple` / `serialize` / `hash`:** include witness in the canonical wire form.
- **Wire-format detail:** when witness is set but earlier optional fields aren't, those fields are encoded as RLP null placeholders (`0x80`) so the node interprets them as "unrestricted" rather than `[]` (which for `scopes` means "scoped, no calls allowed").
- **Backward compatible:** witness-less authorizations encode byte-identically to pre-TIP-1053.

### Tests

- 12 new unit tests in `src/tempo/KeyAuthorization.test.ts` covering encode/decode round-trips, RPC round-trips, witness-changes-the-hash, signing-flow verification, and size validation.
- 2 new e2e tests in `src/tempo/e2e.test.ts` (localnet only) that submit a witness-bearing key authorization through the protocol and confirm the witness round-trips through registration.

All 78 unit tests and 17 keyAuthorization e2e tests pass against a local T5 node.
