### PR TITLE
feat: add `eth_getRawTransactionByHash` to `RpcSchema.Eth` (v1)

### DIFF
--- a/.changeset/eth-get-raw-transaction-by-hash.md
+++ b/.changeset/eth-get-raw-transaction-by-hash.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Added `eth_getRawTransactionByHash` to `RpcSchema.Eth` and `z.RpcSchema.Eth`.

--- a/src/core/internal/rpcSchemas/eth.ts
+++ b/src/core/internal/rpcSchemas/eth.ts
@@ -446,6 +446,22 @@ export type Eth = RpcSchema.From<
       ReturnType: AccountProof.Rpc
     }
   /**
+   * Returns the raw, serialized transaction specified by hash
+   *
+   * @example
+   * ```
+   * request({ method: 'eth_getRawTransactionByHash', params: ['0x...'] })
+   * // '0x...'
+   * ```
+   */
+  | {
+      Request: {
+        method: 'eth_getRawTransactionByHash'
+        params: [hash: Hex.Hex]
+      }
+      ReturnType: Hex.Hex | null
+    }
+  /**
    * Returns the value from a storage position at an address
    *
    * @example

--- a/src/zod/internal/rpcSchemas/Eth.ts
+++ b/src/zod/internal/rpcSchemas/Eth.ts
@@ -181,6 +181,12 @@ export const eth_getProof = from({
   returns: z_AccountProof.AccountProof,
 })
 
+export const eth_getRawTransactionByHash = from({
+  method: 'eth_getRawTransactionByHash',
+  params: z.tuple([z_Hex.Hex]),
+  returns: z.nullable(z_Hex.Hex),
+})
+
 export const eth_getStorageAt = from({
   method: 'eth_getStorageAt',
   params: z.tuple([z_Address.Address, z_Hex.Hex, BlockNumberOrTagOrIdentifier]),


### PR DESCRIPTION
Adds the `eth_getRawTransactionByHash` method to `RpcSchema.Eth` and the zod schemas (`z.RpcSchema.Eth`), returning `Hex | null`. v1 port of https://github.com/wevm/ox/pull/286.
