### PR TITLE
feat(tempo): add ReceivePolicyReceipt module for TIP-1028 claim receipts

### DIFF
--- a/.changeset/receive-policy-receipt.md
+++ b/.changeset/receive-policy-receipt.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+`ox/tempo`: Added the `ReceivePolicyReceipt` module for decoding TIP-1028 receive-policy claim receipts (`ClaimReceiptV1` witnesses) with `decode`, `from`, and `fromTransactionReceipt` (returns one receipt per `TransferBlocked` log).

--- a/.changeset/receive-policy-receipt.md
+++ b/.changeset/receive-policy-receipt.md
@@ -2,4 +2,4 @@
 "ox": patch
 ---
 
-`ox/tempo`: Added the `ReceivePolicyReceipt` module for decoding TIP-1028 receive-policy claim receipts (`ClaimReceiptV1` witnesses) with `decode`, `from`, and `fromTransactionReceipt` (returns one receipt per `TransferBlocked` log).
+`ox/tempo`: Added the `ReceivePolicyReceipt` module for encoding/decoding TIP-1028 receive-policy claim receipts (`ClaimReceiptV1` witnesses) with `decode`, `encode`, `from`, `fromLog`, and `fromTransactionReceipt` (returns one receipt per `TransferBlocked` log).

--- a/src/tempo/ReceivePolicyReceipt.test.ts
+++ b/src/tempo/ReceivePolicyReceipt.test.ts
@@ -98,6 +98,37 @@ describe('decode', () => {
   })
 })
 
