### PR TITLE
fix(Base58): preserve leading zeros for zero-valued and empty inputs

### DIFF
--- a/src/core/Base58.ts
+++ b/src/core/Base58.ts
@@ -125,8 +125,9 @@ export function toHex(value: string): Hex.Hex {
     integer = integer + internal.alphabetToInteger[char]!
   }
 
-  if (!pad) return `0x${integer.toString(16)}` as Hex.Hex
-  return `0x${'0'.repeat(pad * 2)}${integer.toString(16)}` as Hex.Hex
+  const body = integer === 0n ? '' : integer.toString(16)
+  if (!pad) return `0x${body}` as Hex.Hex
+  return `0x${'0'.repeat(pad * 2)}${body}` as Hex.Hex
 }
 
 export declare namespace toHex {

--- a/src/core/_test/Base58.test.ts
+++ b/src/core/_test/Base58.test.ts
@@ -17,6 +17,16 @@ describe('fromHex', () => {
   test('default', () => {
     expect(Base58.fromHex('0x00000000287fb4cd')).toBe('1111233QC4')
   })
+
+  test('leading zeros (all-zero value)', () => {
+    expect(Base58.fromHex('0x00')).toBe('1')
+    expect(Base58.fromHex('0x0000')).toBe('11')
+    expect(Base58.fromHex('0x000000')).toBe('111')
+  })
+
+  test('empty', () => {
+    expect(Base58.fromHex('0x')).toBe('')
+  })
 })
 
 describe('fromString', () => {
@@ -47,6 +57,15 @@ describe('toBytes', () => {
       ]
     `)
   })
+
+  test('leading zeros', () => {
+    expect(Base58.toBytes('1')).toStrictEqual(new Uint8Array([0]))
+    expect(Base58.toBytes('1112NEpo7TZRRrLZSi2U')).toStrictEqual(
+      new Uint8Array([
+        0, 0, 0, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+      ]),
+    )
+  })
 })
 
 describe('toHex', () => {
@@ -56,6 +75,16 @@ describe('toHex', () => {
     expect(() => Base58.toHex('233QC4I')).toThrowErrorMatchingInlineSnapshot(
       '[Error: invalid base58 character: I]',
     )
+  })
+
+  test('leading ones (all-zero value)', () => {
+    expect(Base58.toHex('1')).toBe('0x00')
+    expect(Base58.toHex('11')).toBe('0x0000')
+    expect(Base58.toHex('111')).toBe('0x000000')
+  })
+
+  test('empty', () => {
+    expect(Base58.toHex('')).toBe('0x')
   })
 })
 

--- a/src/core/internal/base58.ts
+++ b/src/core/internal/base58.ts
@@ -77,6 +77,7 @@ export function from(value: Hex.Hex | Bytes.Bytes) {
   let integer = (() => {
     let hex = value
     if (value instanceof Uint8Array) hex = Hex.fromBytes(bytes)
+    if (hex === '0x') return 0n
     return BigInt(hex as string)
   })()
 
@@ -87,7 +88,7 @@ export function from(value: Hex.Hex | Bytes.Bytes) {
     result = integerToAlphabet[remainder] + result
   }
 
-  while (bytes.length > 1 && bytes[0] === 0) {
+  while (bytes.length > 0 && bytes[0] === 0) {
     result = '1' + result
     bytes = bytes.slice(1)
   }


### PR DESCRIPTION
### Problem

`Base58` drops a leading `1` for all-zero inputs and throws on empty input, so round-trips are broken for zero-valued payloads:

```ts
Base58.fromHex('0x00')    // ''      (should be '1')
Base58.fromHex('0x0000')  // '1'     (should be '11')
Base58.fromHex('0x')      // throws  (should be '')
Base58.toHex('1')         // '0x000' (should be '0x00')
Base58.toHex('')          // '0x0'   (should be '0x')
```

Inputs with a non-zero tail were already correct (e.g. `0x0000287fb4cd` → `1111233QC4`), which is why the existing leading-zero vectors passed and this went unnoticed. It only surfaces when the value portion is entirely zero.

Impact: any all-zero or empty Base58 payload round-trips to the wrong byte length and is rejected/misread by other Base58 tools (`bs58`, `ethers`). Empty input throws an uncaught `Cannot convert 0x to a BigInt` instead of returning `''`.

### Cause

`src/core/internal/base58.ts` (encode): the leading-zero loop runs while `bytes.length > 1`, so the final zero byte is never counted (n zero bytes produce n−1 `1`s), and `BigInt('0x')` throws on empty input.

`src/core/Base58.ts` (decode): `integer.toString(16)` appends a stray `0` nibble when the decoded value is `0n`.

### Fix

- Count every leading zero byte (`> 0` instead of `> 1`).
- Treat empty hex as `0n` instead of throwing.
- Emit no body nibble when the decoded integer is `0` (the zero bytes come entirely from the leading-`1` count).

Non-zero inputs are untouched: both loops already stop at the first non-zero byte, and the decode body is unchanged for non-zero values.

### Spec

The [Base58 spec](https://digitalbazaar.github.io/base58-spec/) referenced in the `Base58` docs (and Base58Check) maps each leading `0x00` byte to exactly one `1`. Output verified to match `bs58` and `ethers` across all-zero, leading-zero, empty and random inputs.

### Tests

Added regression cases for the all-zero and empty paths on `fromHex` / `toHex` / `toBytes`. They fail on `main` and pass with the fix; the existing suite is unchanged (12/12 green).