### PR TITLE
chore: change multisig changeset to patch bump

### DIFF
--- a/.changeset/multisig-remove-config-id.md
+++ b/.changeset/multisig-remove-config-id.md
@@ -1,5 +1,5 @@
 ---
-'ox': minor
+'ox': patch
 ---
 
 **Breaking (`ox/tempo`):** Removed the TIP-1061 multisig `config_id` concept to match the updated Tempo reference implementation: multisig account addresses now derive directly from the initial config, owner approval digests bind only `account`, the signature wire format is `0x05 || rlp([account, signatures, init?])`, `MultisigConfig.maxOwners` is now 255 with `u8` weights, and owner approvals may be nested multisig signatures.


### PR DESCRIPTION
Changes the multisig `config_id` changeset from https://github.com/wevm/ox/pull/281 to a `patch` bump.
