### PR TITLE
feat(tempo): add TIP-1049 admin access keys to KeyAuthorization

### DIFF
--- a/.changeset/tip-1049-admin-keys.md
+++ b/.changeset/tip-1049-admin-keys.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+`ox/tempo`: Added support for TIP-1049 (admin access keys) via optional `isAdmin` and `account` fields on `KeyAuthorization` that bind into the signing hash.

--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -2317,3 +2317,152 @@ describe('witness (TIP-1053)', () => {
     expect(KeyAuthorization.hash(restored)).toBe(payload)
   })
 })
+
+describe('admin keys (TIP-1049)', () => {
+  const account = '0x1111111111111111111111111111111111111111' as const
+
+  test('from: preserves isAdmin and account', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    })
+    expect(authorization.isAdmin).toBe(true)
+    expect(authorization.account).toBe(account)
+  })
+
+  test('toTuple: emits isAdmin + account together', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    })
+    const [authTuple] = KeyAuthorization.toTuple(authorization)
+    expect(authTuple).toEqual([
+      '0x1',
+      '0x',
+      address,
+      '0x', // expiry placeholder
+      '0x', // limits placeholder
+      '0x', // scopes placeholder
+      '0x', // witness placeholder
+      '0x01', // isAdmin = true
+      account,
+    ])
+  })
+
+  test('toTuple: omits both when neither is set (byte-equivalent to pre-TIP-1049)', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+    })
+    const [authTuple] = KeyAuthorization.toTuple(authorization)
+    expect((authTuple as unknown as unknown[]).length).toBe(3)
+  })
+
+  test('fromTuple: drops orphan isAdmin without account', () => {
+    const restored = KeyAuthorization.fromTuple([
+      ['0x01', '0x', address, '0x', [], [], '0x', '0x01'],
+    ])
+    expect(restored.isAdmin).toBeUndefined()
+    expect(restored.account).toBeUndefined()
+  })
+
+  test('fromTuple: drops orphan account without isAdmin', () => {
+    const restored = KeyAuthorization.fromTuple([
+      ['0x01', '0x', address, '0x', [], [], '0x', '0x', account],
+    ])
+    expect(restored.isAdmin).toBeUndefined()
+    expect(restored.account).toBeUndefined()
+  })
+
+  test('fromTuple: extracts isAdmin + account together', () => {
+    const restored = KeyAuthorization.fromTuple([
+      ['0x01', '0x', address, '0x', [], [], '0x', '0x01', account],
+    ])
+    expect(restored.isAdmin).toBe(true)
+    expect(restored.account).toBe(account)
+  })
+
+  test('fromTuple: throws on invalid admin marker', () => {
+    expect(() =>
+      KeyAuthorization.fromTuple([
+        ['0x01', '0x', address, '0x', [], [], '0x', '0x02'],
+      ]),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[KeyAuthorization.InvalidAdminMarkerError: Admin marker \`0x02\` is invalid; expected \`0x01\` (TIP-1049).]`,
+    )
+  })
+
+  test('serialize/deserialize: roundtrip with isAdmin + account', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    })
+    const serialized = KeyAuthorization.serialize(authorization)
+    const restored = KeyAuthorization.deserialize(serialized)
+    expect(restored.isAdmin).toBe(true)
+    expect(restored.account).toBe(account)
+  })
+
+  test('toRpc/fromRpc: roundtrip with isAdmin + account', () => {
+    const authorization = KeyAuthorization.from(
+      {
+        address,
+        account,
+        chainId: 1n,
+        isAdmin: true,
+        type: 'secp256k1',
+      },
+      { signature: SignatureEnvelope.from(signature_secp256k1) },
+    )
+    const rpc = KeyAuthorization.toRpc(authorization)
+    expect(rpc.isAdmin).toBe(true)
+    expect(rpc.account).toBe(account)
+    const restored = KeyAuthorization.fromRpc(rpc)
+    expect(restored.isAdmin).toBe(true)
+    expect(restored.account).toBe(account)
+  })
+
+  test('hash: changes when admin pair is added', () => {
+    const plain = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+    })
+    const admin = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    })
+    expect(KeyAuthorization.hash(plain)).not.toBe(KeyAuthorization.hash(admin))
+  })
+
+  test('hash: changes when account in admin pair changes', () => {
+    const a = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    })
+    const b = KeyAuthorization.from({
+      address,
+      account: '0x2222222222222222222222222222222222222222',
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    })
+    expect(KeyAuthorization.hash(a)).not.toBe(KeyAuthorization.hash(b))
+  })
+})

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -3,7 +3,7 @@ import type * as Address from '../core/Address.js'
 import type * as Errors from '../core/Errors.js'
 import * as Hash from '../core/Hash.js'
 import * as Hex from '../core/Hex.js'
