### PR TITLE
feat(tempo): add genesisConfig shorthand to multisig helpers

### DIFF
--- a/.changeset/multisig-genesis-config.md
+++ b/.changeset/multisig-genesis-config.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+`viem/tempo`: Added `genesisConfig` shorthand to TIP-1061 multisig helpers and renamed `configId` → `genesisConfigId` on the typed `SignatureEnvelope.Multisig`.

--- a/src/tempo/MultisigConfig.test.ts
+++ b/src/tempo/MultisigConfig.test.ts
@@ -30,7 +30,7 @@ describe('from', () => {
   })
 })
 
-describe('configId', () => {
+describe('genesisConfigId', () => {
   test('matches independent ground truth', () => {
     expect(MultisigConfig.toId(singleOwnerConfig)).toMatchInlineSnapshot(
       `"0xd1f20e1a5bfdd89488f57f68db5bd1aae9a51b510f4a042b2604b57a0b7b471d"`,
@@ -65,14 +65,14 @@ describe('configId', () => {
 describe('getAddress', () => {
   test('matches independent ground truth', () => {
     expect(
-      MultisigConfig.getAddress({ config: singleOwnerConfig }),
+      MultisigConfig.getAddress(singleOwnerConfig),
     ).toMatchInlineSnapshot(`"0x6ca655065b1de473d903eebd50e5cb4996e10468"`)
   })
 
-  test('derives from config or configId identically', () => {
-    const configId = MultisigConfig.toId(singleOwnerConfig)
-    expect(MultisigConfig.getAddress({ configId })).toBe(
-      MultisigConfig.getAddress({ config: singleOwnerConfig }),
+  test('derives from positional config or `{ genesisConfigId }` identically', () => {
+    const genesisConfigId = MultisigConfig.toId(singleOwnerConfig)
+    expect(MultisigConfig.getAddress({ genesisConfigId })).toBe(
+      MultisigConfig.getAddress(singleOwnerConfig),
     )
   })
 
@@ -86,17 +86,26 @@ describe('getAddress', () => {
 
 describe('getSignPayload', () => {
   test('matches independent ground truth', () => {
-    const configId = MultisigConfig.toId(singleOwnerConfig)
-    const account = MultisigConfig.getAddress({ configId })
     expect(
       MultisigConfig.getSignPayload({
         payload: `0x${'42'.repeat(32)}`,
-        account,
-        configId,
+        genesisConfig: singleOwnerConfig,
       }),
     ).toMatchInlineSnapshot(
       `"0xe3d66f6118b89a67c71c8137c46abf0c829056a46ee6a038a1b42c84529fc17e"`,
     )
+  })
+
+  test('behavior: `genesisConfig` and `{account, genesisConfigId}` produce identical digests', () => {
+    const genesisConfigId = MultisigConfig.toId(singleOwnerConfig)
+    const account = MultisigConfig.getAddress({ genesisConfigId })
+    const payload = `0x${'42'.repeat(32)}` as const
+    expect(
+      MultisigConfig.getSignPayload({
+        payload,
+        genesisConfig: singleOwnerConfig,
+      }),
+    ).toBe(MultisigConfig.getSignPayload({ payload, account, genesisConfigId }))
   })
 })
 

--- a/src/tempo/MultisigConfig.test.ts
+++ b/src/tempo/MultisigConfig.test.ts
@@ -64,9 +64,9 @@ describe('genesisConfigId', () => {
 
 describe('getAddress', () => {
   test('matches independent ground truth', () => {
-    expect(
-      MultisigConfig.getAddress(singleOwnerConfig),
-    ).toMatchInlineSnapshot(`"0x6ca655065b1de473d903eebd50e5cb4996e10468"`)
+    expect(MultisigConfig.getAddress(singleOwnerConfig)).toMatchInlineSnapshot(
+      `"0x6ca655065b1de473d903eebd50e5cb4996e10468"`,
+    )
   })
 
   test('derives from positional config or `{ genesisConfigId }` identically', () => {

--- a/src/tempo/MultisigConfig.ts
+++ b/src/tempo/MultisigConfig.ts
@@ -3,7 +3,7 @@ import type * as Bytes from '../core/Bytes.js'
 import * as Errors from '../core/Errors.js'
 import * as Hash from '../core/Hash.js'
 import * as Hex from '../core/Hex.js'
-import type { Compute } from '../core/internal/types.js'
+import type { Compute, OneOf } from '../core/internal/types.js'
 
 /** Maximum number of owners allowed in a native multisig config. */
 export const maxOwners = 10
@@ -203,27 +203,53 @@ export function fromTuple(tuple: Tuple): Config {
  * ```ts twoslash
  * import { MultisigConfig } from 'ox/tempo'
  *
- * const config = MultisigConfig.from({
+ * const genesisConfig = MultisigConfig.from({
  *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
  * })
  *
- * const address = MultisigConfig.getAddress({ config })
+ * const address = MultisigConfig.getAddress(genesisConfig)
  * ```
  *
- * @param value - The config or config ID to derive the address from.
+ * @example
+ * ### From an genesis config ID
+ *
+ * If you already have the permanent `genesisConfigId`, pass it directly:
+ *
+ * ```ts twoslash
+ * import { MultisigConfig } from 'ox/tempo'
+ *
+ * const genesisConfigId =
+ *   `0x${'00'.repeat(32)}` as const
+ *
+ * const address = MultisigConfig.getAddress({ genesisConfigId })
+ * ```
+ *
+ * @param value - The genesis config (positional) or `{ genesisConfigId }`.
  * @returns The multisig account address.
  */
 export function getAddress(value: getAddress.Value): Address.Address {
-  const id = 'configId' in value ? value.configId : toId(value.config)
+  const id =
+    typeof value === 'object' && 'genesisConfigId' in value
+      ? value.genesisConfigId
+      : toId(value)
   const hash = Hash.keccak256(Hex.concat(Hex.fromString(accountDomain), id))
   return Address.from(Hex.slice(hash, 12, 32))
 }
 
 export declare namespace getAddress {
-  type Value = { config: Config } | { configId: Hex.Hex }
+  type Value =
+    | Config
+    | {
+        /**
+         * The permanent genesis config ID (`MultisigConfig.toId(genesisConfig)`).
+         * Config updates never change this value, so it identifies the
+         * account permanently.
+         */
+        genesisConfigId: Hex.Hex
+      }
 
   type ErrorType =
     | toId.ErrorType
@@ -241,18 +267,21 @@ export declare namespace getAddress {
  * where `inner_digest` is the transaction sign payload
  * ({@link ox#TxEnvelopeTempo.(getSignPayload:function)}).
  *
+ * The digest is always keyed on the permanent `account`/`genesisConfigId`
+ * derived from the genesis (bootstrap) config — config updates never change
+ * these values, so the genesis config is the correct input even for
+ * post-update transactions.
+ *
  * @example
  * ```ts twoslash
  * import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
  *
- * const config = MultisigConfig.from({
+ * const genesisConfig = MultisigConfig.from({
  *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
  * })
- * const configId = MultisigConfig.toId(config)
- * const account = MultisigConfig.getAddress({ configId })
  *
  * const envelope = TxEnvelopeTempo.from({
  *   chainId: 1,
@@ -261,8 +290,34 @@ export declare namespace getAddress {
  *
  * const digest = MultisigConfig.getSignPayload({
  *   payload: TxEnvelopeTempo.getSignPayload(envelope),
+ *   genesisConfig,
+ * })
+ * ```
+ *
+ * @example
+ * ### From `account` + `genesisConfigId`
+ *
+ * If you already have the permanent `account` and `genesisConfigId` (for
+ * example, recovered from a stored envelope), pass them directly:
+ *
+ * ```ts twoslash
+ * import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
+ *
+ * const genesisConfig = MultisigConfig.from({
+ *   threshold: 1,
+ *   owners: [
+ *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
+ *   ],
+ * })
+ * const genesisConfigId = MultisigConfig.toId(genesisConfig)
+ * const account = MultisigConfig.getAddress(genesisConfig)
+ *
+ * const envelope = TxEnvelopeTempo.from({ chainId: 1, calls: [] })
+ *
+ * const digest = MultisigConfig.getSignPayload({
+ *   payload: TxEnvelopeTempo.getSignPayload(envelope),
  *   account,
- *   configId,
+ *   genesisConfigId,
  * })
  * ```
  *
@@ -270,13 +325,21 @@ export declare namespace getAddress {
  * @returns The owner approval digest.
  */
 export function getSignPayload(value: getSignPayload.Value): Hex.Hex {
-  const { payload, account, configId } = value
+  const { payload } = value
+  const account =
+    'account' in value && value.account
+      ? value.account
+      : getAddress((value as { genesisConfig: Config }).genesisConfig)
+  const genesisConfigId =
+    'genesisConfigId' in value && value.genesisConfigId
+      ? value.genesisConfigId
+      : toId((value as { genesisConfig: Config }).genesisConfig)
   return Hash.keccak256(
     Hex.concat(
       Hex.fromString(signatureDomain),
       Hex.from(payload),
       account,
-      configId,
+      genesisConfigId,
     ),
   )
 }
@@ -285,13 +348,28 @@ export declare namespace getSignPayload {
   type Value = {
     /** The inner transaction sign payload (`tx.signature_hash()`). */
     payload: Hex.Hex | Bytes.Bytes
-    /** The native multisig account address. */
-    account: Address.Address
-    /** The permanent config ID. */
-    configId: Hex.Hex
-  }
+  } & OneOf<
+    | {
+        /** The native multisig account address. */
+        account: Address.Address
+        /** The permanent config ID. */
+        genesisConfigId: Hex.Hex
+      }
+    | {
+        /**
+         * The initial multisig config (the bootstrap config that derived the
+         * permanent `account` and `genesisConfigId`). Used to derive both values
+         * automatically. Config updates never change `account`/`genesisConfigId`,
+         * so the genesis config is also the correct input for post-update
+         * transactions.
+         */
+        genesisConfig: Config
+      }
+  >
 
   type ErrorType =
+    | getAddress.ErrorType
+    | toId.ErrorType
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
     | Hex.from.ErrorType
@@ -316,7 +394,7 @@ export declare namespace getSignPayload {
  *   ],
  * })
  *
- * const configId = MultisigConfig.toId(config)
+ * const genesisConfigId = MultisigConfig.toId(config)
  * ```
  *
  * @param config - The multisig config.

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -1097,6 +1097,80 @@ describe('from', () => {
       expect(envelope.keyId).toBe(explicitKeyId)
     })
   })
+
+  describe('multisig', () => {
+    const genesisConfig = MultisigConfig.from({
+      threshold: 1,
+      owners: [
+        {
+          owner: '0x1111111111111111111111111111111111111111',
+          weight: 1,
+        },
+      ],
+    })
+
+    test('behavior: derives `account`/`genesisConfigId` from `genesisConfig`', () => {
+      const envelope = SignatureEnvelope.from({
+        genesisConfig,
+        signatures: [SignatureEnvelope.from(signature_secp256k1)],
+      })
+
+      expect(envelope).toMatchObject({
+        type: 'multisig',
+        account: MultisigConfig.getAddress(genesisConfig),
+        genesisConfigId: MultisigConfig.toId(genesisConfig),
+      })
+      expect('genesisConfig' in envelope).toBe(false)
+      expect((envelope as SignatureEnvelope.Multisig).init).toBeUndefined()
+    })
+
+    test('behavior: `init: true` opts into bootstrap (uses `genesisConfig` as `init`)', () => {
+      const envelope = SignatureEnvelope.from({
+        genesisConfig,
+        signatures: [SignatureEnvelope.from(signature_secp256k1)],
+        init: true,
+      })
+
+      expect((envelope as SignatureEnvelope.Multisig).init).toEqual(
+        genesisConfig,
+      )
+    })
+
+    test('behavior: `init` accepts an explicit config', () => {
+      const otherConfig = MultisigConfig.from({
+        threshold: 1,
+        owners: [
+          {
+            owner: '0x2222222222222222222222222222222222222222',
+            weight: 1,
+          },
+        ],
+      })
+      const envelope = SignatureEnvelope.from({
+        genesisConfig,
+        signatures: [SignatureEnvelope.from(signature_secp256k1)],
+        init: otherConfig,
+      })
+
+      expect((envelope as SignatureEnvelope.Multisig).init).toEqual(otherConfig)
+    })
+
+    test('behavior: `{account, genesisConfigId}` form still works', () => {
+      const account = MultisigConfig.getAddress(genesisConfig)
+      const genesisConfigId = MultisigConfig.toId(genesisConfig)
+      const envelope = SignatureEnvelope.from({
+        account,
+        genesisConfigId,
+        signatures: [SignatureEnvelope.from(signature_secp256k1)],
+      })
+
+      expect(envelope).toMatchObject({
+        type: 'multisig',
+        account,
+        genesisConfigId,
+      })
+    })
+  })
 })
 
 describe('getType', () => {
@@ -1698,33 +1772,40 @@ describe('serialize', () => {
 })
 
 describe('sortMultisigApprovals', () => {
-  const account = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const
-  const configId = `0x${'11'.repeat(32)}` as const
-  const payload = `0x${'42'.repeat(32)}` as const
-  const digest = MultisigConfig.getSignPayload({
-    account,
-    configId,
-    payload,
-  })
-
-  const owners = Array.from({ length: 3 }, () => {
+  // Build owner key pairs first so we can construct a real genesis config
+  // whose owner set matches the keys that produce the approvals below.
+  const ownerKeys = Array.from({ length: 3 }, () => {
     const privateKey = Secp256k1.randomPrivateKey()
     const address = Address.fromPublicKey(
       Secp256k1.getPublicKey({ privateKey }),
     )
-    const signature = SignatureEnvelope.from(
-      Secp256k1.sign({ payload: digest, privateKey }),
-    )
-    return { address, signature } as const
+    return { address, privateKey } as const
   })
-  const ascending = [...owners].sort((a, b) =>
+  const ascendingOwners = [...ownerKeys].sort((a, b) =>
     Hex.toBigInt(a.address) < Hex.toBigInt(b.address) ? -1 : 1,
   )
 
+  const genesisConfig = MultisigConfig.from({
+    threshold: 2,
+    owners: ascendingOwners.map((o) => ({ owner: o.address, weight: 1 })),
+  })
+  const payload = `0x${'42'.repeat(32)}` as const
+  const digest = MultisigConfig.getSignPayload({ payload, genesisConfig })
+
+  const owners = ownerKeys.map((owner) => ({
+    address: owner.address,
+    signature: SignatureEnvelope.from(
+      Secp256k1.sign({ payload: digest, privateKey: owner.privateKey }),
+    ),
+  }))
+  const ascending = ascendingOwners.map((o) => ({
+    address: o.address,
+    signature: owners.find((x) => x.address === o.address)!.signature,
+  }))
+
   test('behavior: orders approvals ascending by recovered owner address', () => {
     const ordered = SignatureEnvelope.sortMultisigApprovals({
-      account,
-      configId,
+      genesisConfig,
       payload,
       // Provide approvals in reverse of the canonical order.
       signatures: [...ascending].reverse().map((owner) => owner.signature),
@@ -1736,8 +1817,7 @@ describe('sortMultisigApprovals', () => {
     const signatures = ascending.map((owner) => owner.signature)
     expect(
       SignatureEnvelope.sortMultisigApprovals({
-        account,
-        configId,
+        genesisConfig,
         payload,
         signatures,
       }),
@@ -1746,8 +1826,7 @@ describe('sortMultisigApprovals', () => {
 
   test('behavior: recovered order matches the config owner order', () => {
     const ordered = SignatureEnvelope.sortMultisigApprovals({
-      account,
-      configId,
+      genesisConfig,
       payload,
       signatures: owners.map((owner) => owner.signature),
     })
@@ -1755,6 +1834,25 @@ describe('sortMultisigApprovals', () => {
       SignatureEnvelope.extractAddress({ payload: digest, signature }),
     )
     expect(recovered).toEqual(ascending.map((owner) => owner.address))
+  })
+
+  test('behavior: `genesisConfig` and `{account, genesisConfigId}` produce identical ordering', () => {
+    const account = MultisigConfig.getAddress(genesisConfig)
+    const genesisConfigId = MultisigConfig.toId(genesisConfig)
+    const signatures = owners.map((owner) => owner.signature)
+
+    const fromConfig = SignatureEnvelope.sortMultisigApprovals({
+      genesisConfig,
+      payload,
+      signatures,
+    })
+    const fromIds = SignatureEnvelope.sortMultisigApprovals({
+      account,
+      genesisConfigId,
+      payload,
+      signatures,
+    })
+    expect(fromConfig).toEqual(fromIds)
   })
 })
 
@@ -2757,7 +2855,7 @@ describe('CoercionError', () => {
 
 describe('multisig', () => {
   const account = '0x8ba6d26ff5c4e82ba0c8caf8c8ca794e1489a7ae'
-  const configId =
+  const genesisConfigId =
     '0x01781fe551182476f2422c759e82d81c92e3263737afbbad57def6e8b69d21f5'
 
   // P256 signatures do not carry `yParity` in the wire format, so use a clean
@@ -2771,7 +2869,7 @@ describe('multisig', () => {
   const envelope = SignatureEnvelope.from({
     type: 'multisig',
     account,
-    configId,
+    genesisConfigId,
     signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
   })
 
@@ -2825,7 +2923,7 @@ describe('multisig', () => {
     const bootstrapEnvelope = SignatureEnvelope.from({
       type: 'multisig',
       account,
-      configId,
+      genesisConfigId,
       signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
       init,
     })
@@ -2841,7 +2939,7 @@ describe('multisig', () => {
       const salted = SignatureEnvelope.from({
         type: 'multisig',
         account,
-        configId,
+        genesisConfigId,
         signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
         init: { ...init, salt: `0x${'42'.repeat(32)}` },
       })
@@ -2895,7 +2993,7 @@ describe('multisig', () => {
         SignatureEnvelope.assert({
           type: 'multisig',
           account,
-          configId,
+          genesisConfigId,
           signatures: [],
           init: { threshold: 1, owners: [] },
         } as never),

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -1318,7 +1318,8 @@ export function sortMultisigApprovals(
       : {
           payload,
           account: (value as { account: Address.Address }).account,
-          genesisConfigId: (value as { genesisConfigId: Hex.Hex }).genesisConfigId,
+          genesisConfigId: (value as { genesisConfigId: Hex.Hex })
+            .genesisConfigId,
         },
   )
   // Recover each signer once (decorate–sort–undecorate) rather than inside the

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -74,7 +74,7 @@ export type GetType<
               ? 'keychain'
               : envelope extends {
                     account: Address.Address
-                    configId: `0x${string}`
+                    genesisConfigId: `0x${string}`
                     signatures: any
                   }
                 ? 'multisig'
@@ -161,7 +161,7 @@ export type Multisig<bigintType = bigint, numberType = number> = {
   /** Native multisig account address. */
   account: Address.Address
   /** Permanent config ID derived from the initial multisig config. */
-  configId: Hex.Hex
+  genesisConfigId: Hex.Hex
   /** Primitive owner approvals over the multisig owner approval digest. */
   signatures: readonly SignatureEnvelope<bigintType, numberType>[]
   /**
@@ -175,6 +175,11 @@ export type Multisig<bigintType = bigint, numberType = number> = {
 export type MultisigRpc = {
   type: 'multisig'
   account: Address.Address
+  /**
+   * The permanent multisig config ID (TIP-1061 wire field `config_id`).
+   * Maps to {@link ox#SignatureEnvelope.Multisig.genesisConfigId} on the
+   * typed envelope.
+   */
   configId: Hex.Hex
   /**
    * Encoded primitive owner approvals (raw serialized signatures), matching the
@@ -328,7 +333,7 @@ export function assert(envelope: PartialBy<SignatureEnvelope, 'type'>): void {
     const multisig = envelope as Multisig
     const missing: string[] = []
     if (!multisig.account) missing.push('account')
-    if (!multisig.configId) missing.push('configId')
+    if (!multisig.genesisConfigId) missing.push('genesisConfigId')
     if (!Array.isArray(multisig.signatures)) missing.push('signatures')
     if (missing.length > 0)
       throw new MissingPropertiesError({ envelope, missing, type: 'multisig' })
@@ -613,10 +618,10 @@ export function deserialize(value: Serialized): SignatureEnvelope {
   }
 
   if (typeId === serializedMultisigType) {
-    // Wire format: `0x05 || rlp([account, configId, signatures, init])`. `init`
+    // Wire format: `0x05 || rlp([account, genesisConfigId, signatures, init])`. `init`
     // is optional: absent when the element is missing or the `0x80` placeholder
     // (decoded as the empty string `0x`), otherwise the bootstrap config list.
-    const [account, configId, signatures, init] = Rlp.toHex(data) as [
+    const [account, genesisConfigId, signatures, init] = Rlp.toHex(data) as [
       Hex.Hex,
       Hex.Hex,
       readonly Hex.Hex[],
@@ -625,7 +630,7 @@ export function deserialize(value: Serialized): SignatureEnvelope {
     return {
       type: 'multisig',
       account,
-      configId,
+      genesisConfigId,
       signatures: signatures.map((signature) => deserialize(signature)),
       ...(init && init !== '0x'
         ? {
@@ -753,6 +758,43 @@ export function deserialize(value: Serialized): SignatureEnvelope {
  * })
  * ```
  *
+ * @example
+ * ### Multisig (from genesis config)
+ *
+ * Pass `genesisConfig` to derive `account` and `genesisConfigId` automatically.
+ * Set `init: true` to opt into bootstrap (uses `genesisConfig` as the
+ * bootstrap `init`); omit `init` for subsequent (non-bootstrap) transactions.
+ *
+ * ```ts twoslash
+ * import { Secp256k1 } from 'ox'
+ * import { MultisigConfig, SignatureEnvelope } from 'ox/tempo'
+ *
+ * const genesisConfig = MultisigConfig.from({
+ *   threshold: 1,
+ *   owners: [
+ *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
+ *   ],
+ * })
+ *
+ * const privateKey = Secp256k1.randomPrivateKey()
+ * const signature = SignatureEnvelope.from(
+ *   Secp256k1.sign({ payload: '0xdeadbeef', privateKey }),
+ * )
+ *
+ * // Bootstrap transaction
+ * const bootstrap = SignatureEnvelope.from({
+ *   genesisConfig,
+ *   signatures: [signature],
+ *   init: true,
+ * })
+ *
+ * // Subsequent (non-bootstrap) transactions
+ * const subsequent = SignatureEnvelope.from({
+ *   genesisConfig,
+ *   signatures: [signature],
+ * })
+ * ```
+ *
  * @param value - The value to coerce (either a hex string or signature envelope).
  * @returns The signature envelope.
  */
@@ -774,20 +816,42 @@ export function from<const value extends from.Value>(
   const type = getType(value)
 
   if (type === 'multisig') {
-    const multisig = value as Multisig
+    const multisig = value as Multisig & {
+      genesisConfig?: MultisigConfig.Config | undefined
+      init?: MultisigConfig.Config | boolean | undefined
+    }
+    const { genesisConfig, init, ...rest } = multisig
+    // Derive `account`/`genesisConfigId` from `genesisConfig` when not provided
+    // explicitly.
+    const account = (() => {
+      if (rest.account) return rest.account
+      if (genesisConfig) return MultisigConfig.getAddress(genesisConfig)
+      return rest.account
+    })()
+    const genesisConfigId = (() => {
+      if (rest.genesisConfigId) return rest.genesisConfigId
+      if (genesisConfig) return MultisigConfig.toId(genesisConfig)
+      return rest.genesisConfigId
+    })()
+    // `init: true` opts into bootstrap using the supplied `genesisConfig`.
+    // Otherwise, `init` is treated as the explicit bootstrap config (or
+    // omitted).
+    const initSource = init === true ? genesisConfig : init || undefined
     return {
-      ...multisig,
-      signatures: multisig.signatures.map((signature) => from(signature)),
+      ...rest,
+      account,
+      genesisConfigId,
+      signatures: rest.signatures.map((signature) => from(signature)),
       // Normalize the bootstrap config (sorts owners, defaults the salt) so the
       // in-memory envelope matches what `deserialize` reconstructs.
-      ...(multisig.init ? { init: MultisigConfig.from(multisig.init) } : {}),
+      ...(initSource ? { init: MultisigConfig.from(initSource) } : {}),
       type,
     } as never
   }
 
   return {
     ...value,
-    ...(type === 'p256' ? { prehash: value.prehash } : {}),
+    ...(type === 'p256' ? { prehash: (value as P256).prehash } : {}),
     ...(type === 'keychain'
       ? {
           ...(!(
@@ -827,10 +891,24 @@ export declare namespace from {
     payload?: Hex.Hex | Bytes.Bytes | undefined
   }
 
+  /**
+   * Multisig envelope input variant where `account` and `genesisConfigId` are derived
+   * from the supplied `genesisConfig`. Pass `init: true` to opt into bootstrap
+   * (uses `genesisConfig` as the bootstrap `init`); omit `init` for subsequent
+   * (non-bootstrap) transactions.
+   */
+  type MultisigFromGenesisConfig = {
+    type?: 'multisig' | undefined
+    genesisConfig: MultisigConfig.Config
+    signatures: readonly SignatureEnvelope[]
+    init?: MultisigConfig.Config | boolean | undefined
+  }
+
   type Value =
     | UnionPartialBy<SignatureEnvelope, 'prehash' | 'type'>
     | Secp256k1Flat
     | Serialized
+    | MultisigFromGenesisConfig
 
   type ReturnValue<value extends Value> = Compute<
     OneOf<
@@ -838,16 +916,18 @@ export declare namespace from {
         ? SignatureEnvelope
         : value extends Secp256k1Flat
           ? Secp256k1
-          : IsNarrowable<value, SignatureEnvelope> extends true
-            ? SignatureEnvelope
-            : Assign<
-                value,
-                {
-                  readonly type: GetType<value>
-                } & (GetType<value> extends 'keychain'
-                  ? { keyId?: Address.Address | undefined }
-                  : {})
-              >
+          : value extends MultisigFromGenesisConfig
+            ? Multisig
+            : IsNarrowable<value, SignatureEnvelope> extends true
+              ? SignatureEnvelope
+              : Assign<
+                  value,
+                  {
+                    readonly type: GetType<value>
+                  } & (GetType<value> extends 'keychain'
+                    ? { keyId?: Address.Address | undefined }
+                    : {})
+                >
     >
   >
 }
@@ -963,7 +1043,9 @@ export function fromRpc(envelope: SignatureEnvelopeRpc): SignatureEnvelope {
     return {
       type: 'multisig',
       account: multisig.account,
-      configId: multisig.configId,
+      // Map RPC wire field `configId` (TIP-1061 spec name) to the typed
+      // envelope's `genesisConfigId`.
+      genesisConfigId: multisig.configId,
       // Owner approvals are raw serialized signatures (node `Vec<Bytes>`).
       signatures: multisig.signatures.map((signature) =>
         deserialize(signature),
@@ -1050,8 +1132,8 @@ export function getType<
 
   // Detect Multisig signature
   if (
-    'account' in envelope &&
-    'configId' in envelope &&
+    (('account' in envelope && 'genesisConfigId' in envelope) ||
+      'genesisConfig' in envelope) &&
     'signatures' in envelope
   )
     return 'multisig' as never
@@ -1151,7 +1233,7 @@ export function serialize(
 
   if (type === 'multisig') {
     const multisig = envelope as Multisig
-    // Format: `0x05 || rlp([account, configId, signatures, init])`, where each
+    // Format: `0x05 || rlp([account, genesisConfigId, signatures, init])`, where each
     // owner approval is an encoded primitive signature. `init` is the bootstrap
     // config (an RLP list) when present, otherwise the canonical empty-string
     // placeholder (`0x` → RLP `0x80`).
@@ -1159,7 +1241,7 @@ export function serialize(
       serializedMultisigType,
       Rlp.fromHex([
         multisig.account,
-        multisig.configId,
+        multisig.genesisConfigId,
         multisig.signatures.map((signature) => serialize(signature)),
         multisig.init ? MultisigConfig.toTuple(multisig.init) : '0x',
       ]),
@@ -1191,33 +1273,33 @@ export declare namespace serialize {
  * recovered owner address. Works for any owner key type (secp256k1, p256,
  * webAuthn, keychain).
  *
+ * Config updates never change `account`/`genesisConfigId`, so the genesis
+ * config is the correct input even for post-update transactions.
+ *
  * @example
  * ```ts twoslash
  * import { Secp256k1 } from 'ox'
  * import { MultisigConfig, SignatureEnvelope, TxEnvelopeTempo } from 'ox/tempo'
  *
- * const config = MultisigConfig.from({
+ * const genesisConfig = MultisigConfig.from({
  *   threshold: 2,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *     { owner: '0x2222222222222222222222222222222222222222', weight: 1 },
  *   ],
  * })
- * const configId = MultisigConfig.toId(config)
- * const account = MultisigConfig.getAddress({ configId })
  *
  * const tx = TxEnvelopeTempo.from({ chainId: 1, calls: [] })
  * const payload = TxEnvelopeTempo.getSignPayload(tx)
- * const digest = MultisigConfig.getSignPayload({ payload, account, configId })
  *
  * const privateKeys = [Secp256k1.randomPrivateKey(), Secp256k1.randomPrivateKey()]
+ * const digest = MultisigConfig.getSignPayload({ payload, genesisConfig })
  * const signatures = privateKeys.map((privateKey) =>
  *   SignatureEnvelope.from(Secp256k1.sign({ payload: digest, privateKey })),
  * )
  *
  * const ordered = SignatureEnvelope.sortMultisigApprovals({ // [!code focus]
- *   account, // [!code focus]
- *   configId, // [!code focus]
+ *   genesisConfig, // [!code focus]
  *   payload, // [!code focus]
  *   signatures, // [!code focus]
  * }) // [!code focus]
@@ -1229,12 +1311,16 @@ export declare namespace serialize {
 export function sortMultisigApprovals(
   value: sortMultisigApprovals.Value,
 ): readonly SignatureEnvelope[] {
-  const { account, configId, payload, signatures } = value
-  const digest = MultisigConfig.getSignPayload({
-    account,
-    configId,
-    payload,
-  })
+  const { payload, signatures } = value
+  const digest = MultisigConfig.getSignPayload(
+    'genesisConfig' in value && value.genesisConfig
+      ? { payload, genesisConfig: value.genesisConfig }
+      : {
+          payload,
+          account: (value as { account: Address.Address }).account,
+          genesisConfigId: (value as { genesisConfigId: Hex.Hex }).genesisConfigId,
+        },
+  )
   // Recover each signer once (decorate–sort–undecorate) rather than inside the
   // comparator.
   return signatures
@@ -1248,15 +1334,26 @@ export function sortMultisigApprovals(
 
 export declare namespace sortMultisigApprovals {
   type Value = {
-    /** The native multisig account address. */
-    account: Address.Address
-    /** The permanent config ID. */
-    configId: Hex.Hex
     /** The inner transaction sign payload (`tx.signature_hash()`). */
     payload: Hex.Hex | Bytes.Bytes
     /** The primitive owner approvals to order. */
     signatures: readonly SignatureEnvelope[]
-  }
+  } & OneOf<
+    | {
+        /** The native multisig account address. */
+        account: Address.Address
+        /** The permanent config ID. */
+        genesisConfigId: Hex.Hex
+      }
+    | {
+        /**
+         * The initial multisig config (the bootstrap config that derived the
+         * permanent `account` and `genesisConfigId`). Used to derive both values
+         * automatically.
+         */
+        genesisConfig: MultisigConfig.Config
+      }
+  >
 
   type ErrorType =
     | MultisigConfig.getSignPayload.ErrorType
@@ -1336,7 +1433,9 @@ export function toRpc(envelope: SignatureEnvelope): SignatureEnvelopeRpc {
     return {
       type: 'multisig',
       account: multisig.account,
-      configId: multisig.configId,
+      // Map the typed envelope's `genesisConfigId` to the RPC wire field
+      // `configId` (TIP-1061 spec name).
+      configId: multisig.genesisConfigId,
       // Owner approvals are raw serialized signatures (node `Vec<Bytes>`).
       signatures: multisig.signatures.map((signature) => serialize(signature)),
       ...(multisig.init ? { init: multisig.init } : {}),

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -177,8 +177,8 @@ export type MultisigRpc = {
   account: Address.Address
   /**
    * The permanent multisig config ID (TIP-1061 wire field `config_id`).
-   * Maps to {@link ox#SignatureEnvelope.Multisig.genesisConfigId} on the
-   * typed envelope.
+   * Maps to `genesisConfigId` on the typed
+   * {@link ox#SignatureEnvelope.Multisig} envelope.
    */
   configId: Hex.Hex
   /**

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -3015,7 +3015,7 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
       return { address, privateKey } as const
     })
 
-    const config = MultisigConfig.from({
+    const genesisConfig = MultisigConfig.from({
       // A fresh random salt yields a distinct account each run, exercising the
       // salt-inclusive config-ID derivation against the node.
       salt: Hex.random(32),
@@ -3025,10 +3025,9 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
         weight: 1,
       })),
     })
-    const configId = MultisigConfig.toId(config)
-    const account = MultisigConfig.getAddress({ configId })
+    const account = MultisigConfig.getAddress(genesisConfig)
 
-    return { account, config, configId, ownerKeys } as const
+    return { account, genesisConfig, ownerKeys } as const
   }
 
   // Signs the multisig owner digest with the provided owner keys, returning
@@ -3036,32 +3035,26 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
   // address (required by the node: "recovered owners must be strictly
   // ascending").
   function approve(parameters: {
-    account: Address.Address
-    configId: Hex.Hex
+    genesisConfig: MultisigConfig.Config
     payload: Hex.Hex
     signers: readonly { privateKey: Hex.Hex }[]
   }) {
-    const { account, configId, payload, signers } = parameters
-    const digest = MultisigConfig.getSignPayload({
-      account,
-      configId,
-      payload,
-    })
+    const { genesisConfig, payload, signers } = parameters
+    const digest = MultisigConfig.getSignPayload({ payload, genesisConfig })
     const signatures = signers.map((signer) =>
       SignatureEnvelope.from(
         Secp256k1.sign({ payload: digest, privateKey: signer.privateKey }),
       ),
     )
     return SignatureEnvelope.sortMultisigApprovals({
-      account,
-      configId,
+      genesisConfig,
       payload,
       signatures,
     })
   }
 
   test('behavior: bootstrap + spend (2-of-3 secp256k1)', async () => {
-    const { account, config, configId, ownerKeys } = setup({
+    const { account, genesisConfig, ownerKeys } = setup({
       count: 3,
       threshold: 2,
     })
@@ -3083,15 +3076,12 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
 
     const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
       signature: SignatureEnvelope.from({
-        type: 'multisig',
-        account,
-        configId,
-        // The bootstrap config is carried by the signature `init`.
-        init: config,
+        genesisConfig,
+        // Initialize multisig.
+        init: true,
         // Approve with 2 of the 3 owners to satisfy the threshold.
         signatures: approve({
-          account,
-          configId,
+          genesisConfig,
           payload: TxEnvelopeTempo.getSignPayload(bootstrap),
           signers: [ownerKeys[0]!, ownerKeys[1]!],
         }),
@@ -3121,7 +3111,7 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
       // The bootstrap config is carried by the multisig signature `init`.
       expect(
         (response.signature as SignatureEnvelope.Multisig | undefined)?.init,
-      ).toEqual(config)
+      ).toEqual(genesisConfig)
     }
 
     // Spend (subsequent transaction): no signature `init`, nonce 1, uses the
@@ -3143,13 +3133,10 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
 
     const spend_signed = TxEnvelopeTempo.serialize(spend, {
       signature: SignatureEnvelope.from({
-        type: 'multisig',
-        account,
-        configId,
+        genesisConfig,
         // A different 2-of-3 subset still authorizes the transaction.
         signatures: approve({
-          account,
-          configId,
+          genesisConfig,
           payload: TxEnvelopeTempo.getSignPayload(spend),
           signers: [ownerKeys[1]!, ownerKeys[2]!],
         }),
@@ -3168,7 +3155,7 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
   })
 
   test('behavior: rejects below-threshold approvals', async () => {
-    const { account, config, configId, ownerKeys } = setup({
+    const { account, genesisConfig, ownerKeys } = setup({
       count: 3,
       threshold: 2,
     })
@@ -3187,15 +3174,12 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
 
     const serialized_signed = TxEnvelopeTempo.serialize(bootstrap, {
       signature: SignatureEnvelope.from({
-        type: 'multisig',
-        account,
-        configId,
-        // The bootstrap config is carried by the signature `init`.
-        init: config,
+        genesisConfig,
+        // Opt into bootstrap: writes `genesisConfig` into the signature `init`.
+        init: true,
         // Only one approval — below the threshold of 2.
         signatures: approve({
-          account,
-          configId,
+          genesisConfig,
           payload: TxEnvelopeTempo.getSignPayload(bootstrap),
           signers: [ownerKeys[0]!],
         }),

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -114,7 +114,7 @@ export * as KeyAuthorization from './KeyAuthorization.js'
  * ```ts twoslash
  * import { MultisigConfig } from 'ox/tempo'
  *
- * const config = MultisigConfig.from({
+ * const genesisConfig = MultisigConfig.from({
  *   threshold: 2,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
@@ -122,7 +122,7 @@ export * as KeyAuthorization from './KeyAuthorization.js'
  *   ],
  * })
  *
- * const account = MultisigConfig.getAddress({ config })
+ * const account = MultisigConfig.getAddress(genesisConfig)
  * ```
  *
  * @category Reference


### PR DESCRIPTION
Adds `genesisConfig` shorthand to TIP-1061 multisig helpers and renames `configId` → `genesisConfigId` on the typed `SignatureEnvelope.Multisig`.