### PR TITLE
chore(site): bump vocs, move ai search vectors to cloudflare vectorize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.map
 .bench
+.claude/
 .DS_Store
 .attest
 .env

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,8 +331,8 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
       vocs:
-        specifier: 2.3.3
-        version: 2.3.3(@types/node@24.10.2)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(rollup@4.61.1)(terser@5.31.5)(typescript@5.5.4)(waku@1.0.0-beta.6(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0))
+        specifier: https://pkg.pr.new/vocs@35ebd0c
+        version: https://pkg.pr.new/vocs@35ebd0c(@types/node@24.10.2)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(rollup@4.61.1)(terser@5.31.5)(typescript@5.5.4)(waku@1.0.0-beta.6(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.7))
       waku:
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0)
@@ -884,12 +884,6 @@ packages:
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: '>=4.6.5'
-
-  '@hono/node-server@2.0.4':
-    resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
-    engines: {node: '>=20'}
     peerDependencies:
       hono: '>=4.6.5'
 
@@ -3872,6 +3866,9 @@ packages:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -4942,10 +4939,6 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5797,6 +5790,9 @@ packages:
     resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
     engines: {node: '>=22.19.0'}
 
+  unhead@3.1.7:
+    resolution: {integrity: sha512-Db1M8yQmxdzhQFMmlZ6cr/ZlpGPRabTMDPBE4GGBv69TYUNP6jV8z54H8PTU08gMsWXVtqPBs9VwCldjrqknGw==}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -5867,6 +5863,39 @@ packages:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
 
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '>=0.24.3'
+      rolldown: '*'
+      rollup: '>=4.22.4'
+      unloader: '*'
+      vite: '*'
+      webpack: '>=5.94.0'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -5935,8 +5964,9 @@ packages:
       vite:
         optional: true
 
-  vocs@2.3.3:
-    resolution: {integrity: sha512-mIRjZ4pCAXVM+2tJHJrloMW1U2tlSSm1g/lmZSF/uSABrOfMubZW0BagdBt90E/3j2/brEeKQVHSPKPvY8wkAg==}
+  vocs@https://pkg.pr.new/vocs@35ebd0c:
+    resolution: {integrity: sha512-WgXalTW6xBeSjWOtqNX2vO0R61urSdXs4bjWHNh0Kn6ypgtoSbVgE7LlTwFKtgBs1nui6ZfZHiDO7t5dFmVSlg==, tarball: https://pkg.pr.new/vocs@35ebd0c}
+    version: 2.5.2
     hasBin: true
     peerDependencies:
       '@vocs/twoslash-rust': ^0.1.0
@@ -6170,7 +6200,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -6183,10 +6213,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -6198,8 +6228,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -6217,7 +6247,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6225,7 +6255,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -6243,7 +6273,7 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
@@ -6258,17 +6288,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -6815,10 +6845,6 @@ snapshots:
       vue: 3.5.39(typescript@5.5.4)
 
   '@hono/node-server@1.19.14(hono@4.12.18)':
-    dependencies:
-      hono: 4.12.18
-
-  '@hono/node-server@2.0.4(hono@4.12.18)':
     dependencies:
       hono: 4.12.18
 
@@ -8057,7 +8083,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.5.4))':
@@ -8456,7 +8482,7 @@ snapshots:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
       lightningcss: 1.32.0
-      postcss: 8.5.14
+      postcss: 8.5.16
     optionalDependencies:
       '@types/node': 24.10.2
       esbuild: 0.27.7
@@ -8827,7 +8853,7 @@ snapshots:
 
   aria-hidden@1.2.6:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   arktype@2.0.0-rc.5:
     dependencies:
@@ -9260,7 +9286,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   dotenv@16.6.1: {}
 
@@ -10089,6 +10115,8 @@ snapshots:
 
   hono@4.12.18: {}
 
+  hookable@6.1.1: {}
+
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
@@ -10436,7 +10464,7 @@ snapshots:
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   lowlight@3.3.0:
     dependencies:
@@ -11067,7 +11095,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   node-fetch@2.7.0:
     dependencies:
@@ -11371,12 +11399,6 @@ snapshots:
       fsevents: 2.3.2
 
   pngjs@7.0.0: {}
-
-  postcss@8.5.14:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.16:
     dependencies:
@@ -11984,7 +12006,7 @@ snapshots:
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   socks-proxy-agent@8.0.4:
     dependencies:
@@ -12378,6 +12400,39 @@ snapshots:
 
   undici@8.3.0: {}
 
