### PR TITLE
fix: handle zero-width types in `AbiParameters.encode` and `AbiParameters.decode`

### DIFF
--- a/.changeset/zero-width-abi-types.md
+++ b/.changeset/zero-width-abi-types.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `AbiParameters.encode` and `AbiParameters.decode` handling of zero-width types (zero-length fixed arrays and empty tuples).

--- a/src/core/AbiParameters.ts
+++ b/src/core/AbiParameters.ts
@@ -96,7 +96,9 @@ export function decode(
   const values: any = as === 'Array' ? [] : {}
   for (let i = 0; i < parameters.length; ++i) {
     const param = parameters[i] as Parameter
-    cursor.setPosition(consumed)
+    // Zero-width types (e.g. `uint256[0]`, empty tuples) at the end of the
+    // data consume no bytes, so the cursor may already be exhausted.
+    if (consumed < bytes.length) cursor.setPosition(consumed)
     const [data, consumed_] = internal.decodeParameter(cursor, param, {
       checksumAddress,
       staticPosition: 0,

--- a/src/core/_test/AbiParameters.decode.test.ts
+++ b/src/core/_test/AbiParameters.decode.test.ts
@@ -1526,7 +1526,7 @@ test('data size too small', () => {
       '0x0000000000000000000000000000000000000000000000000000000000010f2c',
     ),
   ).toThrowErrorMatchingInlineSnapshot(
-    '[Cursor.PositionOutOfBoundsError: Position `32` is out of bounds (`0 < position < 32`).]',
+    '[Cursor.PositionOutOfBoundsError: Position `63` is out of bounds (`0 < position < 32`).]',
   )
 })
 
@@ -1586,12 +1586,12 @@ test('zst', () => {
   expect(() =>
     AbiParameters.decode([{ type: 'uint256[0][4294967295]' }], payload),
   ).toThrowErrorMatchingInlineSnapshot(
-    '[Cursor.PositionOutOfBoundsError: Position `64` is out of bounds (`0 < position < 64`).]',
+    '[Cursor.RecursiveReadLimitExceededError: Recursive read limit of `8192` exceeded (recursive read count: `8193`).]',
   )
   expect(() =>
     AbiParameters.decode([{ type: 'uint32[0][4294967295]' }], payload),
   ).toThrowErrorMatchingInlineSnapshot(
-    '[Cursor.PositionOutOfBoundsError: Position `64` is out of bounds (`0 < position < 64`).]',
+    '[Cursor.RecursiveReadLimitExceededError: Recursive read limit of `8192` exceeded (recursive read count: `8193`).]',
   )
   expect(() =>
     AbiParameters.decode(
@@ -1727,4 +1727,66 @@ test('recursive 2', () => {
   ).toThrowErrorMatchingInlineSnapshot(
     '[Cursor.RecursiveReadLimitExceededError: Recursive read limit of `8192` exceeded (recursive read count: `8193`).]',
   )
+})
+
+describe('zero-width types', () => {
+  test('zero-length fixed array', () => {
+    expect(
+      AbiParameters.decode(
+        [{ type: 'uint256[0]' }, { type: 'uint256' }],
+        '0x0000000000000000000000000000000000000000000000000000000000000003',
+      ),
+    ).toEqual([[], 3n])
+  })
+
+  test('trailing empty tuple', () => {
+    expect(
+      AbiParameters.decode(
+        [{ type: 'uint256' }, { type: 'tuple', components: [] }],
+        '0x0000000000000000000000000000000000000000000000000000000000000005',
+      ),
+    ).toEqual([5n, []])
+  })
+
+  test('zero-length fixed array of dynamic type', () => {
+    expect(
+      AbiParameters.decode(
+        [{ type: 'string[0]' }, { type: 'uint256' }],
+        '0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000003',
+      ),
+    ).toEqual([[], 3n])
+  })
+
+  test('round-trip', () => {
+    const cases = [
+      {
+        parameters: [{ type: 'uint256[0]' }, { type: 'uint256' }],
+        values: [[], 3n],
+      },
+      {
+        parameters: [{ type: 'uint256' }, { type: 'tuple', components: [] }],
+        values: [5n, []],
+      },
+      {
+        parameters: [{ type: 'string[0]' }, { type: 'uint256' }],
+        values: [[], 3n],
+      },
+      {
+        parameters: [{ type: 'uint256[0]' }, { type: 'string' }],
+        values: [[], 'hello'],
+      },
+      {
+        parameters: [{ type: 'uint256[0][2]' }, { type: 'uint256' }],
+        values: [[[], []], 9n],
+      },
+    ] as const
+    for (const { parameters, values } of cases) {
+      expect(
+        AbiParameters.decode(
+          parameters,
+          AbiParameters.encode(parameters, values as never),
+        ),
+      ).toEqual(values)
+    }
+  })
 })

--- a/src/core/_test/AbiParameters.encode.test.ts
+++ b/src/core/_test/AbiParameters.encode.test.ts
@@ -1963,3 +1963,71 @@ test('https://github.com/wevm/viem/issues/1960', () => {
     `[BaseError: Invalid boolean value: "true" (type: string). Expected: \`true\` or \`false\`.]`,
   )
 })
+
+describe('zero-width types', () => {
+  // Per the ABI spec, `enc(T[0])` and `enc(())` are zero-length: a zero-length
+  // fixed array or empty tuple contributes no bytes. Expected values verified
+  // against ethers `AbiCoder.defaultAbiCoder()`.
+  test('zero-length fixed array', () => {
+    expect(
+      AbiParameters.encode(
+        [{ type: 'uint256[0]' }, { type: 'uint256' }],
+        [[], 3n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000003')
+  })
+
+  test('empty tuple', () => {
+    expect(
+      AbiParameters.encode(
+        [{ type: 'uint256' }, { type: 'tuple', components: [] }],
+        [5n, []],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000005')
+  })
+
+  test('empty tuple only', () => {
+    expect(
+      AbiParameters.encode([{ type: 'tuple', components: [] }], [[]]),
+    ).toBe('0x')
+  })
+
+  test('nested zero-length fixed arrays', () => {
+    expect(
+      AbiParameters.encode(
+        [{ type: 'uint256[0][2]' }, { type: 'uint256' }],
+        [[[], []], 9n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000009')
+    expect(
+      AbiParameters.encode(
+        [{ type: 'uint256[2][0]' }, { type: 'uint256' }],
+        [[], 9n],
+      ),
+    ).toBe('0x0000000000000000000000000000000000000000000000000000000000000009')
+  })
+
+  test('offsets skip zero-width parameters', () => {
+    expect(
+      AbiParameters.encode(
+        [{ type: 'uint256[0]' }, { type: 'string' }],
+        [[], 'hello'],
+      ),
+    ).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000',
+    )
+  })
+
+  // `T[0]` of a dynamic `T` is dynamic per the ABI spec: 32-byte offset
+  // pointing at a zero-length tail.
+  test('zero-length fixed array of dynamic type', () => {
+    expect(
+      AbiParameters.encode(
+        [{ type: 'string[0]' }, { type: 'uint256' }],
+        [[], 3n],
+      ),
+    ).toBe(
+      '0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000003',
+    )
+  })
+})

--- a/src/core/internal/abiParameters.ts
+++ b/src/core/internal/abiParameters.ts
@@ -140,7 +140,8 @@ export function decodeArray(
 
   // If the length of the array is not known in advance (dynamic array),
   // this means we will need to wonder off to the pointer and decode.
-  if (!length) {
+  // Note: zero-length fixed arrays (`T[0]`) are not dynamic.
+  if (length === null) {
     // Dealing with a dynamic type, so get the offset of the array data.
     const offset = Bytes.toNumber(cursor.readBytes(sizeOfOffset))
 
@@ -167,6 +168,12 @@ export function decodeArray(
       })
       consumed += consumed_
       value.push(data)
+      // Charge zero-width elements against the read limit to bound work
+      // on huge lengths of zero-width types (e.g. `uint256[0][]`).
+      if (consumed_ === 0) {
+        cursor.assertReadLimit()
+        cursor._touch()
+      }
     }
 
     // As we have gone wondering, restore to the original position + next slot.
@@ -211,6 +218,12 @@ export function decodeArray(
     })
     consumed += consumed_
     value.push(data)
+    // Charge zero-width elements against the read limit to bound work
+    // on huge lengths of zero-width types (e.g. `uint256[0][4294967295]`).
+    if (consumed_ === 0) {
+      cursor.assertReadLimit()
+      cursor._touch()
+    }
   }
   return [value, consumed]
 }
@@ -583,7 +596,9 @@ export function encodeArray<const parameter extends AbiParameters.Parameter>(
       type: `${parameter.type}[${length}]`,
     })
 
-  let dynamicChild = false
+  // Zero-length fixed arrays of dynamic types (e.g. `string[0]`) are dynamic
+  // per the ABI spec, even though they have no elements to inspect.
+  let dynamicChild = value.length === 0 && hasDynamicChild(parameter)
   const preparedParameters: PreparedParameter[] = []
   for (let i = 0; i < value.length; i++) {
     const preparedParam = prepareParameter({


### PR DESCRIPTION
`AbiParameters.decode` mishandled zero-width types. Zero-length fixed arrays (`uint256[0]`) were conflated with dynamic arrays (`T[]`), and zero-width parameters at the end of data threw `Cursor.PositionOutOfBoundsError`. `AbiParameters.encode` misclassified zero-length fixed arrays of dynamic types (`string[0]`) as static.

Per the [ABI spec](https://docs.soliditylang.org/en/latest/abi-spec.html), `enc(T[0])` and `enc(())` are zero-length, and `T[k]` is dynamic for any dynamic `T` and any `k >= 0`. Encode and decode now match ethers byte-for-byte on these types and round-trip each other.

Decoding zero-width elements now charges the cursor read limit. This preserves the zero-sized type hardening: huge lengths of zero-width elements (e.g. `uint256[0][4294967295]`) throw `Cursor.RecursiveReadLimitExceededError` instead of looping unbounded.

Counterpart to the same fix in viem. Related: https://github.com/wevm/viem/pull/4777.
