### PR TITLE
fix(Hex): throw on empty hex in toNumber instead of returning NaN

### DIFF
--- a/.changeset/hex-tonumber-empty.md
+++ b/.changeset/hex-tonumber-empty.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `Hex.toNumber` (and `Bytes.toNumber`, which delegates to it) returning `NaN` for empty hex (`0x`) instead of throwing, consistent with `Hex.toBigInt`.

--- a/src/core/Hex.ts
+++ b/src/core/Hex.ts
@@ -665,7 +665,12 @@ export declare namespace toBytes {
  */
 export function toNumber(hex: Hex, options: toNumber.Options = {}): number {
   const { signed, size } = options
-  if (!signed && !size) return Number(hex)
+  if (!signed && !size) {
+    const number = Number(hex)
+    // `Number('0x')` is `NaN`; defer to `toBigInt` so empty hex throws
+    // instead of silently returning `NaN` (consistent with `Hex.toBigInt`).
+    if (!Number.isNaN(number)) return number
+  }
   return Number(toBigInt(hex, options))
 }
 

--- a/src/core/_test/Hex.test.ts
+++ b/src/core/_test/Hex.test.ts
@@ -641,6 +641,11 @@ describe('toNumber', () => {
       '[Hex.SizeOverflowError: Size cannot exceed `32` bytes. Given size: `64` bytes.]',
     )
   })
+
+  test('error: empty hex', () => {
+    // Consistent with `Hex.toBigInt('0x')`, which throws. Must not return `NaN`.
+    expect(() => Hex.toNumber('0x')).toThrow()
+  })
 })
 
 describe('toString', () => {


### PR DESCRIPTION
`Hex.toNumber('0x')` returns `NaN`, while `Hex.toBigInt('0x')` throws.

The no-options fast path decodes via `Number(hex)`, and `Number('0x')` is `NaN`, so empty hex silently yields a non-number instead of erroring. viem's `hexToNumber` routes through `hexToBigInt` and throws here; `Bytes.toNumber` (which delegates to `Hex.toNumber`) is affected too.

The fix keeps the fast path for valid hex and only defers to `toBigInt` when `Number(hex)` is `NaN`. For all valid hex, `Number(hex) === Number(toBigInt(hex))`; `0x` is the only divergence, so no valid result changes.

Added a regression test asserting `Hex.toNumber('0x')` throws.