+  unhead@3.1.7(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(rollup@4.61.1)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(webpack@5.104.1(esbuild@0.27.7))(yaml@2.9.0):
+    dependencies:
+      hookable: 6.1.1
+      unplugin: 3.3.0(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0))(esbuild@0.27.7)(rollup@4.61.1)(webpack@5.104.1(esbuild@0.27.7))
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0)'
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@farmfe/core'
+      - '@rspack/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - bun-types-no-globals
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - rolldown
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unloader
+      - unplugin-unused
+      - unrun
+      - webpack
+      - yaml
+
   unicorn-magic@0.1.0: {}
 
   unified@11.0.5:
@@ -12457,6 +12512,17 @@ snapshots:
       acorn: 8.15.0
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
+
+  unplugin@3.3.0(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0))(esbuild@0.27.7)(rollup@4.61.1)(webpack@5.104.1(esbuild@0.27.7)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.27.7
+      rollup: 4.61.1
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0)'
+      webpack: 5.104.1(esbuild@0.27.7)
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -12593,11 +12659,11 @@ snapshots:
     optionalDependencies:
       vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0)'
 
-  vocs@2.3.3(@types/node@24.10.2)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(rollup@4.61.1)(terser@5.31.5)(typescript@5.5.4)(waku@1.0.0-beta.6(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0)):
+  vocs@https://pkg.pr.new/vocs@35ebd0c(@types/node@24.10.2)(@types/react@19.2.16)(@vue/compiler-sfc@3.5.39)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(rollup@4.61.1)(terser@5.31.5)(typescript@5.5.4)(waku@1.0.0-beta.6(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.104.1(esbuild@0.27.7)))(react@19.2.7)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.7)):
     dependencies:
       '@base-ui/react': 1.4.1(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@hono/node-server': 2.0.4(hono@4.12.18)
+      '@hono/node-server': 2.0.8(hono@4.12.18)
       '@iconify-json/lucide': 1.2.107
       '@iconify-json/simple-icons': 1.2.82
       '@iconify-json/vscode-icons': 1.2.50
@@ -12665,6 +12731,7 @@ snapshots:
       tailwindcss-logical: 4.2.0(tailwindcss@4.3.0)
       tsx: 4.21.0
       twoslash: 0.3.8(typescript@5.5.4)
+      unhead: 3.1.7(@types/node@24.10.2)(esbuild@0.27.7)(jiti@2.7.0)(rollup@4.61.1)(terser@5.31.5)(tsx@4.21.0)(typescript@5.5.4)(webpack@5.104.1(esbuild@0.27.7))(yaml@2.9.0)
       unified: 11.0.5
       unist-util-visit: 5.1.0
       unplugin-icons: 22.5.0(@svgr/core@8.1.0(typescript@5.5.4))(@vue/compiler-sfc@3.5.39)
@@ -12681,8 +12748,10 @@ snapshots:
       - '@arethetypeswrong/core'
       - '@cfworker/json-schema'
       - '@date-fns/tz'
+      - '@farmfe/core'
       - '@remix-run/react'
       - '@rolldown/plugin-babel'
+      - '@rspack/core'
       - '@svgx/core'
       - '@tanstack/react-router'
       - '@tsdown/css'
@@ -12695,6 +12764,7 @@ snapshots:
       - async-validator
       - axios
       - babel-plugin-react-compiler
+      - bun-types-no-globals
       - change-case
       - date-fns
       - drauu
@@ -12710,6 +12780,7 @@ snapshots:
       - react-router
       - react-router-dom
       - react-server-dom-webpack
+      - rolldown
       - rollup
       - sass
       - sass-embedded
@@ -12721,10 +12792,12 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
+      - unloader
       - unplugin-unused
       - unrun
       - vue-template-compiler
       - vue-template-es2015-compiler
+      - webpack
 
   vue-component-type-helpers@3.3.6: {}
 

--- a/site/package.json
+++ b/site/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^19.2.7",
     "react-server-dom-webpack": "19.2.7",
     "tailwindcss": "^4.3.0",
-    "vocs": "2.3.3",
+    "vocs": "https://pkg.pr.new/vocs@35ebd0c",
     "waku": "1.0.0-beta.6"
   },
   "devDependencies": {

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -27,8 +27,8 @@ export default defineConfig({
           retriever: Retriever.local({
             embedding: Embedding.cloudflare(),
             reranker: Reranker.cloudflare(),
-            // int8 quantization keeps the server AI manifest under Vercel's 250MB function limit.
-            vectorStore: VectorStore.static({ format: 'int8' }),
+            // Remote store keeps vectors out of the server bundle entirely.
+            vectorStore: VectorStore.cloudflare({ index: 'ox-docs' }),
           }),
         },
       }


### PR DESCRIPTION
Bumps `vocs` to https://pkg.pr.new/vocs@35ebd0c (strips twoslash cache blobs from the search index) and switches AI search to a remote Cloudflare Vectorize store, keeping vectors out of the server bundle.
