### PR TITLE
feat: add `eth_getRawTransactionByHash` to `RpcSchema.Eth`

### DIFF
--- a/.changeset/eth-get-raw-transaction-by-hash.md
+++ b/.changeset/eth-get-raw-transaction-by-hash.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Added `eth_getRawTransactionByHash` to `RpcSchema.Eth`.

--- a/src/core/internal/rpcSchemas/eth.ts
+++ b/src/core/internal/rpcSchemas/eth.ts
@@ -437,6 +437,22 @@ export type Eth = RpcSchema.From<
       ReturnType: AccountProof.Rpc
     }
   /**
+   * Returns the raw, serialized transaction specified by hash
+   *
+   * @example
+   * ```
+   * request({ method: 'eth_getRawTransactionByHash', params: ['0x...'] })
+   * // '0x...'
+   * ```
+   */
+  | {
+      Request: {
+        method: 'eth_getRawTransactionByHash'
+        params: [hash: Hex.Hex]
+      }
+      ReturnType: Hex.Hex | null
+    }
+  /**
    * Returns the value from a storage position at an address
    *
    * @example


### PR DESCRIPTION
Adds the `eth_getRawTransactionByHash` method to `RpcSchema.Eth` (params `[hash: Hex]`, returns `Hex | null`), enabling typed `Provider.request` / `RpcTransport` calls for raw transaction retrieval.
