### PR TITLE
refactor(tempo)!: remove multisig `config_id` concept

### DIFF
--- a/.changeset/multisig-remove-config-id.md
+++ b/.changeset/multisig-remove-config-id.md
@@ -1,8 +1,8 @@
 ---
-'ox': major
+'ox': patch
 ---
 
-**Breaking:** Removed the TIP-1061 multisig `config_id` concept to match the updated Tempo reference implementation: multisig account addresses now derive directly from the initial config, owner approval digests bind only `account`, the signature wire format is `0x05 || rlp([account, signatures, init?])`, `MultisigConfig.maxOwners` is now 255 with `u8` weights, and owner approvals may be nested multisig signatures.
+`ox/tempo`: Removed the TIP-1061 multisig `config_id` concept to match the updated Tempo reference implementation: multisig account addresses now derive directly from the initial config, owner approval digests bind only `account`, the signature wire format is `0x05 || rlp([account, signatures, init?])`, `MultisigConfig.maxOwners` is now 255 with `u8` weights, and owner approvals may be nested multisig signatures.
 
 ```diff
 - const id = MultisigConfig.toId(genesisConfig)

--- a/.changeset/multisig-remove-config-id.md
+++ b/.changeset/multisig-remove-config-id.md
@@ -1,0 +1,17 @@
+---
+'ox': major
+---
+
+**Breaking:** Removed the TIP-1061 multisig `config_id` concept to match the updated Tempo reference implementation: multisig account addresses now derive directly from the initial config, owner approval digests bind only `account`, the signature wire format is `0x05 || rlp([account, signatures, init?])`, `MultisigConfig.maxOwners` is now 255 with `u8` weights, and owner approvals may be nested multisig signatures.
+
+```diff
+- const id = MultisigConfig.toId(genesisConfig)
+- const account = MultisigConfig.getAddress({ genesisConfigId: id })
++ const account = MultisigConfig.getAddress(genesisConfig)
+
+- MultisigConfig.getSignPayload({ payload, account, genesisConfigId })
++ MultisigConfig.getSignPayload({ payload, account })
+
+- SignatureEnvelope.from({ account, genesisConfigId, signatures })
++ SignatureEnvelope.from({ account, signatures })
+```

--- a/src/tempo/MultisigConfig.test.ts
+++ b/src/tempo/MultisigConfig.test.ts
@@ -30,31 +30,51 @@ describe('from', () => {
   })
 })
 
-describe('genesisConfigId', () => {
+describe('getAddress', () => {
   test('matches independent ground truth', () => {
-    expect(MultisigConfig.toId(singleOwnerConfig)).toMatchInlineSnapshot(
-      `"0xd1f20e1a5bfdd89488f57f68db5bd1aae9a51b510f4a042b2604b57a0b7b471d"`,
+    expect(MultisigConfig.getAddress(singleOwnerConfig)).toMatchInlineSnapshot(
+      `"0x8820d1497eeaf4f68e00b2cfc00a2f3b1dbb00da"`,
     )
   })
 
+  test('matches independent ground truth (salt + weights)', () => {
+    expect(
+      MultisigConfig.getAddress({
+        salt: `0x${'42'.repeat(32)}`,
+        threshold: 2,
+        owners: [
+          { owner: owner1, weight: 1 },
+          { owner: owner2, weight: 2 },
+        ],
+      }),
+    ).toMatchInlineSnapshot(`"0x0773e28146400643e42cb28f6659b74e7c0b451d"`)
+  })
+
   test('is stable across calls', () => {
-    expect(MultisigConfig.toId(singleOwnerConfig)).toBe(
-      MultisigConfig.toId(singleOwnerConfig),
+    expect(MultisigConfig.getAddress(singleOwnerConfig)).toBe(
+      MultisigConfig.getAddress(singleOwnerConfig),
     )
   })
 
   test('differs for a different salt', () => {
-    expect(MultisigConfig.toId(singleOwnerConfig)).not.toBe(
-      MultisigConfig.toId({
+    expect(MultisigConfig.getAddress(singleOwnerConfig)).not.toBe(
+      MultisigConfig.getAddress({
         ...singleOwnerConfig,
         salt: `0x${'42'.repeat(32)}`,
       }),
     )
   })
 
+  test('address is chain-independent', () => {
+    // Derivation does not include chain ID; identical config → identical address.
+    const a = MultisigConfig.getAddress(singleOwnerConfig)
+    const b = MultisigConfig.getAddress(MultisigConfig.from(singleOwnerConfig))
+    expect(a).toBe(b)
+  })
+
   test('throws on invalid config', () => {
     expect(() =>
-      MultisigConfig.toId({
+      MultisigConfig.getAddress({
         threshold: 5,
         owners: singleOwnerConfig.owners,
       }),
@@ -62,50 +82,27 @@ describe('genesisConfigId', () => {
   })
 })
 
-describe('getAddress', () => {
-  test('matches independent ground truth', () => {
-    expect(MultisigConfig.getAddress(singleOwnerConfig)).toMatchInlineSnapshot(
-      `"0x6ca655065b1de473d903eebd50e5cb4996e10468"`,
-    )
-  })
-
-  test('derives from positional config or `{ genesisConfigId }` identically', () => {
-    const genesisConfigId = MultisigConfig.toId(singleOwnerConfig)
-    expect(MultisigConfig.getAddress({ genesisConfigId })).toBe(
-      MultisigConfig.getAddress(singleOwnerConfig),
-    )
-  })
-
-  test('config ID and address are chain-independent', () => {
-    // Derivation does not include chain ID; identical config → identical id/address.
-    const a = MultisigConfig.toId(singleOwnerConfig)
-    const b = MultisigConfig.toId(MultisigConfig.from(singleOwnerConfig))
-    expect(a).toBe(b)
-  })
-})
-
 describe('getSignPayload', () => {
   test('matches independent ground truth', () => {
     expect(
       MultisigConfig.getSignPayload({
-        payload: `0x${'42'.repeat(32)}`,
+        payload: `0x${'de'.repeat(32)}`,
         genesisConfig: singleOwnerConfig,
       }),
     ).toMatchInlineSnapshot(
-      `"0xe3d66f6118b89a67c71c8137c46abf0c829056a46ee6a038a1b42c84529fc17e"`,
+      `"0x7df8cb9fef4fc2aeb271b617d1a4c6178b720ae1d7564f48a363069b7d77a079"`,
     )
   })
 
-  test('behavior: `genesisConfig` and `{account, genesisConfigId}` produce identical digests', () => {
-    const genesisConfigId = MultisigConfig.toId(singleOwnerConfig)
-    const account = MultisigConfig.getAddress({ genesisConfigId })
+  test('behavior: `genesisConfig` and `{ account }` produce identical digests', () => {
+    const account = MultisigConfig.getAddress(singleOwnerConfig)
     const payload = `0x${'42'.repeat(32)}` as const
     expect(
       MultisigConfig.getSignPayload({
         payload,
         genesisConfig: singleOwnerConfig,
       }),
-    ).toBe(MultisigConfig.getSignPayload({ payload, account, genesisConfigId }))
+    ).toBe(MultisigConfig.getSignPayload({ payload, account }))
   })
 })
 
@@ -152,8 +149,16 @@ describe('assert / validate', () => {
     expect(MultisigConfig.validate({ threshold: 1, owners: [] })).toBe(false)
   })
 
+  test('accepts 255 owners', () => {
+    const owners = Array.from({ length: 255 }, (_, i) => ({
+      owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
+      weight: 1,
+    }))
+    expect(MultisigConfig.validate({ threshold: 255, owners })).toBe(true)
+  })
+
   test('too many owners', () => {
-    const owners = Array.from({ length: 11 }, (_, i) => ({
+    const owners = Array.from({ length: 256 }, (_, i) => ({
       owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
       weight: 1,
     }))
@@ -174,6 +179,18 @@ describe('assert / validate', () => {
       MultisigConfig.validate({
         threshold: 2,
         owners: singleOwnerConfig.owners,
+      }),
+    ).toBe(false)
+  })
+
+  test('total weight exceeds u8 max', () => {
+    expect(
+      MultisigConfig.validate({
+        threshold: 255,
+        owners: [
+          { owner: owner1, weight: 128 },
+          { owner: owner2, weight: 128 },
+        ],
       }),
     ).toBe(false)
   })

--- a/src/tempo/MultisigConfig.ts
+++ b/src/tempo/MultisigConfig.ts
@@ -6,7 +6,13 @@ import * as Hex from '../core/Hex.js'
 import type { Compute, OneOf } from '../core/internal/types.js'
 
 /** Maximum number of owners allowed in a native multisig config. */
-export const maxOwners = 10
+export const maxOwners = 255
+
+/**
+ * Maximum number of native multisig signatures in one nested authorization
+ * path, including the top-level transaction signature.
+ */
+export const maxNestingDepth = 3
 
 /** Maximum encoded byte length for one primitive owner approval. */
 export const maxOwnerSignatureBytes = 2049
@@ -20,20 +26,17 @@ export const zeroSalt = `0x${'00'.repeat(32)}` as const
 /** Domain prefix for the native multisig account address derivation. */
 const accountDomain = 'tempo:multisig:account'
 
-/** Domain prefix for the native multisig config ID derivation. */
-const configDomain = 'tempo:multisig:config'
-
 /** Domain prefix for native multisig owner approvals. */
 const signatureDomain = 'tempo:multisig:signature'
 
 /**
- * Native multisig configuration. Determines the permanent config ID and the
- * stable multisig account address.
+ * Native multisig configuration. Determines the stable multisig account
+ * address.
  */
 export type Config<numberType = number> = Compute<{
   /**
-   * Caller-chosen 32-byte salt mixed into the permanent config ID. Defaults to
-   * the zero salt (`MultisigConfig.zeroSalt`) when omitted.
+   * Caller-chosen 32-byte salt mixed into the derived account address.
+   * Defaults to the zero salt (`MultisigConfig.zeroSalt`) when omitted.
    */
   salt?: Hex.Hex | undefined
   /** Minimum total owner weight required to authorize a transaction. */
@@ -44,7 +47,7 @@ export type Config<numberType = number> = Compute<{
 
 /** Native multisig owner entry. */
 export type Owner<numberType = number> = {
-  /** Owner address (recovered from the owner's primitive signature). */
+  /** Owner address (recovered from the owner's approval). */
   owner: Address.Address
   /** Nonzero owner weight. */
   weight: numberType
@@ -60,9 +63,9 @@ export type Tuple = readonly [
 /**
  * Asserts that a native multisig {@link ox#MultisigConfig.Config} is valid.
  *
- * Mirrors the Tempo `validate_multisig_config` rules: owners non-empty and
+ * Mirrors the Tempo `InitMultisig::validate` rules: owners non-empty and
  * `<= maxOwners`, strictly ascending unique nonzero owner addresses, nonzero
- * owner weights, `threshold >= 1`, total weight `<= u32::MAX`, and
+ * owner weights, `threshold >= 1`, total weight `<= 255` (u8 max), and
  * `threshold <= total weight`.
  *
  * @example
@@ -112,9 +115,9 @@ export function assert<numberType = number>(config: Config<numberType>): void {
     totalWeight += Number(owner.weight)
   }
 
-  if (totalWeight > 0xffffffff)
+  if (totalWeight > 0xff)
     throw new InvalidConfigError({
-      reason: 'total owner weight exceeds u32 max',
+      reason: 'total owner weight exceeds u8 max',
     })
   if (Number(threshold) > totalWeight)
     throw new InvalidConfigError({
@@ -130,7 +133,7 @@ export declare namespace assert {
  * Normalizes a native multisig {@link ox#MultisigConfig.Config}.
  *
  * Sorts owners into strictly ascending `owner` address order (the canonical
- * form required for config ID derivation) and asserts the config is valid.
+ * form required for account derivation) and asserts the config is valid.
  *
  * @example
  * ```ts twoslash