-import type { Compute } from '../core/internal/types.js'
+import type { Compute, OneOf } from '../core/internal/types.js'
 import * as Rlp from '../core/Rlp.js'
 import * as SignatureEnvelope from './SignatureEnvelope.js'
 import * as TempoAddress from './TempoAddress.js'
@@ -65,13 +65,28 @@ export type KeyAuthorization<
    * [TIP-1053 Specification](https://tips.sh/1053)
    */
   witness?: Hex.Hex | undefined
-} & (signed extends true
-  ? { signature: SignatureEnvelope.SignatureEnvelope<bigintType, numberType> }
-  : {
-      signature?:
-        | SignatureEnvelope.SignatureEnvelope<bigintType, numberType>
-        | undefined
-    })
+} & OneOf<
+    // TIP-1049 admin access keys: `account` and `isAdmin` are paired — either
+    // both are specified or neither. The `account` binding scopes the signing
+    // hash to a specific account, and `isAdmin: true` provisions an admin
+    // access key with unrestricted keychain mutator privileges.
+    //
+    // [TIP-1049 Specification](https://tips.sh/1049)
+    | {
+        /** Account address this authorization is bound to. */
+        account: addressType
+        /** Whether this authorization provisions an admin access key. */
+        isAdmin: boolean
+      }
+    | {}
+  > &
+  (signed extends true
+    ? { signature: SignatureEnvelope.SignatureEnvelope<bigintType, numberType> }
+    : {
+        signature?:
+          | SignatureEnvelope.SignatureEnvelope<bigintType, numberType>
+          | undefined
+      })
 
 /** Input type for a Key Authorization. */
 export type Input = KeyAuthorization<
@@ -83,12 +98,16 @@ export type Input = KeyAuthorization<
 
 /** RPC representation matching the node's wire format. */
 export type Rpc = {
+  /** Optional account address binding (TIP-1049). */
+  account?: Address.Address | null | undefined
   /** Allowed call scopes (node field: `allowedCalls`). */
   allowedCalls?: readonly RpcCallScope[] | undefined
   /** Chain ID (hex quantity). */
   chainId: Hex.Hex
   /** Expiry timestamp (hex quantity or null). */
   expiry: Hex.Hex | null | undefined
+  /** Whether this authorization provisions an admin access key (TIP-1049). */
+  isAdmin?: boolean | null | undefined
   /** Key identifier. */
   keyId: Address.Address
   /** Key type. */
@@ -163,6 +182,23 @@ type AuthorizationTuple =
       limits: readonly TokenLimitTuple[],
       calls: readonly CallScopeTuple[],
       witness: Hex.Hex,
+    ]
+  | readonly [
+      ...BaseTuple,
+      expiry: Hex.Hex,
+      limits: readonly TokenLimitTuple[],
+      calls: readonly CallScopeTuple[],
+      witness: Hex.Hex,
+      isAdmin: Hex.Hex,
+    ]
+  | readonly [
+      ...BaseTuple,
+      expiry: Hex.Hex,
+      limits: readonly TokenLimitTuple[],
+      calls: readonly CallScopeTuple[],
+      witness: Hex.Hex,
+      isAdmin: Hex.Hex,
+      account: Address.Address,
     ]
 
 /** Tuple representation of a Key Authorization. */