+describe('encode', () => {
+  test('round-trips with decode', () => {
+    const witness = encodeWitness()
+    expect(
+      ReceivePolicyReceipt.encode(ReceivePolicyReceipt.decode(witness)),
+    ).toBe(witness)
+  })
+
+  test('behavior: maps enum strings back to indices', () => {
+    const receipt = ReceivePolicyReceipt.decode(
+      encodeWitness({ blockedReason: 1, kind: 1 }),
+    )
+    const reencoded = ReceivePolicyReceipt.encode(receipt)
+    expect(ReceivePolicyReceipt.decode(reencoded)).toEqual(receipt)
+  })
+})
+
+describe('fromLog', () => {
+  test('default', () => {
+    expect(ReceivePolicyReceipt.fromLog(blockedLog(encodeWitness()))).toEqual(
+      ReceivePolicyReceipt.decode(encodeWitness()),
+    )
+  })
+
+  test('error: non-matching log', () => {
+    expect(() =>
+      ReceivePolicyReceipt.fromLog({ data: '0x', topics: [zeroHash] }),
+    ).toThrow()
+  })
+})
+
 describe('from', () => {
   test('from encoded witness', () => {
     expect(ReceivePolicyReceipt.from(encodeWitness())).toEqual(
@@ -157,7 +188,9 @@ test('exports', () => {
   expect(Object.keys(ReceivePolicyReceipt)).toMatchInlineSnapshot(`
     [
       "decode",
+      "encode",
       "from",
+      "fromLog",
       "fromTransactionReceipt",
     ]
   `)

--- a/src/tempo/ReceivePolicyReceipt.test.ts
+++ b/src/tempo/ReceivePolicyReceipt.test.ts
@@ -117,9 +117,8 @@ describe('encode', () => {
 
 describe('fromLog', () => {
   test('default', () => {
-    expect(ReceivePolicyReceipt.fromLog(blockedLog(encodeWitness()))).toEqual(
-      ReceivePolicyReceipt.decode(encodeWitness()),
-    )
+    const witness = encodeWitness()
+    expect(ReceivePolicyReceipt.fromLog(blockedLog(witness))).toBe(witness)
   })
 
   test('error: non-matching log', () => {
@@ -130,25 +129,27 @@ describe('fromLog', () => {
 })
 
 describe('from', () => {
-  test('from encoded witness', () => {
-    expect(ReceivePolicyReceipt.from(encodeWitness())).toEqual(
-      ReceivePolicyReceipt.decode(encodeWitness()),
-    )
+  test('passthrough encoded receipt', () => {
+    const witness = encodeWitness()
+    expect(ReceivePolicyReceipt.from(witness)).toBe(witness)
   })
 
-  test('passthrough decoded receipt', () => {
-    const receipt = ReceivePolicyReceipt.decode(encodeWitness())
-    expect(ReceivePolicyReceipt.from(receipt)).toBe(receipt)
+  test('from decoded fields', () => {
+    const witness = encodeWitness()
+    expect(
+      ReceivePolicyReceipt.from(ReceivePolicyReceipt.decode(witness)),
+    ).toBe(witness)
   })
 })
 
 describe('fromTransactionReceipt', () => {
   test('single blocked transfer', () => {
+    const witness = encodeWitness()
     const receipts = ReceivePolicyReceipt.fromTransactionReceipt({
-      logs: [blockedLog(encodeWitness())],
+      logs: [blockedLog(witness)],
     })
     expect(receipts).toHaveLength(1)
-    expect(receipts[0]).toEqual(ReceivePolicyReceipt.decode(encodeWitness()))
+    expect(receipts[0]).toBe(witness)
   })
 
   test('multiple blocked transfers', () => {
@@ -159,8 +160,8 @@ describe('fromTransactionReceipt', () => {
       ],
     })
     expect(receipts).toHaveLength(2)
-    expect(receipts[0]!.kind).toBe('transfer')
-    expect(receipts[1]!.kind).toBe('mint')
+    expect(ReceivePolicyReceipt.decode(receipts[0]!).kind).toBe('transfer')
+    expect(ReceivePolicyReceipt.decode(receipts[1]!).kind).toBe('mint')
   })
 
   test('ignores unrelated logs', () => {

--- a/src/tempo/ReceivePolicyReceipt.test.ts
+++ b/src/tempo/ReceivePolicyReceipt.test.ts
@@ -1,0 +1,164 @@
+import { AbiEvent, AbiParameters } from 'ox'
+import { ReceivePolicyReceipt } from 'ox/tempo'
+import { describe, expect, test } from 'vitest'
+
+const token = '0x20c0000000000000000000000000000000000001'
+const originator = '0x0000000000000000000000000000000000000aaa'
+const recipient = '0x0000000000000000000000000000000000000bbb'
+const zeroAddress = '0x0000000000000000000000000000000000000000'
+const zeroHash =
+  '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+const witnessParameters = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'version', type: 'uint8' },
+      { name: 'token', type: 'address' },
+      { name: 'recoveryAuthority', type: 'address' },
+      { name: 'originator', type: 'address' },
+      { name: 'recipient', type: 'address' },
+      { name: 'blockedAt', type: 'uint64' },
+      { name: 'blockedNonce', type: 'uint64' },
+      { name: 'blockedReason', type: 'uint8' },
+      { name: 'kind', type: 'uint8' },
+      { name: 'memo', type: 'bytes32' },
+    ],
+  },
+] as const
+
+function encodeWitness(
+  overrides: Partial<{
+    blockedReason: number
+    kind: number
+  }> = {},
+) {
+  return AbiParameters.encode(witnessParameters, [
+    {
+      version: 1,
+      token,
+      recoveryAuthority: zeroAddress,
+      originator,
+      recipient,
+      blockedAt: 1234n,
+      blockedNonce: 5n,
+      blockedReason: overrides.blockedReason ?? 2,
+      kind: overrides.kind ?? 0,
+      memo: zeroHash,
+    },
+  ])
+}
+
+const transferBlocked = AbiEvent.from(
+  'event TransferBlocked(address indexed token, address indexed receiver, uint64 indexed blockedNonce, uint256 amount, uint8 receiptVersion, bytes receipt)',
+)
+
+function blockedLog(witness: `0x${string}`) {
+  const { topics } = AbiEvent.encode(transferBlocked, {
+    token,
+    receiver: recipient,
+    blockedNonce: 5n,
+  })
+  const data = AbiParameters.encode(
+    [{ type: 'uint256' }, { type: 'uint8' }, { type: 'bytes' }],
+    [10_000_000n, 1, witness],
+  )
+  return { data, topics: topics as readonly `0x${string}`[] }
+}
+
+describe('decode', () => {
+  test('default', () => {
+    expect(ReceivePolicyReceipt.decode(encodeWitness())).toMatchInlineSnapshot(`
+      {
+        "blockedAt": 1234n,
+        "blockedNonce": 5n,
+        "blockedReason": "receivePolicy",
+        "kind": "transfer",
+        "memo": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "originator": "0x0000000000000000000000000000000000000aaa",
+        "recipient": "0x0000000000000000000000000000000000000bbb",
+        "recoveryAuthority": "0x0000000000000000000000000000000000000000",
+        "token": "0x20c0000000000000000000000000000000000001",
+        "version": 1,
+      }
+    `)
+  })
+
+  test('behavior: kind mint', () => {
+    expect(ReceivePolicyReceipt.decode(encodeWitness({ kind: 1 })).kind).toBe(
+      'mint',
+    )
+  })
+
+  test('behavior: blocked reason token filter', () => {
+    expect(
+      ReceivePolicyReceipt.decode(encodeWitness({ blockedReason: 1 }))
+        .blockedReason,
+    ).toBe('tokenFilter')
+  })
+})
+
+describe('from', () => {
+  test('from encoded witness', () => {
+    expect(ReceivePolicyReceipt.from(encodeWitness())).toEqual(
+      ReceivePolicyReceipt.decode(encodeWitness()),
+    )
+  })
+
+  test('passthrough decoded receipt', () => {
+    const receipt = ReceivePolicyReceipt.decode(encodeWitness())
+    expect(ReceivePolicyReceipt.from(receipt)).toBe(receipt)
+  })
+})
+
+describe('fromTransactionReceipt', () => {
+  test('single blocked transfer', () => {
+    const receipts = ReceivePolicyReceipt.fromTransactionReceipt({
+      logs: [blockedLog(encodeWitness())],
+    })
+    expect(receipts).toHaveLength(1)
+    expect(receipts[0]).toEqual(ReceivePolicyReceipt.decode(encodeWitness()))
+  })
+
+  test('multiple blocked transfers', () => {
+    const receipts = ReceivePolicyReceipt.fromTransactionReceipt({
+      logs: [
+        blockedLog(encodeWitness()),
+        blockedLog(encodeWitness({ kind: 1 })),
+      ],
+    })
+    expect(receipts).toHaveLength(2)
+    expect(receipts[0]!.kind).toBe('transfer')
+    expect(receipts[1]!.kind).toBe('mint')
+  })
+
+  test('ignores unrelated logs', () => {
+    const receipts = ReceivePolicyReceipt.fromTransactionReceipt({
+      logs: [
+        {
+          data: '0x',
+          topics: [zeroHash],
+        },
+        blockedLog(encodeWitness()),
+      ],
+    })
+    expect(receipts).toHaveLength(1)
+  })
+
+  test('behavior: no logs', () => {
+    expect(ReceivePolicyReceipt.fromTransactionReceipt({})).toEqual([])
+    expect(ReceivePolicyReceipt.fromTransactionReceipt({ logs: [] })).toEqual(
+      [],
+    )
+  })
+})
+
+test('exports', () => {
+  expect(Object.keys(ReceivePolicyReceipt)).toMatchInlineSnapshot(`
+    [
+      "decode",
+      "from",
+      "fromTransactionReceipt",
+    ]
+  `)
+})

--- a/src/tempo/ReceivePolicyReceipt.ts
+++ b/src/tempo/ReceivePolicyReceipt.ts
@@ -5,21 +5,25 @@ import type * as Errors from '../core/Errors.js'
 import type * as Hex from '../core/Hex.js'
 import type { Compute } from '../core/internal/types.js'
 
+/**
+ * A TIP-1028 receive-policy claim receipt: the ABI-encoded `ClaimReceiptV1`
+ * witness emitted when an inbound transfer or mint violates the recipient's
+ * receive policy.
+ *
+ * This is the canonical, on-chain representation – the value passed to the
+ * `ReceivePolicyGuard`'s `claim` and `burn` functions. Use
+ * {@link ox#ReceivePolicyReceipt.decode} to read its fields.
+ */
+export type ReceivePolicyReceipt = Hex.Hex
+
 /** Reason an inbound transfer or mint was blocked by a receive policy. */
 export type BlockedReason = 'none' | 'tokenFilter' | 'receivePolicy'
 
 /** Kind of inbound operation that was blocked. */
 export type Kind = 'transfer' | 'mint'
 
-/**
- * A decoded TIP-1028 receive-policy claim receipt.
- *
- * When an inbound transfer or mint violates the recipient's receive policy, the
- * funds are redirected to the `ReceivePolicyGuard` and a `ClaimReceiptV1`
- * witness is emitted. The witness is required to later `claim` or `burn` the
- * blocked funds.
- */
-export type ReceivePolicyReceipt = Compute<{
+/** A decoded {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}. */
+export type Decoded = Compute<{
   /** Receipt layout version. */
   version: number
   /** TIP-20 token holding the blocked funds. */
@@ -73,8 +77,8 @@ const transferBlocked = AbiEvent.from(
 )
 
 /**
- * Decodes an ABI-encoded `ClaimReceiptV1` witness into a
- * {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}.
+ * Decodes a {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt} (ABI-encoded
+ * `ClaimReceiptV1` witness) into its fields.
  *
  * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
  *
@@ -82,13 +86,13 @@ const transferBlocked = AbiEvent.from(
  * ```ts twoslash
  * import { ReceivePolicyReceipt } from 'ox/tempo'
  *
- * const receipt = ReceivePolicyReceipt.decode('0x...')
+ * const decoded = ReceivePolicyReceipt.decode('0x...')
  * ```
  *
- * @param receipt - The ABI-encoded `ClaimReceiptV1` witness.
- * @returns The decoded receive-policy receipt.
+ * @param receipt - The receive-policy receipt.
+ * @returns The decoded fields.
  */
-export function decode(receipt: Hex.Hex): ReceivePolicyReceipt {
+export function decode(receipt: ReceivePolicyReceipt): Decoded {
   const [decoded] = AbiParameters.decode(parameters, receipt)
   return {
     version: decoded.version,
@@ -109,11 +113,9 @@ export declare namespace decode {
 }
 
 /**
- * Encodes a receive-policy receipt into an ABI-encoded `ClaimReceiptV1`
- * witness. Inverse of {@link ox#ReceivePolicyReceipt.decode}.
- *
- * Useful for reconstructing the witness bytes required by the
- * `ReceivePolicyGuard`'s `claim` and `burn` functions from a decoded receipt.
+ * Encodes decoded fields into a
+ * {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}. Inverse of
+ * {@link ox#ReceivePolicyReceipt.decode}.
  *
  * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
  *
@@ -122,27 +124,26 @@ export declare namespace decode {
  * // @noErrors
  * import { ReceivePolicyReceipt } from 'ox/tempo'
  *
- * const [receipt] = ReceivePolicyReceipt.fromTransactionReceipt(txReceipt)
- * const witness = ReceivePolicyReceipt.encode(receipt)
- * // @log: '0x...' (pass to `claim` / `burn`)
+ * const decoded = ReceivePolicyReceipt.decode('0x...')
+ * const receipt = ReceivePolicyReceipt.encode(decoded)
  * ```
  *
- * @param receipt - The decoded receive-policy receipt.
- * @returns The ABI-encoded `ClaimReceiptV1` witness.
+ * @param decoded - The decoded fields.
+ * @returns The receive-policy receipt.
  */
-export function encode(receipt: ReceivePolicyReceipt): Hex.Hex {
+export function encode(decoded: Decoded): ReceivePolicyReceipt {
   return AbiParameters.encode(parameters, [
     {
-      version: receipt.version,
-      token: receipt.token,
-      recoveryAuthority: receipt.recoveryAuthority,
-      originator: receipt.originator,
-      recipient: receipt.recipient,
-      blockedAt: receipt.blockedAt,
-      blockedNonce: receipt.blockedNonce,
-      blockedReason: blockedReasons.indexOf(receipt.blockedReason),
-      kind: kinds.indexOf(receipt.kind),
-      memo: receipt.memo,
+      version: decoded.version,
+      token: decoded.token,
+      recoveryAuthority: decoded.recoveryAuthority,
+      originator: decoded.originator,
+      recipient: decoded.recipient,
+      blockedAt: decoded.blockedAt,
+      blockedNonce: decoded.blockedNonce,
+      blockedReason: blockedReasons.indexOf(decoded.blockedReason),
+      kind: kinds.indexOf(decoded.kind),
+      memo: decoded.memo,
     },
   ])
 }
@@ -152,42 +153,43 @@ export declare namespace encode {
 }
 
 /**
- * Normalizes a receive-policy receipt from either an ABI-encoded
- * `ClaimReceiptV1` witness or an already-decoded receipt.
+ * Normalizes a {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt} from either
+ * an encoded receipt (passthrough) or decoded fields.
  *
  * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
  *
  * @example
  * ```ts twoslash
+ * // @noErrors
  * import { ReceivePolicyReceipt } from 'ox/tempo'
  *
- * // From an encoded witness.
+ * // From an encoded receipt (passthrough).
  * const a = ReceivePolicyReceipt.from('0x...')
  *
- * // From a decoded receipt (passthrough).
- * const b = ReceivePolicyReceipt.from(a)
+ * // From decoded fields.
+ * const b = ReceivePolicyReceipt.from(ReceivePolicyReceipt.decode('0x...'))
  * ```
  *
- * @param value - The ABI-encoded witness or a decoded receipt.
- * @returns The decoded receive-policy receipt.
+ * @param value - An encoded receipt or decoded fields.
+ * @returns The receive-policy receipt.
  */
 export function from(
-  value: Hex.Hex | ReceivePolicyReceipt,
+  value: ReceivePolicyReceipt | Decoded,
 ): ReceivePolicyReceipt {
-  if (typeof value === 'string') return decode(value)
-  return value
+  if (typeof value === 'string') return value
+  return encode(value)
 }
 
 export declare namespace from {
-  type ErrorType = decode.ErrorType | Errors.GlobalErrorType
+  type ErrorType = encode.ErrorType | Errors.GlobalErrorType
 }
 
 /**
- * Decodes a `ReceivePolicyGuard` `TransferBlocked` log into a
- * {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}.
+ * Extracts the {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt} from a
+ * `ReceivePolicyGuard` `TransferBlocked` log.
  *
  * Throws if the log is not a `TransferBlocked` event. Use
- * {@link ox#ReceivePolicyReceipt.fromTransactionReceipt} to decode every
+ * {@link ox#ReceivePolicyReceipt.fromTransactionReceipt} to extract every
  * blocked transfer in a transaction (which skips unrelated logs).
  *
  * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
@@ -201,24 +203,22 @@ export declare namespace from {
  * ```
  *
  * @param log - A `TransferBlocked` log (`data` & `topics`).
- * @returns The decoded receive-policy receipt.
+ * @returns The receive-policy receipt.
  */
 export function fromLog(log: fromLog.Log): ReceivePolicyReceipt {
   const { receipt } = AbiEvent.decode(transferBlocked, log)
-  return decode(receipt)
+  return receipt
 }
 
 export declare namespace fromLog {
   type Log = AbiEvent.decode.Log
 
-  type ErrorType =
-    | AbiEvent.decode.ErrorType
-    | decode.ErrorType
-    | Errors.GlobalErrorType
+  type ErrorType = AbiEvent.decode.ErrorType | Errors.GlobalErrorType
 }
 
 /**
- * Extracts every receive-policy receipt from a transaction receipt's logs.
+ * Extracts every {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt} from a
+ * transaction receipt's logs.
  *
  * A single transaction may block multiple inbound transfers (e.g. a batched
  * transfer to several recipients), so this returns an array – one entry per
@@ -233,11 +233,11 @@ export declare namespace fromLog {
  * import { ReceivePolicyReceipt } from 'ox/tempo'
  *
  * const receipts = ReceivePolicyReceipt.fromTransactionReceipt(receipt)
- * // @log: [{ token: '0x…', originator: '0x…', kind: 'transfer', … }]
+ * // @log: ['0x...'] (pass each to `claim` / `burn`)
  * ```
  *
  * @param receipt - The transaction receipt (or any object with `logs`).
- * @returns The decoded receive-policy receipts, one per blocked transfer.
+ * @returns The receive-policy receipts, one per blocked transfer.
  */
 export function fromTransactionReceipt(
   receipt: fromTransactionReceipt.Receipt,

--- a/src/tempo/ReceivePolicyReceipt.ts
+++ b/src/tempo/ReceivePolicyReceipt.ts
@@ -109,6 +109,49 @@ export declare namespace decode {
 }
 
 /**
+ * Encodes a receive-policy receipt into an ABI-encoded `ClaimReceiptV1`
+ * witness. Inverse of {@link ox#ReceivePolicyReceipt.decode}.
+ *
+ * Useful for reconstructing the witness bytes required by the
+ * `ReceivePolicyGuard`'s `claim` and `burn` functions from a decoded receipt.
+ *
+ * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { ReceivePolicyReceipt } from 'ox/tempo'
+ *
+ * const [receipt] = ReceivePolicyReceipt.fromTransactionReceipt(txReceipt)
+ * const witness = ReceivePolicyReceipt.encode(receipt)
+ * // @log: '0x...' (pass to `claim` / `burn`)
+ * ```
+ *
+ * @param receipt - The decoded receive-policy receipt.
+ * @returns The ABI-encoded `ClaimReceiptV1` witness.
+ */
+export function encode(receipt: ReceivePolicyReceipt): Hex.Hex {
+  return AbiParameters.encode(parameters, [
+    {
+      version: receipt.version,
+      token: receipt.token,
+      recoveryAuthority: receipt.recoveryAuthority,
+      originator: receipt.originator,
+      recipient: receipt.recipient,
+      blockedAt: receipt.blockedAt,
+      blockedNonce: receipt.blockedNonce,
+      blockedReason: blockedReasons.indexOf(receipt.blockedReason),
+      kind: kinds.indexOf(receipt.kind),
+      memo: receipt.memo,
+    },
+  ])
+}
+
+export declare namespace encode {
+  type ErrorType = AbiParameters.encode.ErrorType | Errors.GlobalErrorType
+}
+
+/**
  * Normalizes a receive-policy receipt from either an ABI-encoded
  * `ClaimReceiptV1` witness or an already-decoded receipt.
  *
@@ -140,6 +183,41 @@ export declare namespace from {
 }
 
 /**
+ * Decodes a `ReceivePolicyGuard` `TransferBlocked` log into a
+ * {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}.
+ *
+ * Throws if the log is not a `TransferBlocked` event. Use
+ * {@link ox#ReceivePolicyReceipt.fromTransactionReceipt} to decode every
+ * blocked transfer in a transaction (which skips unrelated logs).
+ *
+ * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { ReceivePolicyReceipt } from 'ox/tempo'
+ *
+ * const receipt = ReceivePolicyReceipt.fromLog(log)
+ * ```
+ *
+ * @param log - A `TransferBlocked` log (`data` & `topics`).
+ * @returns The decoded receive-policy receipt.
+ */
+export function fromLog(log: fromLog.Log): ReceivePolicyReceipt {
+  const { receipt } = AbiEvent.decode(transferBlocked, log)
+  return decode(receipt)
+}
+
+export declare namespace fromLog {
+  type Log = AbiEvent.decode.Log
+
+  type ErrorType =
+    | AbiEvent.decode.ErrorType
+    | decode.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Extracts every receive-policy receipt from a transaction receipt's logs.
  *
  * A single transaction may block multiple inbound transfers (e.g. a batched
@@ -168,8 +246,7 @@ export function fromTransactionReceipt(
   const receipts: ReceivePolicyReceipt[] = []
   for (const log of receipt.logs ?? []) {
     if (log.topics[0] !== selector) continue
-    const { receipt: witness } = AbiEvent.decode(transferBlocked, log)
-    receipts.push(decode(witness))
+    receipts.push(fromLog(log))
   }
   return receipts
 }
@@ -181,8 +258,7 @@ export declare namespace fromTransactionReceipt {
   }
 
   type ErrorType =
-    | AbiEvent.decode.ErrorType
     | AbiEvent.getSelector.ErrorType
-    | decode.ErrorType
+    | fromLog.ErrorType
     | Errors.GlobalErrorType
 }

--- a/src/tempo/ReceivePolicyReceipt.ts
+++ b/src/tempo/ReceivePolicyReceipt.ts
@@ -1,0 +1,188 @@
+import * as AbiEvent from '../core/AbiEvent.js'
+import * as AbiParameters from '../core/AbiParameters.js'
+import type * as Address from '../core/Address.js'
+import type * as Errors from '../core/Errors.js'
+import type * as Hex from '../core/Hex.js'
+import type { Compute } from '../core/internal/types.js'
+
+/** Reason an inbound transfer or mint was blocked by a receive policy. */
+export type BlockedReason = 'none' | 'tokenFilter' | 'receivePolicy'
+
+/** Kind of inbound operation that was blocked. */
+export type Kind = 'transfer' | 'mint'
+
+/**
+ * A decoded TIP-1028 receive-policy claim receipt.
+ *
+ * When an inbound transfer or mint violates the recipient's receive policy, the
+ * funds are redirected to the `ReceivePolicyGuard` and a `ClaimReceiptV1`
+ * witness is emitted. The witness is required to later `claim` or `burn` the
+ * blocked funds.
+ */
+export type ReceivePolicyReceipt = Compute<{
+  /** Receipt layout version. */
+  version: number
+  /** TIP-20 token holding the blocked funds. */
+  token: Address.Address
+  /** Recovery authority captured when the operation was blocked. */
+  recoveryAuthority: Address.Address
+  /** Original sender (transfer) or issuer (mint). */
+  originator: Address.Address
+  /** Addressed recipient (may be a virtual address). */
+  recipient: Address.Address
+  /** Block timestamp when the operation was blocked. */
+  blockedAt: bigint
+  /** Guard nonce assigned when the operation was blocked. */
+  blockedNonce: bigint
+  /** Reason the operation was blocked. */
+  blockedReason: BlockedReason
+  /** Whether the blocked operation was a transfer or mint. */
+  kind: Kind
+  /** Application memo. */
+  memo: Hex.Hex
+}>
+
+/** @internal */
+const blockedReasons = ['none', 'tokenFilter', 'receivePolicy'] as const
+
+/** @internal */
+const kinds = ['transfer', 'mint'] as const
+
+/** @internal ABI parameters for the `ClaimReceiptV1` witness. */
+const parameters = [
+  {
+    type: 'tuple',
+    components: [
+      { name: 'version', type: 'uint8' },
+      { name: 'token', type: 'address' },
+      { name: 'recoveryAuthority', type: 'address' },
+      { name: 'originator', type: 'address' },
+      { name: 'recipient', type: 'address' },
+      { name: 'blockedAt', type: 'uint64' },
+      { name: 'blockedNonce', type: 'uint64' },
+      { name: 'blockedReason', type: 'uint8' },
+      { name: 'kind', type: 'uint8' },
+      { name: 'memo', type: 'bytes32' },
+    ],
+  },
+] as const
+
+/** @internal `TransferBlocked` event emitted by the `ReceivePolicyGuard`. */
+const transferBlocked = AbiEvent.from(
+  'event TransferBlocked(address indexed token, address indexed receiver, uint64 indexed blockedNonce, uint256 amount, uint8 receiptVersion, bytes receipt)',
+)
+
+/**
+ * Decodes an ABI-encoded `ClaimReceiptV1` witness into a
+ * {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}.
+ *
+ * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
+ *
+ * @example
+ * ```ts twoslash
+ * import { ReceivePolicyReceipt } from 'ox/tempo'
+ *
+ * const receipt = ReceivePolicyReceipt.decode('0x...')
+ * ```
+ *
+ * @param receipt - The ABI-encoded `ClaimReceiptV1` witness.
+ * @returns The decoded receive-policy receipt.
+ */
+export function decode(receipt: Hex.Hex): ReceivePolicyReceipt {
+  const [decoded] = AbiParameters.decode(parameters, receipt)
+  return {
+    version: decoded.version,
+    token: decoded.token,
+    recoveryAuthority: decoded.recoveryAuthority,
+    originator: decoded.originator,
+    recipient: decoded.recipient,
+    blockedAt: decoded.blockedAt,
+    blockedNonce: decoded.blockedNonce,
+    blockedReason: blockedReasons[decoded.blockedReason] ?? 'none',
+    kind: kinds[decoded.kind] ?? 'transfer',
+    memo: decoded.memo,
+  }
+}
+
+export declare namespace decode {
+  type ErrorType = AbiParameters.decode.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Normalizes a receive-policy receipt from either an ABI-encoded
+ * `ClaimReceiptV1` witness or an already-decoded receipt.
+ *
+ * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
+ *
+ * @example
+ * ```ts twoslash
+ * import { ReceivePolicyReceipt } from 'ox/tempo'
+ *
+ * // From an encoded witness.
+ * const a = ReceivePolicyReceipt.from('0x...')
+ *
+ * // From a decoded receipt (passthrough).
+ * const b = ReceivePolicyReceipt.from(a)
+ * ```
+ *
+ * @param value - The ABI-encoded witness or a decoded receipt.
+ * @returns The decoded receive-policy receipt.
+ */
+export function from(
+  value: Hex.Hex | ReceivePolicyReceipt,
+): ReceivePolicyReceipt {
+  if (typeof value === 'string') return decode(value)
+  return value
+}
+
+export declare namespace from {
+  type ErrorType = decode.ErrorType | Errors.GlobalErrorType
+}
+
+/**
+ * Extracts every receive-policy receipt from a transaction receipt's logs.
+ *
+ * A single transaction may block multiple inbound transfers (e.g. a batched
+ * transfer to several recipients), so this returns an array – one entry per
+ * `TransferBlocked` log, in log order. Returns an empty array when no transfers
+ * were blocked.
+ *
+ * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { ReceivePolicyReceipt } from 'ox/tempo'
+ *
+ * const receipts = ReceivePolicyReceipt.fromTransactionReceipt(receipt)
+ * // @log: [{ token: '0x…', originator: '0x…', kind: 'transfer', … }]
+ * ```
+ *
+ * @param receipt - The transaction receipt (or any object with `logs`).
+ * @returns The decoded receive-policy receipts, one per blocked transfer.
+ */
+export function fromTransactionReceipt(
+  receipt: fromTransactionReceipt.Receipt,
+): readonly ReceivePolicyReceipt[] {
+  const selector = AbiEvent.getSelector(transferBlocked)
+  const receipts: ReceivePolicyReceipt[] = []
+  for (const log of receipt.logs ?? []) {
+    if (log.topics[0] !== selector) continue
+    const { receipt: witness } = AbiEvent.decode(transferBlocked, log)
+    receipts.push(decode(witness))
+  }
+  return receipts
+}
+
+export declare namespace fromTransactionReceipt {
+  type Receipt = {
+    /** Logs emitted by the transaction. */
+    logs?: readonly AbiEvent.decode.Log[] | undefined
+  }
+
+  type ErrorType =
+    | AbiEvent.decode.ErrorType
+    | AbiEvent.getSelector.ErrorType
+    | decode.ErrorType
+    | Errors.GlobalErrorType
+}

--- a/src/tempo/ReceivePolicyReceipt.ts
+++ b/src/tempo/ReceivePolicyReceipt.ts
@@ -11,8 +11,8 @@ import type { Compute } from '../core/internal/types.js'
  * receive policy.
  *
  * This is the canonical, on-chain representation – the value passed to the
- * `ReceivePolicyGuard`'s `claim` and `burn` functions. Use
- * {@link ox#ReceivePolicyReceipt.decode} to read its fields.
+ * `ReceivePolicyGuard`'s `claim` and `burn` functions. Use `decode` to read its
+ * fields.
  */
 export type ReceivePolicyReceipt = Hex.Hex
 
@@ -114,8 +114,7 @@ export declare namespace decode {
 
 /**
  * Encodes decoded fields into a
- * {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}. Inverse of
- * {@link ox#ReceivePolicyReceipt.decode}.
+ * {@link ox#ReceivePolicyReceipt.ReceivePolicyReceipt}. Inverse of `decode`.
  *
  * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
  *
@@ -189,8 +188,8 @@ export declare namespace from {
  * `ReceivePolicyGuard` `TransferBlocked` log.
  *
  * Throws if the log is not a `TransferBlocked` event. Use
- * {@link ox#ReceivePolicyReceipt.fromTransactionReceipt} to extract every
- * blocked transfer in a transaction (which skips unrelated logs).
+ * `fromTransactionReceipt` to extract every blocked transfer in a transaction
+ * (which skips unrelated logs).
  *
  * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
  *

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -154,6 +154,28 @@ export * as Period from './Period.js'
  */
 export * as PoolId from './PoolId.js'
 /**
+ * TIP-1028 receive-policy claim receipt utilities.
+ *
+ * When an inbound transfer or mint violates the recipient's receive policy, the
+ * funds are redirected to the `ReceivePolicyGuard` and a `ClaimReceiptV1`
+ * witness is emitted. This module decodes those witnesses (required to later
+ * `claim` or `burn` the blocked funds) from raw bytes or transaction receipts.
+ *
+ * [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028)
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { ReceivePolicyReceipt } from 'ox/tempo'
+ *
+ * const receipts = ReceivePolicyReceipt.fromTransactionReceipt(receipt)
+ * const decoded = ReceivePolicyReceipt.decode('0x...')
+ * ```
+ *
+ * @category Reference
+ */
+export * as ReceivePolicyReceipt from './ReceivePolicyReceipt.js'
+/**
  * Union of all JSON-RPC Methods for the `tempo_` namespace.
  *
  * @example


### PR DESCRIPTION
Adds an `ox/tempo` `ReceivePolicyReceipt` module for decoding [TIP-1028](https://docs.tempo.xyz/protocol/tips/tip-1028) receive-policy claim receipts (`ClaimReceiptV1` witnesses).

When an inbound transfer or mint violates the recipient's receive policy, the funds are redirected to the `ReceivePolicyGuard` and a `ClaimReceiptV1` witness is emitted. That witness is required to later `claim` or `burn` the blocked funds.

## API

- `ReceivePolicyReceipt.decode(receipt)` — decode a raw ABI-encoded witness.
- `ReceivePolicyReceipt.from(value)` — normalize from an encoded witness or an already-decoded receipt.
- `ReceivePolicyReceipt.fromTransactionReceipt(receipt)` — extract every receipt from a transaction receipt's logs. Returns an array (one entry per `TransferBlocked` log, in log order) since a single transaction can block multiple inbound transfers; unrelated logs are skipped by topic filtering.

Enums are mapped to string literals for ergonomics (`blockedReason: 'none' | 'tokenFilter' | 'receivePolicy'`, `kind: 'transfer' | 'mint'`); `recoveryAuthority` is exposed as a raw `Address`.