@@ -206,7 +209,11 @@ export function fromTuple(tuple: Tuple): Config {
 /**
  * Derives the stable native multisig account address.
  *
- * `keccak256("tempo:multisig:account" || config_id)[12:32]`.
+ * Preimage (fixed-width big-endian, **not** RLP):
+ * `keccak256("tempo:multisig:account" || salt || u8(threshold) || u8(owners.length) || (owner || u8(weight)) for each owner)[12:32]`.
+ *
+ * The address is derived once from the initial (bootstrap) config and never
+ * changes — config updates do not affect it.
  *
  * @example
  * ```ts twoslash
@@ -225,50 +232,37 @@ export function fromTuple(tuple: Tuple): Config {
  * const address = MultisigConfig.getAddress(genesisConfig)
  * ```
  *
- * @example
- * ### From an genesis config ID
- *
- * If you already have the permanent `genesisConfigId`, pass it directly:
- *
- * ```ts twoslash
- * import { MultisigConfig } from 'ox/tempo'
- *
- * const genesisConfigId = `0x${'00'.repeat(32)}` as const
- *
- * const address = MultisigConfig.getAddress({
- *   genesisConfigId
- * })
- * ```
- *
- * @param value - The genesis config (positional) or `{ genesisConfigId }`.
+ * @param config - The initial (bootstrap) multisig config.
  * @returns The multisig account address.
  */
-export function getAddress(value: getAddress.Value): Address.Address {
-  const id =
-    typeof value === 'object' && 'genesisConfigId' in value
-      ? value.genesisConfigId
-      : toId(value)
-  const hash = Hash.keccak256(Hex.concat(Hex.fromString(accountDomain), id))
-  return Address.from(Hex.slice(hash, 12, 32))
+export function getAddress(config: Config): Address.Address {
+  assert(config)
+  const hash = Hash.keccak256(
+    Hex.concat(
+      Hex.fromString(accountDomain),
+      Hex.padLeft(config.salt ?? zeroSalt, 32),
+      Hex.fromNumber(config.threshold, { size: 1 }),
+      Hex.fromNumber(config.owners.length, { size: 1 }),
+      ...config.owners.flatMap((owner) => [
+        owner.owner,
+        Hex.fromNumber(owner.weight, { size: 1 }),
+      ]),
+    ),
+  )
+  const account = Address.from(Hex.slice(hash, 12, 32))
+  if (Hex.toBigInt(account) === 0n)
+    throw new InvalidConfigError({ reason: 'derived account cannot be zero' })
+  return account
 }
 
 export declare namespace getAddress {
-  type Value =
-    | Config
-    | {
-        /**
-         * The permanent genesis config ID (`MultisigConfig.toId(genesisConfig)`).
-         * Config updates never change this value, so it identifies the
-         * account permanently.
-         */
-        genesisConfigId: Hex.Hex
-      }
-
   type ErrorType =
-    | toId.ErrorType
+    | assert.ErrorType
     | Address.from.ErrorType
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
+    | Hex.fromNumber.ErrorType
+    | Hex.fromString.ErrorType
     | Hex.slice.ErrorType
     | Errors.GlobalErrorType
 }
@@ -276,14 +270,16 @@ export declare namespace getAddress {
 /**
  * Computes the digest a native multisig owner approves (signs).
  *
- * `keccak256("tempo:multisig:signature" || inner_digest || account || config_id)`,
+ * `keccak256("tempo:multisig:signature" || inner_digest || account)`,
  * where `inner_digest` is the transaction sign payload
  * ({@link ox#TxEnvelopeTempo.(getSignPayload:function)}).
  *
- * The digest is always keyed on the permanent `account`/`genesisConfigId`
- * derived from the genesis (bootstrap) config — config updates never change
- * these values, so the genesis config is the correct input even for
- * post-update transactions.
+ * The digest is keyed on the permanent `account` derived from the genesis
+ * (bootstrap) config — config updates never change it, so the genesis config
+ * is the correct input even for post-update transactions.
+ *
+ * For a nested multisig owner approval, the parent digest becomes the nested
+ * approval's `payload`, with the nested multisig `account`.
  *
  * @example
  * ```ts twoslash
@@ -311,10 +307,10 @@ export declare namespace getAddress {
  * ```
  *
  * @example
- * ### From `account` + `genesisConfigId`
+ * ### From `account`
  *
- * If you already have the permanent `account` and `genesisConfigId` (for
- * example, recovered from a stored envelope), pass them directly:
+ * If you already have the permanent `account` (for example, recovered from a
+ * stored envelope), pass it directly:
  *
  * ```ts twoslash
  * import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
@@ -328,7 +324,6 @@ export declare namespace getAddress {
  *     }
  *   ]
  * })
- * const genesisConfigId = MultisigConfig.toId(genesisConfig)
  * const account = MultisigConfig.getAddress(genesisConfig)
  *
  * const envelope = TxEnvelopeTempo.from({
@@ -338,8 +333,7 @@ export declare namespace getAddress {
  *
  * const digest = MultisigConfig.getSignPayload({
  *   payload: TxEnvelopeTempo.getSignPayload(envelope),
- *   account,
- *   genesisConfigId
+ *   account
  * })
  * ```
  *
@@ -352,17 +346,8 @@ export function getSignPayload(value: getSignPayload.Value): Hex.Hex {
     'account' in value && value.account
       ? value.account
       : getAddress((value as { genesisConfig: Config }).genesisConfig)
-  const genesisConfigId =
-    'genesisConfigId' in value && value.genesisConfigId
-      ? value.genesisConfigId
-      : toId((value as { genesisConfig: Config }).genesisConfig)
   return Hash.keccak256(
-    Hex.concat(
-      Hex.fromString(signatureDomain),
-      Hex.from(payload),
-      account,
-      genesisConfigId,
-    ),
+    Hex.concat(Hex.fromString(signatureDomain), Hex.from(payload), account),
   )
 }
 
@@ -374,16 +359,13 @@ export declare namespace getSignPayload {
     | {
         /** The native multisig account address. */
         account: Address.Address
-        /** The permanent config ID. */
-        genesisConfigId: Hex.Hex
       }
     | {
         /**
          * The initial multisig config (the bootstrap config that derived the
-         * permanent `account` and `genesisConfigId`). Used to derive both values
-         * automatically. Config updates never change `account`/`genesisConfigId`,
-         * so the genesis config is also the correct input for post-update
-         * transactions.
+         * permanent `account`). Used to derive the account automatically.
+         * Config updates never change `account`, so the genesis config is
+         * also the correct input for post-update transactions.
          */
         genesisConfig: Config
       }
@@ -391,66 +373,9 @@ export declare namespace getSignPayload {
 
   type ErrorType =
     | getAddress.ErrorType
-    | toId.ErrorType
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
     | Hex.from.ErrorType
-    | Errors.GlobalErrorType
-}
-
-/**
- * Derives the permanent config ID for a native multisig
- * {@link ox#MultisigConfig.Config}.
- *
- * Preimage (fixed-width big-endian, **not** RLP):
- * `keccak256("tempo:multisig:config" || salt || be_u32(threshold) || be_u32(owners.length) || (owner || be_u32(weight)) for each owner)`.
- *
- * @example
- * ```ts twoslash
- * import { MultisigConfig } from 'ox/tempo'
- *
- * const config = MultisigConfig.from({
- *   threshold: 1,
- *   owners: [
- *     {
- *       owner: '0x1111111111111111111111111111111111111111',
- *       weight: 1
- *     }
- *   ]
- * })
- *
- * const genesisConfigId = MultisigConfig.toId(config)
- * ```
- *
- * @param config - The multisig config.
- * @returns The 32-byte config ID.
- */
-export function toId(config: Config): Hex.Hex {
-  assert(config)
-  const id = Hash.keccak256(
-    Hex.concat(
-      Hex.fromString(configDomain),
-      Hex.padLeft(config.salt ?? zeroSalt, 32),
-      Hex.fromNumber(config.threshold, { size: 4 }),
-      Hex.fromNumber(config.owners.length, { size: 4 }),
-      ...config.owners.flatMap((owner) => [
-        owner.owner,
-        Hex.fromNumber(owner.weight, { size: 4 }),
-      ]),
-    ),
-  )
-  if (Hex.toBigInt(id) === 0n)
-    throw new InvalidConfigError({ reason: 'config ID cannot be zero' })
-  return id
-}
-
-export declare namespace toId {
-  type ErrorType =
-    | assert.ErrorType
-    | Hash.keccak256.ErrorType
-    | Hex.concat.ErrorType
-    | Hex.fromNumber.ErrorType
-    | Hex.fromString.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -3,6 +3,7 @@ import {
   Hex,
   P256,
   PublicKey,
+  Rlp,
   Secp256k1,
   Signature,
   WebAuthnP256,
@@ -1125,7 +1126,7 @@ describe('from', () => {
       ],
     })
 
-    test('behavior: derives `account`/`genesisConfigId` from `genesisConfig`', () => {
+    test('behavior: derives `account` from `genesisConfig`', () => {
       const envelope = SignatureEnvelope.from({
         genesisConfig,
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
@@ -1134,7 +1135,6 @@ describe('from', () => {
       expect(envelope).toMatchObject({
         type: 'multisig',
         account: MultisigConfig.getAddress(genesisConfig),
-        genesisConfigId: MultisigConfig.toId(genesisConfig),
       })
       expect('genesisConfig' in envelope).toBe(false)
       expect((envelope as SignatureEnvelope.Multisig).init).toBeUndefined()
@@ -1171,19 +1171,16 @@ describe('from', () => {
       expect((envelope as SignatureEnvelope.Multisig).init).toEqual(otherConfig)
     })
 
-    test('behavior: `{account, genesisConfigId}` form still works', () => {
+    test('behavior: `{ account }` form still works', () => {
       const account = MultisigConfig.getAddress(genesisConfig)
-      const genesisConfigId = MultisigConfig.toId(genesisConfig)
       const envelope = SignatureEnvelope.from({
         account,
-        genesisConfigId,
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
       })
 
       expect(envelope).toMatchObject({
         type: 'multisig',
         account,
-        genesisConfigId,
       })
     })
   })
@@ -1860,9 +1857,8 @@ describe('sortMultisigApprovals', () => {
     expect(recovered).toEqual(ascending.map((owner) => owner.address))
   })
 
-  test('behavior: `genesisConfig` and `{account, genesisConfigId}` produce identical ordering', () => {
+  test('behavior: `genesisConfig` and `{ account }` produce identical ordering', () => {
     const account = MultisigConfig.getAddress(genesisConfig)
-    const genesisConfigId = MultisigConfig.toId(genesisConfig)
     const signatures = owners.map((owner) => owner.signature)
 
     const fromConfig = SignatureEnvelope.sortMultisigApprovals({
@@ -1870,13 +1866,12 @@ describe('sortMultisigApprovals', () => {
       payload,
       signatures,
     })
-    const fromIds = SignatureEnvelope.sortMultisigApprovals({
+    const fromAccount = SignatureEnvelope.sortMultisigApprovals({
       account,
-      genesisConfigId,
       payload,
       signatures,
     })
-    expect(fromConfig).toEqual(fromIds)
+    expect(fromConfig).toEqual(fromAccount)
   })
 })
 
@@ -2883,8 +2878,6 @@ describe('CoercionError', () => {
 
 describe('multisig', () => {
   const account = '0x8ba6d26ff5c4e82ba0c8caf8c8ca794e1489a7ae'
-  const genesisConfigId =
-    '0x01781fe551182476f2422c759e82d81c92e3263737afbbad57def6e8b69d21f5'
 
   // P256 signatures do not carry `yParity` in the wire format, so use a clean
   // inner signature for round-trip equality checks.
@@ -2897,7 +2890,6 @@ describe('multisig', () => {
   const envelope = SignatureEnvelope.from({
     type: 'multisig',
     account,
-    genesisConfigId,
     signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
   })
 
@@ -2906,9 +2898,30 @@ describe('multisig', () => {
     expect(serialized.startsWith('0x05')).toBe(true)
   })
 
+  test('serialize: wire shape is `0x05 || rlp([account, signatures])`', () => {
+    const deterministic = SignatureEnvelope.from({
+      type: 'multisig',
+      account,
+      signatures: [innerP256],
+    })
+    expect(SignatureEnvelope.serialize(deterministic)).toMatchInlineSnapshot(
+      `"0x05f89b948ba6d26ff5c4e82ba0c8caf8c8ca794e1489a7aef884b88201ccbb3485d4726235f13cb15ef394fb7158179fb7b1925eccec0147671090c52e77c3c53373cc1e3b05e7c23f609deb17cea8fe097300c45411237e9fe4166b35ad8ac16e167d6992c3e120d7f17d2376bc1cbcf30c46ba6dd00ce07303e742f511edf6ce1c32de66846f56afa7be1cbd729bc35750b6d0cdcf3ec9d75461aba001"`,
+    )
+  })
+
   test('serialize/deserialize round-trip', () => {
     const serialized = SignatureEnvelope.serialize(envelope)
     expect(SignatureEnvelope.deserialize(serialized)).toEqual(envelope)
+  })
+
+  test('deserialize: rejects the empty `init` placeholder (`0x80`)', () => {
+    const withPlaceholder = Hex.concat(
+      '0x05',
+      Rlp.fromHex([account, [SignatureEnvelope.serialize(innerP256)], '0x']),
+    )
+    expect(() => SignatureEnvelope.deserialize(withPlaceholder)).toThrowError(
+      SignatureEnvelope.InvalidSerializedError,
+    )
   })
 
   test('getType', () => {
@@ -2936,6 +2949,97 @@ describe('multisig', () => {
     ).toThrowError()
   })
 
+  test('assert: rejects keychain owner approvals', () => {
+    expect(() =>
+      SignatureEnvelope.assert({
+        type: 'multisig',
+        account,
+        signatures: [signature_keychain_secp256k1],
+      } as never),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: keychain owner approvals are not allowed.]`,
+    )
+  })
+
+  describe('nested approvals', () => {
+    const nestedAccount = '0x1111111111111111111111111111111111111111'
+    const nested = SignatureEnvelope.from({
+      type: 'multisig',
+      account: nestedAccount,
+      signatures: [innerP256],
+    })
+
+    test('serialize/deserialize round-trip with a nested multisig approval', () => {
+      const parent = SignatureEnvelope.from({
+        type: 'multisig',
+        account,
+        signatures: [innerP256, nested],
+      })
+      const serialized = SignatureEnvelope.serialize(parent)
+      expect(SignatureEnvelope.deserialize(serialized)).toEqual(parent)
+    })
+
+    test('assert: accepts the maximum nesting depth', () => {
+      const depth3 = SignatureEnvelope.from({
+        type: 'multisig',
+        account,
+        signatures: [
+          SignatureEnvelope.from({
+            type: 'multisig',
+            account: nestedAccount,
+            signatures: [nested],
+          }),
+        ],
+      })
+      expect(() => SignatureEnvelope.assert(depth3)).not.toThrowError()
+    })
+
+    test('assert: rejects nesting deeper than the maximum', () => {
+      const depth4 = SignatureEnvelope.from({
+        type: 'multisig',
+        account,
+        signatures: [
+          SignatureEnvelope.from({
+            type: 'multisig',
+            account: nestedAccount,
+            signatures: [
+              SignatureEnvelope.from({
+                type: 'multisig',
+                account: nestedAccount,
+                signatures: [nested],
+              }),
+            ],
+          }),
+        ],
+      })
+      expect(() =>
+        SignatureEnvelope.assert(depth4),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig nesting depth exceeds 3.]`,
+      )
+    })
+
+    test('assert: rejects nested approvals carrying `init`', () => {
+      expect(() =>
+        SignatureEnvelope.assert({
+          type: 'multisig',
+          account,
+          signatures: [
+            {
+              ...nested,
+              init: {
+                threshold: 1,
+                owners: [{ owner: nestedAccount, weight: 1 }],
+              },
+            },
+          ],
+        } as never),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: nested multisig owner approvals cannot carry \`init\`.]`,
+      )
+    })
+  })
+
   describe('init (bootstrap)', () => {
     const init = {
       salt: `0x${'00'.repeat(32)}` as const,
@@ -2951,7 +3055,6 @@ describe('multisig', () => {
     const bootstrapEnvelope = SignatureEnvelope.from({
       type: 'multisig',
       account,
-      genesisConfigId,
       signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
       init,
     })
@@ -2967,7 +3070,6 @@ describe('multisig', () => {
       const salted = SignatureEnvelope.from({
         type: 'multisig',
         account,
-        genesisConfigId,
         signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
         init: { ...init, salt: `0x${'42'.repeat(32)}` },
       })
@@ -3021,7 +3123,6 @@ describe('multisig', () => {
         SignatureEnvelope.assert({
           type: 'multisig',
           account,
-          genesisConfigId,
           signatures: [],
           init: { threshold: 1, owners: [] },
         } as never),

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -86,7 +86,6 @@ export type GetType<
               ? 'keychain'
               : envelope extends {
                     account: Address.Address
-                    genesisConfigId: `0x${string}`
                     signatures: any
                   }
                 ? 'multisig'
@@ -162,9 +161,10 @@ export type KeychainRpc = {
 /**
  * Native multisig signature (type `0x05`).
  *
- * Wraps a set of primitive owner approvals (secp256k1, p256, or webAuthn) over the
- * multisig owner approval digest. The transaction sender is the derived `account`,
- * authorized once the recovered owner weights meet the configured threshold.
+ * Wraps a set of owner approvals (secp256k1, p256, webAuthn, or nested
+ * multisig) over the multisig owner approval digest. The transaction sender is
+ * the derived `account`, authorized once the recovered owner weights meet the
+ * configured threshold.
  *
  * [TIP-1061](https://tips.sh/1061)
  */
@@ -172,9 +172,11 @@ export type Multisig<numberType = number> = {
   type: 'multisig'
   /** Native multisig account address. */
   account: Address.Address
-  /** Permanent config ID derived from the initial multisig config. */
-  genesisConfigId: Hex.Hex
-  /** Primitive owner approvals over the multisig owner approval digest. */
+  /**
+   * Owner approvals over the multisig owner approval digest. Each approval is
+   * either a primitive signature or a nested multisig signature (keychain
+   * approvals are invalid).
+   */
   signatures: readonly SignatureEnvelope<numberType>[]
   /**
    * Initial native multisig config for bootstrapping this account. Present only on
@@ -188,14 +190,8 @@ export type MultisigRpc = {
   type: 'multisig'
   account: Address.Address
   /**
-   * The permanent multisig config ID (TIP-1061 wire field `config_id`).
-   * Maps to `genesisConfigId` on the typed
-   * {@link ox#SignatureEnvelope.Multisig} envelope.
-   */
-  configId: Hex.Hex
-  /**
-   * Encoded primitive owner approvals (raw serialized signatures), matching the
-   * node's `Vec<Bytes>` representation.
+   * Encoded owner approvals (raw serialized signatures), matching the node's
+   * `Vec<Bytes>` representation.
    */
   signatures: readonly Serialized[]
   init?: MultisigConfig.Config | undefined
@@ -345,11 +341,24 @@ export function assert(envelope: PartialBy<SignatureEnvelope, 'type'>): void {
     const multisig = envelope as Multisig
     const missing: string[] = []
     if (!multisig.account) missing.push('account')
-    if (!multisig.genesisConfigId) missing.push('genesisConfigId')
     if (!Array.isArray(multisig.signatures)) missing.push('signatures')
     if (missing.length > 0)
       throw new MissingPropertiesError({ envelope, missing, type: 'multisig' })
-    for (const inner of multisig.signatures) assert(inner)
+    if (getNestingDepth(multisig) > MultisigConfig.maxNestingDepth)
+      throw new InvalidMultisigApprovalError({
+        reason: `multisig nesting depth exceeds ${MultisigConfig.maxNestingDepth}`,
+      })
+    for (const inner of multisig.signatures) {
+      if (inner.type === 'keychain')
+        throw new InvalidMultisigApprovalError({
+          reason: 'keychain owner approvals are not allowed',
+        })
+      if (inner.type === 'multisig' && inner.init)
+        throw new InvalidMultisigApprovalError({
+          reason: 'nested multisig owner approvals cannot carry `init`',
+        })
+      assert(inner)
+    }
     if (multisig.init) MultisigConfig.assert(multisig.init)
     return
   }
@@ -358,10 +367,20 @@ export function assert(envelope: PartialBy<SignatureEnvelope, 'type'>): void {
 export declare namespace assert {
   type ErrorType =
     | CoercionError
+    | InvalidMultisigApprovalError
     | MissingPropertiesError
     | MultisigConfig.assert.ErrorType
     | Signature.assert.ErrorType
     | Errors.GlobalErrorType
+}
+
+// Returns the deepest multisig path length within a multisig envelope.
+function getNestingDepth(envelope: Multisig): number {
+  let deepest = 0
+  for (const inner of envelope.signatures)
+    if (inner.type === 'multisig')
+      deepest = Math.max(deepest, getNestingDepth(inner))
+  return 1 + deepest
 }
 
 /**
@@ -630,24 +649,26 @@ export function deserialize(value: Serialized): SignatureEnvelope {
   }
 
   if (typeId === serializedMultisigType) {
-    // Wire format: `0x05 || rlp([account, genesisConfigId, signatures, init])`. `init`
-    // is optional: absent when the element is missing or the `0x80` placeholder
-    // (decoded as the empty string `0x`), otherwise the bootstrap config list.
-    const [account, genesisConfigId, signatures, init] = Rlp.toHex(data) as [
-      Hex.Hex,
+    // Wire format: `0x05 || rlp([account, signatures, init?])`. `init` is a
+    // trailing optional: the bootstrap config list when present, otherwise
+    // omitted entirely (the empty `0x80` placeholder is rejected).
+    const [account, signatures, init] = Rlp.toHex(data) as [
       Hex.Hex,
       readonly Hex.Hex[],
       (Hex.Hex | MultisigConfig.Tuple)?,
     ]
+    if (typeof init !== 'undefined' && !Array.isArray(init))
+      throw new InvalidSerializedError({
+        reason:
+          'Invalid multisig `init`: expected the bootstrap config list or an omitted trailing element',
+        serialized,
+      })
     return {
       type: 'multisig',
       account,
-      genesisConfigId,
       signatures: signatures.map((signature) => deserialize(signature)),
-      ...(init && init !== '0x'
-        ? {
-            init: MultisigConfig.fromTuple(init as MultisigConfig.Tuple),
-          }
+      ...(init
+        ? { init: MultisigConfig.fromTuple(init as MultisigConfig.Tuple) }
         : {}),
     } satisfies Multisig
   }
@@ -786,9 +807,9 @@ export function deserialize(value: Serialized): SignatureEnvelope {
  * @example
  * ### Multisig (from genesis config)
  *
- * Pass `genesisConfig` to derive `account` and `genesisConfigId` automatically.
- * Set `init: true` to opt into bootstrap (uses `genesisConfig` as the
- * bootstrap `init`); omit `init` for subsequent (non-bootstrap) transactions.
+ * Pass `genesisConfig` to derive `account` automatically. Set `init: true` to
+ * opt into bootstrap (uses `genesisConfig` as the bootstrap `init`); omit
+ * `init` for subsequent (non-bootstrap) transactions.
  *
  * ```ts twoslash
  * import { Secp256k1 } from 'ox'
@@ -849,17 +870,11 @@ export function from<const value extends from.Value>(
       init?: MultisigConfig.Config | boolean | undefined
     }
     const { genesisConfig, init, ...rest } = multisig
-    // Derive `account`/`genesisConfigId` from `genesisConfig` when not provided
-    // explicitly.
+    // Derive `account` from `genesisConfig` when not provided explicitly.
     const account = (() => {
       if (rest.account) return rest.account
       if (genesisConfig) return MultisigConfig.getAddress(genesisConfig)
       return rest.account
-    })()
-    const genesisConfigId = (() => {
-      if (rest.genesisConfigId) return rest.genesisConfigId
-      if (genesisConfig) return MultisigConfig.toId(genesisConfig)
-      return rest.genesisConfigId
     })()
     // `init: true` opts into bootstrap using the supplied `genesisConfig`.
     // Otherwise, `init` is treated as the explicit bootstrap config (or
@@ -868,7 +883,6 @@ export function from<const value extends from.Value>(
     return {
       ...rest,
       account,
-      genesisConfigId,
       signatures: rest.signatures.map((signature) => from(signature)),
       // Normalize the bootstrap config (sorts owners, defaults the salt) so the
       // in-memory envelope matches what `deserialize` reconstructs.
@@ -920,9 +934,9 @@ export declare namespace from {
   }
 
   /**
-   * Multisig envelope input variant where `account` and `genesisConfigId` are derived
-   * from the supplied `genesisConfig`. Pass `init: true` to opt into bootstrap
-   * (uses `genesisConfig` as the bootstrap `init`); omit `init` for subsequent
+   * Multisig envelope input variant where `account` is derived from the
+   * supplied `genesisConfig`. Pass `init: true` to opt into bootstrap (uses
+   * `genesisConfig` as the bootstrap `init`); omit `init` for subsequent
    * (non-bootstrap) transactions.
    */
   type MultisigFromGenesisConfig = {
@@ -1063,17 +1077,12 @@ export function fromRpc(envelope: SignatureEnvelopeRpc): SignatureEnvelope {
 
   if (
     envelope.type === 'multisig' ||
-    ('account' in envelope &&
-      'configId' in envelope &&
-      'signatures' in envelope)
+    ('account' in envelope && 'signatures' in envelope)
   ) {
     const multisig = envelope as MultisigRpc
     return {
       type: 'multisig',
       account: multisig.account,
-      // Map RPC wire field `configId` (TIP-1061 spec name) to the typed
-      // envelope's `genesisConfigId`.
-      genesisConfigId: multisig.configId,
       // Owner approvals are raw serialized signatures (node `Vec<Bytes>`).
       signatures: multisig.signatures.map((signature) =>
         deserialize(signature),
@@ -1164,8 +1173,7 @@ export function getType<
 
   // Detect Multisig signature
   if (
-    (('account' in envelope && 'genesisConfigId' in envelope) ||
-      'genesisConfig' in envelope) &&
+    ('account' in envelope || 'genesisConfig' in envelope) &&
     'signatures' in envelope
   )
     return 'multisig' as never
@@ -1269,17 +1277,15 @@ export function serialize(
 
   if (type === 'multisig') {
     const multisig = envelope as Multisig
-    // Format: `0x05 || rlp([account, genesisConfigId, signatures, init])`, where each
-    // owner approval is an encoded primitive signature. `init` is the bootstrap
-    // config (an RLP list) when present, otherwise the canonical empty-string
-    // placeholder (`0x` → RLP `0x80`).
+    // Format: `0x05 || rlp([account, signatures, init?])`, where each owner
+    // approval is an encoded signature. `init` is a trailing optional: the
+    // bootstrap config list when present, otherwise omitted entirely.
     return Hex.concat(
       serializedMultisigType,
       Rlp.fromHex([
         multisig.account,
-        multisig.genesisConfigId,
         multisig.signatures.map((signature) => serialize(signature)),
-        multisig.init ? MultisigConfig.toTuple(multisig.init) : '0x',
+        ...(multisig.init ? [MultisigConfig.toTuple(multisig.init)] : []),
       ]),
       options.magic ? magicBytes : '0x',
     )
@@ -1307,10 +1313,10 @@ export declare namespace serialize {
  * ({@link ox#MultisigConfig.(getSignPayload:function)}), so the signer of
  * every approval is recovered against that digest and the list is sorted by the
  * recovered owner address. Works for any owner key type (secp256k1, p256,
- * webAuthn, keychain).
+ * webAuthn).
  *
- * Config updates never change `account`/`genesisConfigId`, so the genesis
- * config is the correct input even for post-update transactions.
+ * Config updates never change `account`, so the genesis config is the correct
+ * input even for post-update transactions.
  *
  * @example
  * ```ts twoslash
@@ -1370,12 +1376,7 @@ export function sortMultisigApprovals(
   const digest = MultisigConfig.getSignPayload(
     'genesisConfig' in value && value.genesisConfig
       ? { payload, genesisConfig: value.genesisConfig }
-      : {
-          payload,
-          account: (value as { account: Address.Address }).account,
-          genesisConfigId: (value as { genesisConfigId: Hex.Hex })
-            .genesisConfigId,
-        },
+      : { payload, account: (value as { account: Address.Address }).account },
   )
   // Recover each signer once (decorate–sort–undecorate) rather than inside the
   // comparator.
@@ -1392,20 +1393,17 @@ export declare namespace sortMultisigApprovals {
   type Value = {
     /** The inner transaction sign payload (`tx.signature_hash()`). */
     payload: Hex.Hex | Bytes.Bytes
-    /** The primitive owner approvals to order. */
+    /** The owner approvals to order. */
     signatures: readonly SignatureEnvelope[]
   } & OneOf<
     | {
         /** The native multisig account address. */
         account: Address.Address
-        /** The permanent config ID. */
-        genesisConfigId: Hex.Hex
       }
     | {
         /**
          * The initial multisig config (the bootstrap config that derived the
-         * permanent `account` and `genesisConfigId`). Used to derive both values
-         * automatically.
+         * permanent `account`). Used to derive the account automatically.
          */
         genesisConfig: MultisigConfig.Config
       }
@@ -1493,9 +1491,6 @@ export function toRpc(envelope: toRpc.Input): SignatureEnvelopeRpc {
     return {
       type: 'multisig',
       account: multisig.account,
-      // Map the typed envelope's `genesisConfigId` to the RPC wire field
-      // `configId` (TIP-1061 spec name).
-      configId: multisig.genesisConfigId,
       // Owner approvals are raw serialized signatures (node `Vec<Bytes>`).
       signatures: multisig.signatures.map((signature) => serialize(signature)),
       ...(multisig.init ? { init: multisig.init } : {}),
@@ -1777,6 +1772,16 @@ export class InvalidSerializedError extends Errors.BaseError {
     super(`Unable to deserialize signature envelope: ${reason}`, {
       metaMessages: [`Serialized: ${serialized}`],
     })
+  }
+}
+
+/**
+ * Error thrown when a native multisig owner approval is invalid.
+ */
+export class InvalidMultisigApprovalError extends Errors.BaseError {
+  override readonly name = 'SignatureEnvelope.InvalidMultisigApprovalError'
+  constructor({ reason }: { reason: string }) {
+    super(`Invalid native multisig owner approval: ${reason}.`)
   }
 }
 

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -3204,4 +3204,224 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
       }),
     ).rejects.toThrow()
   })
+
+  test('behavior: keychain access key (authorize via AccountKeychain + spend)', async () => {
+    const { account, genesisConfig, ownerKeys } = setup({
+      count: 2,
+      threshold: 2,
+    })
+
+    await fundAddress(client, { address: account })
+
+    // Fresh secp256k1 access key for the multisig account.
+    const access = (() => {
+      const privateKey = Secp256k1.randomPrivateKey()
+      const address = Address.fromPublicKey(
+        Secp256k1.getPublicKey({ privateKey }),
+      )
+      return { address, privateKey } as const
+    })()
+
+    // Bootstrap the multisig (nonce 0).
+    const bootstrap = TxEnvelopeTempo.from({
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      chainId,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      nonce: 0n,
+      gas: 2_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+
+    const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
+      signature: SignatureEnvelope.from({
+        genesisConfig,
+        init: true,
+        signatures: approve({
+          genesisConfig,
+          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
+          signers: ownerKeys,
+        }),
+      }),
+    })
+
+    const bootstrap_receipt = (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [bootstrap_signed],
+      })
+      .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+    expect(bootstrap_receipt.status).toBe('success')
+
+    // Authorize the access key (nonce 1): multisig transactions cannot carry
+    // a TIP-1049 `keyAuthorization`, so the multisig account calls the
+    // AccountKeychain precompile's `authorizeKey` directly.
+    const authorizeKey = AbiFunction.from(
+      'function authorizeKey(address keyId, uint8 signatureType, (uint64 expiry, bool enforceLimits, (address token, uint256 amount, uint64 period)[] limits, bool allowAnyCalls, (address target, (bytes4 selector, address[] recipients)[] selectorRules)[] allowedCalls) config)',
+    )
+
+    const authorize = TxEnvelopeTempo.from({
+      calls: [
+        {
+          to: '0xaaaaaaaa00000000000000000000000000000000',
+          data: AbiFunction.encodeData(authorizeKey, [
+            access.address,
+            0, // secp256k1
+            {
+              expiry: 18446744073709551615n, // u64 max (never expires)
+              enforceLimits: false,
+              limits: [],
+              allowAnyCalls: true,
+              allowedCalls: [],
+            },
+          ]),
+        },
+      ],
+      chainId,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      nonce: 1n,
+      gas: 2_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+
+    const authorize_signed = TxEnvelopeTempo.serialize(authorize, {
+      signature: SignatureEnvelope.from({
+        genesisConfig,
+        signatures: approve({
+          genesisConfig,
+          payload: TxEnvelopeTempo.getSignPayload(authorize),
+          signers: ownerKeys,
+        }),
+      }),
+    })
+
+    const authorize_receipt = (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [authorize_signed],
+      })
+      .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+    expect(authorize_receipt.status).toBe('success')
+    expect(authorize_receipt.from).toBe(account)
+
+    // Spend with the access key (nonce 2): outer keychain signature with the
+    // multisig account as `userAddress` — no owner approvals involved.
+    const nonce = await getTransactionCount(client, {
+      address: account,
+      blockTag: 'pending',
+    })
+
+    const spend = TxEnvelopeTempo.from({
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      chainId,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      nonce: BigInt(nonce),
+      gas: 2_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+
+    const spend_signature = Secp256k1.sign({
+      payload: TxEnvelopeTempo.getSignPayload(spend, { from: account }),
+      privateKey: access.privateKey,
+    })
+
+    const spend_signed = TxEnvelopeTempo.serialize(spend, {
+      signature: SignatureEnvelope.from({
+        userAddress: account,
+        inner: SignatureEnvelope.from(spend_signature),
+        type: 'keychain',
+      }),
+    })
+
+    const spend_receipt = (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [spend_signed],
+      })
+      .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+    expect(spend_receipt.status).toBe('success')
+    expect(spend_receipt.from).toBe(account)
+
+    {
+      const response = await client
+        .request({
+          method: 'eth_getTransactionByHash',
+          params: [spend_receipt.transactionHash],
+        })
+        .then((tx) => Transaction.fromRpc(tx as any))
+      if (!response) throw new Error()
+      expect(response.from).toBe(account)
+      expect(response.signature?.type).toBe('keychain')
+      expect(
+        (response.signature as SignatureEnvelope.Keychain | undefined)
+          ?.userAddress,
+      ).toBe(account)
+    }
+  })
+
+  test('behavior: rejects `keyAuthorization` on multisig transactions', async () => {
+    const { account, genesisConfig, ownerKeys } = setup({
+      count: 1,
+      threshold: 1,
+    })
+
+    await fundAddress(client, { address: account })
+
+    const access = (() => {
+      const privateKey = Secp256k1.randomPrivateKey()
+      const address = Address.fromPublicKey(
+        Secp256k1.getPublicKey({ privateKey }),
+      )
+      return { address, privateKey } as const
+    })()
+
+    // TIP-1049 key authorizations are only valid on primitive/keychain
+    // transactions; multisig accounts must call the AccountKeychain
+    // precompile instead.
+    const keyAuth = KeyAuthorization.from({
+      address: access.address,
+      chainId: BigInt(chainId),
+      type: 'secp256k1',
+    })
+    const keyAuth_signed = KeyAuthorization.from(keyAuth, {
+      signature: SignatureEnvelope.from(
+        Secp256k1.sign({
+          payload: KeyAuthorization.getSignPayload(keyAuth),
+          privateKey: ownerKeys[0]!.privateKey,
+        }),
+      ),
+    })
+
+    const bootstrap = TxEnvelopeTempo.from({
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      chainId,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      keyAuthorization: keyAuth_signed,
+      nonce: 0n,
+      gas: 2_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+
+    const serialized_signed = TxEnvelopeTempo.serialize(bootstrap, {
+      signature: SignatureEnvelope.from({
+        genesisConfig,
+        init: true,
+        signatures: approve({
+          genesisConfig,
+          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
+          signers: ownerKeys,
+        }),
+      }),
+    })
+
+    await expect(
+      client.request({
+        method: 'eth_sendRawTransactionSync',
+        params: [serialized_signed],
+      }),
+    ).rejects.toThrow()
+  })
 })

--- a/src/tempo/e2e.test.ts
+++ b/src/tempo/e2e.test.ts
@@ -3028,7 +3028,7 @@ describe.skip('behavior: multisig (TIP-1061)', () => {
 
     const genesisConfig = MultisigConfig.from({
       // A fresh random salt yields a distinct account each run, exercising the
-      // salt-inclusive config-ID derivation against the node.
+      // salt-inclusive account derivation against the node.
       salt: Hex.random(32),
       threshold,
       owners: ownerKeys.map((key) => ({

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -122,8 +122,8 @@ export * as KeyAuthorization from './KeyAuthorization.js'
 /**
  * Native multisig account utilities (TIP-1061).
  *
- * Derives stable multisig account addresses and permanent config IDs from a weighted
- * owner configuration, and computes the owner approval digest that owners sign.
+ * Derives stable multisig account addresses from a weighted owner
+ * configuration, and computes the owner approval digest that owners sign.
  *
  * [TIP-1061](https://tips.sh/1061)
  *

--- a/src/zod/tempo/SignatureEnvelope.ts
+++ b/src/zod/tempo/SignatureEnvelope.ts
@@ -83,7 +83,6 @@ export const KeychainRpc = z.object({
 /** RPC native multisig signature envelope schema. */
 export const MultisigRpc = z.object({
   account: z_Address.Address,
-  configId: z_Hex.Hex,
   init: z.optional(z_MultisigConfig.Config),
   // Owner approvals are raw serialized signatures (node `Vec<Bytes>`).
   signatures: z.readonly(z.array(z_Hex.Hex)),
@@ -140,7 +139,6 @@ export const Keychain = z.object({
 /** Native multisig signature envelope schema. */
 export const Multisig = z.object({
   account: z_Address.Address,
-  genesisConfigId: z_Hex.Hex,
   init: z.optional(z_MultisigConfig.Config),
   // `signatures` is recursive; type the getter concretely to break the cycle.
   signatures: z.lazy(

--- a/src/zod/tempo/_test/SignatureEnvelope.test.ts
+++ b/src/zod/tempo/_test/SignatureEnvelope.test.ts
@@ -21,8 +21,6 @@ const p256 = {
 
 const multisig = {
   account: '0xbe95c3f554e9fc85ec51be69a3d807a0d55bcf2c',
-  configId:
-    '0x0000000000000000000000000000000000000000000000000000000000000000',
   signatures: [
     core_SignatureEnvelope.serialize(core_SignatureEnvelope.fromRpc(secp256k1)),
   ],


### PR DESCRIPTION
Tracks the removal of the `config_id` concept from the TIP-1061 native multisig implementation in [tempoxyz/tempo#5178](https://github.com/tempoxyz/tempo/pull/5178), along with the follow-up changes that landed in the same PR (compact `u8` weights, 255 owner cap, nested owner approvals).

The multisig account address now derives directly from the initial config: `keccak256("tempo:multisig:account" || salt || u8(threshold) || u8(owners.len) || (owner || u8(weight))…)[12:32]`. The owner approval digest binds only `account`, and the signature wire format drops the config ID element: `0x05 || rlp([account, signatures, init?])`, with `init` omitted entirely when absent (the `0x80` placeholder is rejected).

Breaking changes:

- Removed `MultisigConfig.toId`; `getAddress` takes only a config, and `getSignPayload` takes `{ account }` or `{ genesisConfig }`.
- Removed `genesisConfigId` from `SignatureEnvelope.Multisig` and `configId` from the RPC shape and zod schemas.
- Raised `MultisigConfig.maxOwners` to 255; total owner weight and threshold are now `u8`-bounded.

Owner approvals may now be nested multisig signatures. `SignatureEnvelope.assert` enforces the new stateless rules: keychain approvals rejected, nested approvals cannot carry `init`, and nesting depth is capped at `MultisigConfig.maxNestingDepth` (3).

Derivation and digest snapshots are pinned to vectors computed independently with `cast keccak` over the spec preimages.
