### PR TITLE
fix(rlp): limit decode depth

### DIFF
--- a/.changeset/rlp-decode-depth-limit.md
+++ b/.changeset/rlp-decode-depth-limit.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Added a decode depth limit (1024) to `Rlp.toBytes` / `Rlp.toHex`, throwing `Rlp.DepthLimitExceededError` instead of overflowing the call stack on deeply nested untrusted RLP input.

--- a/src/core/Rlp.ts
+++ b/src/core/Rlp.ts
@@ -5,6 +5,9 @@ import * as internal_bytes from './internal/bytes.js'
 import * as Cursor from './internal/cursor.js'
 import type { ExactPartial, RecursiveArray } from './internal/types.js'
 
+/** Maximum nesting depth permitted when decoding an RLP value. */
+const depthLimit = 1_024
+
 /**
  * Decodes a Recursive-Length Prefix (RLP) value into a {@link ox#Bytes.Bytes} value.
  *
@@ -91,7 +94,11 @@ export declare namespace to {
 export function decodeRlpCursor<to extends 'Hex' | 'Bytes' = 'Hex'>(
   cursor: Cursor.Cursor,
   to: to | 'Hex' | 'Bytes' | undefined = 'Hex',
+  depth = 0,
 ): decodeRlpCursor.ReturnType<to> {
+  if (depth >= depthLimit)
+    throw new DepthLimitExceededError({ limit: depthLimit })
+
   if (cursor.bytes.length === 0)
     return (
       to === 'Hex' ? Hex.fromBytes(cursor.bytes) : cursor.bytes
@@ -111,7 +118,12 @@ export function decodeRlpCursor<to extends 'Hex' | 'Bytes' = 'Hex'>(
 
   // list
   const length = readLength(cursor, prefix, 0xc0)
-  return readList(cursor, length, to) as {} as decodeRlpCursor.ReturnType<to>
+  return readList(
+    cursor,
+    length,
+    to,
+    depth + 1,
+  ) as {} as decodeRlpCursor.ReturnType<to>
 }
 
 /** @internal */
@@ -121,6 +133,7 @@ export declare namespace decodeRlpCursor {
     | Hex.fromBytes.ErrorType
     | readLength.ErrorType
     | readList.ErrorType
+    | DepthLimitExceededError
     | Errors.GlobalErrorType
 }
 
@@ -149,17 +162,18 @@ export function readList<to extends 'Hex' | 'Bytes'>(
   cursor: Cursor.Cursor,
   length: number,
   to: to | 'Hex' | 'Bytes',
+  depth = 0,
 ) {
   const position = cursor.position
   const value: decodeRlpCursor.ReturnType<to>[] = []
   while (cursor.position - position < length)
-    value.push(decodeRlpCursor(cursor, to))
+    value.push(decodeRlpCursor(cursor, to, depth))
   return value
 }
 
 /** @internal */
 export declare namespace readList {
-  type ErrorType = Errors.GlobalErrorType
+  type ErrorType = DepthLimitExceededError | Errors.GlobalErrorType
 }
 
 /**
@@ -642,4 +656,13 @@ function writeBigEndian(
 
 function invalidNibble(hex: Hex.Hex): Errors.BaseError {
   return new Errors.BaseError(`Invalid hex string \`${hex}\`.`)
+}
+
+/** Thrown when an RLP value nests deeper than the decode depth limit. */
+export class DepthLimitExceededError extends Errors.BaseError {
+  override readonly name = 'Rlp.DepthLimitExceededError'
+
+  constructor({ limit }: { limit: number }) {
+    super(`RLP depth limit of \`${limit}\` exceeded.`)
+  }
 }

--- a/src/core/_test/Rlp.test.ts
+++ b/src/core/_test/Rlp.test.ts
@@ -13,6 +13,7 @@ test('exports', () => {
       "from",
       "fromBytes",
       "fromHex",
+      "DepthLimitExceededError",
     ]
   `)
 })
@@ -334,6 +335,46 @@ describe('Rlp.to', () => {
 
     It must be an even length.]
   `,
+    )
+  })
+})
+
+describe('decode depth limit', () => {
+  // Builds an RLP-encoded value of `depth` nested empty lists without recursing
+  // (so we can exceed the decoder's depth limit without overflowing the encoder).
+  const nestedEmptyLists = (depth: number) => {
+    let bytes = Uint8Array.from([0xc0])
+    for (let i = 0; i < depth; i++) {
+      const length = bytes.length
+      const prefix =
+        length <= 55
+          ? [0xc0 + length]
+          : (() => {
+              const lengthBytes: number[] = []
+              let n = length
+              while (n > 0) {
+                lengthBytes.unshift(n & 0xff)
+                n >>= 8
+              }
+              return [0xf7 + lengthBytes.length, ...lengthBytes]
+            })()
+      const next = new Uint8Array(prefix.length + bytes.length)
+      next.set(prefix, 0)
+      next.set(bytes, prefix.length)
+      bytes = next
+    }
+    return bytes
+  }
+
+  test('decodes up to the depth limit', () => {
+    expect(() => Rlp.toBytes(nestedEmptyLists(1_023))).not.toThrow()
+  })
+
+  test('throws when the depth limit is exceeded', () => {
+    expect(() =>
+      Rlp.toBytes(nestedEmptyLists(2_000)),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Rlp.DepthLimitExceededError: RLP depth limit of \`1024\` exceeded.]`,
     )
   })
 })


### PR DESCRIPTION
## Summary

`Rlp.toBytes` / `Rlp.toHex` recurse once per nested list with no depth bound, so deeply nested untrusted RLP input overflows the call stack (`RangeError: Maximum call stack size exceeded`) — a DoS vector when decoding attacker-controlled payloads (e.g. RPC responses, raw transactions).

This adds a decode depth limit of **1024**, throwing a new `Rlp.DepthLimitExceededError` instead of overflowing.

## Changes

- `decodeRlpCursor` / `readList` thread a `depth` counter; exceeding `depthLimit` (1024) throws `Rlp.DepthLimitExceededError`.
- New exported `Rlp.DepthLimitExceededError` error class.
- Tests: decodes up to the limit; throws past it.

## Notes

Mirrors the equivalent hardening in viem (`fromRlp` decode-depth limit). Encoding (`Rlp.from`) is unaffected. `yParity` validation is intentionally **not** included here — ox already validates it via `Signature.assert` (typed envelopes) and `Signature.vToYParity` (legacy).

🤖 Generated with [Amp](https://ampcode.com/threads/T-019f11c2-9b15-775b-964d-340d62f0a299)