@@ -476,6 +512,8 @@ export function fromRpc(authorization: Rpc): Signed {
   const { allowedCalls, chainId, keyId, expiry, limits, keyType } =
     authorization
   const witness = authorization.witness ?? undefined
+  const isAdmin = authorization.isAdmin ?? undefined
+  const account = authorization.account ?? undefined
   const signature = SignatureEnvelope.fromRpc(authorization.signature)
   if (witness !== undefined) assertWitness(witness)
 
@@ -511,6 +549,8 @@ export function fromRpc(authorization: Rpc): Signed {
     signature,
     type: keyType,
     ...(witness !== undefined ? { witness } : {}),
+    ...(isAdmin ? { isAdmin: true } : {}),
+    ...(account !== undefined ? { account } : {}),
   }
 }
 
@@ -584,7 +624,8 @@ export function fromTuple<const tuple extends Tuple>(
   // Trailing optional fields in wire order. Each entry pulls one slot off the
   // trailing array and decodes it (treating absent or RLP-null placeholders as
   // missing). To add a new optional trailing field, append a single entry.
-  const [rawExpiry, rawLimits, rawScopes, rawWitness] = trailing
+  const [rawExpiry, rawLimits, rawScopes, rawWitness, rawIsAdmin, rawAccount] =
+    trailing
   const expiry = isAbsent(rawExpiry)
     ? undefined
     : hexToNumber(rawExpiry as Hex.Hex) || undefined
@@ -620,6 +661,22 @@ export function fromTuple<const tuple extends Tuple>(
     : undefined
   const witness = isAbsent(rawWitness) ? undefined : (rawWitness as Hex.Hex)
   if (witness !== undefined) assertWitness(witness)
+  const isAdmin = (() => {
+    if (isAbsent(rawIsAdmin)) return undefined
+    // TIP-1049: the admin marker is strictly `0x01`. Any other value is a
+    // protocol-level decode error on the node, so reject it here too.
+    if (rawIsAdmin !== '0x01')
+      throw new InvalidAdminMarkerError(rawIsAdmin as Hex.Hex)
+    return true
+  })()
+  const account = isAbsent(rawAccount)
+    ? undefined
+    : (rawAccount as Address.Address)
+  // TIP-1049 admin fields are paired: only emit both when both are present on
+  // the wire. Wire shapes carrying only one are tolerated for forward-compat
+  // but the orphan field is dropped (since the public API requires both).
+  const adminPair =
+    account !== undefined && isAdmin ? { account, isAdmin: true as const } : {}
   const args: KeyAuthorization = {
     address: keyId,
     chainId: chainId === '0x' ? 0n : Hex.toBigInt(chainId),
@@ -628,6 +685,7 @@ export function fromTuple<const tuple extends Tuple>(
     ...(limits !== undefined ? { limits } : {}),
     ...(scopes !== undefined ? { scopes } : {}),
     ...(witness !== undefined ? { witness } : {}),
+    ...adminPair,
   }
   if (signatureSerialized)
     args.signature = SignatureEnvelope.deserialize(signatureSerialized)
@@ -831,8 +889,18 @@ export declare namespace serialize {
  * @returns An RPC-formatted Key Authorization.
  */
 export function toRpc(authorization: Signed): Rpc {
-  const { address, scopes, chainId, expiry, limits, type, signature, witness } =
-    authorization
+  const {
+    address,
+    scopes,
+    chainId,
+    expiry,
+    limits,
+    type,
+    signature,
+    witness,
+    isAdmin,
+    account,
+  } = authorization
   if (witness !== undefined) assertWitness(witness)
 
   // Group flat scopes by address into nested allowedCalls wire format
@@ -872,6 +940,8 @@ export function toRpc(authorization: Signed): Rpc {
     signature: SignatureEnvelope.toRpc(signature),
     ...(allowedCalls ? { allowedCalls } : {}),
     ...(witness !== undefined ? { witness } : {}),
+    ...(isAdmin ? { isAdmin: true } : {}),
+    ...(account !== undefined ? { account } : {}),
   }
 }
 
@@ -913,7 +983,16 @@ export declare namespace toRpc {
 export function toTuple<const authorization extends KeyAuthorization>(
   authorization: authorization,
 ): toTuple.ReturnType<authorization> {
-  const { address, chainId, scopes, expiry, limits, witness } = authorization
+  const {
+    address,
+    chainId,
+    scopes,
+    expiry,
+    limits,
+    witness,
+    isAdmin,
+    account,
+  } = authorization
   if (witness !== undefined) assertWitness(witness)
   const signature = authorization.signature
     ? SignatureEnvelope.serialize(authorization.signature)
@@ -967,12 +1046,15 @@ export function toTuple<const authorization extends KeyAuthorization>(
   // Placeholder convention:
   // - `'0x'` (RLP null) is the canonical placeholder for fields added at or
   //   after TIP-1053. The node decodes it as `None` (unrestricted).
-  // - `limits` keeps `[]` as its skipped placeholder when no witness is
-  //   present — preserving byte-for-byte equivalence with pre-TIP-1053
-  //   signed payloads.
+  // - `limits` keeps `[]` as its skipped placeholder for pre-TIP-1053 wire
+  //   shapes — preserving byte-for-byte equivalence with signed payloads
+  //   produced before TIP-1053 was added. When any TIP-1053+ field is
+  //   present, the canonical `'0x'` placeholder is used instead.
   //
   // To add a new optional trailing field (e.g. from a future TIP): append a
   // single entry to this list with `placeholder: '0x'`.
+  const hasTip1053Plus =
+    witness !== undefined || isAdmin || account !== undefined
   const optionals: readonly { value: unknown; placeholder: unknown }[] = [
     {
       value:
@@ -983,10 +1065,15 @@ export function toTuple<const authorization extends KeyAuthorization>(
     },
     {
       value: limitsValue,
-      placeholder: witness !== undefined ? '0x' : [],
+      placeholder: hasTip1053Plus ? '0x' : [],
     },
     { value: callsValue, placeholder: '0x' },
     { value: witness, placeholder: '0x' },
+    // TIP-1049: admin marker. Present = `0x01` (RLP integer 1); absent
+    // skipped or omitted. Any other value is a hard decode error on the node.
+    { value: isAdmin ? '0x01' : undefined, placeholder: '0x' },
+    // TIP-1049: optional account binding. Last field — never a placeholder.
+    { value: account, placeholder: '0x' },
   ]
   let lastPresent = -1
   for (let i = optionals.length - 1; i >= 0; i--)
@@ -1053,6 +1140,16 @@ export class InvalidWitnessSizeError extends Error {
   constructor(witness: Hex.Hex) {
     super(
       `Witness \`${witness}\` must be exactly 32 bytes (got ${Hex.size(witness)} bytes).`,
+    )
+  }
+}
+
+/** Thrown when a TIP-1049 admin marker has any value other than `0x01`. */
+export class InvalidAdminMarkerError extends Error {
+  override readonly name = 'KeyAuthorization.InvalidAdminMarkerError'
+  constructor(marker: Hex.Hex) {
+    super(
+      `Admin marker \`${marker}\` is invalid; expected \`0x01\` (TIP-1049).`,
     )
   }
 }

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -2825,4 +2825,171 @@ describe('behavior: keyAuthorization', () => {
       expect(response.keyAuthorization?.witness).toBeUndefined()
     },
   )
+
+  // TODO: remove skipIf when devnet/testnet have T6 (TIP-1049).
+  test.skipIf(nodeEnv !== 'localnet')(
+    'behavior: TIP-1049 admin access key round-trips through registration',
+    async () => {
+      const accessPrivateKey = Secp256k1.randomPrivateKey()
+      const accessAddress = Address.fromPublicKey(
+        Secp256k1.getPublicKey({ privateKey: accessPrivateKey }),
+      )
+
+      const keyAuth = KeyAuthorization.from({
+        address: accessAddress,
+        account: root.address,
+        chainId: BigInt(chainId),
+        isAdmin: true,
+        type: 'secp256k1',
+      })
+
+      const keyAuth_signed = KeyAuthorization.from(keyAuth, {
+        signature: SignatureEnvelope.from(
+          Secp256k1.sign({
+            payload: KeyAuthorization.getSignPayload(keyAuth),
+            privateKey: root.privateKey,
+          }),
+        ),
+      })
+
+      const nonce = await getTransactionCount(client, {
+        address: root.address,
+        blockTag: 'pending',
+      })
+
+      const transaction = TxEnvelopeTempo.from({
+        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+        chainId,
+        feeToken: '0x20c0000000000000000000000000000000000001',
+        keyAuthorization: keyAuth_signed,
+        nonce: BigInt(nonce),
+        gas: 1_000_000n,
+        maxFeePerGas: Value.fromGwei('20'),
+        maxPriorityFeePerGas: Value.fromGwei('10'),
+      })
+
+      // The admin access key signs and authorizes itself in the same tx
+      // (the canonical "auth+use" registration pattern).
+      const signature = Secp256k1.sign({
+        payload: TxEnvelopeTempo.getSignPayload(transaction, {
+          from: root.address,
+        }),
+        privateKey: accessPrivateKey,
+      })
+
+      const serialized_signed = TxEnvelopeTempo.serialize(transaction, {
+        signature: SignatureEnvelope.from({
+          userAddress: root.address,
+          inner: SignatureEnvelope.from(signature),
+          type: 'keychain',
+        }),
+      })
+
+      const receipt = (await client
+        .request({
+          method: 'eth_sendRawTransactionSync',
+          params: [serialized_signed],
+        })
+        .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+      expect(receipt.status).toBe('success')
+
+      const response = await client
+        .request({
+          method: 'eth_getTransactionByHash',
+          params: [receipt.transactionHash],
+        })
+        .then((tx) => Transaction.fromRpc(tx as any))
+      if (!response) throw new Error()
+
+      // isAdmin + account must survive the round trip through the node.
+      expect(response.keyAuthorization?.isAdmin).toBe(true)
+      expect(response.keyAuthorization?.account).toBe(root.address)
+
+      // The signing hash of the round-tripped authorization equals the
+      // admin-bearing hash.
+      expect(KeyAuthorization.hash(response.keyAuthorization!)).toBe(
+        KeyAuthorization.hash(keyAuth_signed),
+      )
+    },
+  )
+
+  // TODO: remove skipIf when devnet/testnet have T6.
+  test.skipIf(nodeEnv !== 'localnet')(
+    'behavior: TIP-1049 non-admin authorization is byte-equivalent to pre-TIP-1049',
+    async () => {
+      const accessPrivateKey = Secp256k1.randomPrivateKey()
+      const accessAddress = Address.fromPublicKey(
+        Secp256k1.getPublicKey({ privateKey: accessPrivateKey }),
+      )
+
+      // Without isAdmin or account, the encoded tuple must not carry trailing
+      // TIP-1049 slots.
+      const keyAuth = KeyAuthorization.from({
+        address: accessAddress,
+        chainId: BigInt(chainId),
+        type: 'secp256k1',
+      })
+      const [authTuple] = KeyAuthorization.toTuple(keyAuth)
+      expect((authTuple as unknown as unknown[]).length).toBe(3)
+
+      const keyAuth_signed = KeyAuthorization.from(keyAuth, {
+        signature: SignatureEnvelope.from(
+          Secp256k1.sign({
+            payload: KeyAuthorization.getSignPayload(keyAuth),
+            privateKey: root.privateKey,
+          }),
+        ),
+      })
+
+      const nonce = await getTransactionCount(client, {
+        address: root.address,
+        blockTag: 'pending',
+      })
+
+      const transaction = TxEnvelopeTempo.from({
+        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+        chainId,
+        feeToken: '0x20c0000000000000000000000000000000000001',
+        keyAuthorization: keyAuth_signed,
+        nonce: BigInt(nonce),
+        gas: 1_000_000n,
+        maxFeePerGas: Value.fromGwei('20'),
+        maxPriorityFeePerGas: Value.fromGwei('10'),
+      })
+
+      const signature = Secp256k1.sign({
+        payload: TxEnvelopeTempo.getSignPayload(transaction, {
+          from: root.address,
+        }),
+        privateKey: accessPrivateKey,
+      })
+
+      const serialized_signed = TxEnvelopeTempo.serialize(transaction, {
+        signature: SignatureEnvelope.from({
+          userAddress: root.address,
+          inner: SignatureEnvelope.from(signature),
+          type: 'keychain',
+        }),
+      })
+
+      const receipt = (await client
+        .request({
+          method: 'eth_sendRawTransactionSync',
+          params: [serialized_signed],
+        })
+        .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+      expect(receipt.status).toBe('success')
+
+      const response = await client
+        .request({
+          method: 'eth_getTransactionByHash',
+          params: [receipt.transactionHash],
+        })
+        .then((tx) => Transaction.fromRpc(tx as any))
+      if (!response) throw new Error()
+
+      expect(response.keyAuthorization?.isAdmin).toBeUndefined()
+      expect(response.keyAuthorization?.account).toBeUndefined()
+    },
+  )
 })


### PR DESCRIPTION
Implements [TIP-1049](https://tips.sh/1049) (admin access keys) ox-side, matching the wire format in [tempoxyz/tempo](https://github.com/tempoxyz/tempo).

## Summary

Adds two paired fields to `KeyAuthorization` that together declare an admin access key with an explicit account binding:

- **`isAdmin: boolean`** — encodes as RLP integer `1` (`0x01`) at trailing position 7. Any other marker value is a hard decode error (`InvalidAdminMarkerError`).
- **`account: addressType`** — 20-byte address at trailing position 8, providing TIP-1049 cross-account replay protection.

The two fields are modeled as a `OneOf` union — either both are specified or neither — since they conceptually pair together.

## Wire layout

```
[chainId, keyType, keyId, expiry?, limits?, scopes?, witness?, isAdmin?, account?]
                                                              ↑         ↑
                                                              TIP-1049 ──┘
```

Built on the extensible `optionals` table from #260, so this PR adds two entries to `toTuple` and destructures two more slots in `fromTuple` — no structural changes.

## Behaviour

- Construction (`from`, `fromRpc`) requires `account` + `isAdmin` together or neither — the type-level `OneOf` enforces it.
- `toTuple` emits both fields when present, omits both when absent (byte-equivalent to pre-TIP-1049).
- `fromTuple` tolerates orphan wire shapes (only one of the two fields on the wire) by dropping the orphan, since the public API requires the pair.
- `account`/`isAdmin` are included in the signing hash, so admin authorizations cannot be replayed against a different account that shares the same root key.

## Depends on

- #260 (TIP-1053 witness support — provides the extensible trailing-optional encoding pattern)

## Tests

- **Unit (`src/tempo/KeyAuthorization.test.ts`)**: 11 new tests covering `from`/`toTuple`/`fromTuple`/`serialize`/`hash`/`toRpc`/`fromRpc` round-trips, paired encoding/decoding, marker validation, orphan tolerance.
- **E2E (`src/tempo/e2e.test.ts`)**: registers an admin access key via auth+use keychain envelope against the localnet T6 image and verifies `isAdmin` + `account` survive the round trip through the node. Also covers the byte-equivalence check for the no-admin-pair case.

89/89 tempo-unit tests pass, 2/2 TIP-1049 e2e tests pass, types clean.
