### PR TITLE
fix: `KeyAuthorization.fromRpc` return type mismatch

### DIFF
--- a/.changeset/keyauthorization-fromrpc-type.md
+++ b/.changeset/keyauthorization-fromrpc-type.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `KeyAuthorization.fromRpc` return type mismatch under TypeScript configs without `exactOptionalPropertyTypes`.

--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -2432,6 +2432,28 @@ describe('admin keys (TIP-1049)', () => {
     expect(restored.account).toBe(account)
   })
 
+  test('fromRpc: drops orphan isAdmin without account', () => {
+    const authorization = KeyAuthorization.from(
+      { address, chainId: 1n, type: 'secp256k1' },
+      { signature: SignatureEnvelope.from(signature_secp256k1) },
+    )
+    const rpc = KeyAuthorization.toRpc(authorization)
+    const restored = KeyAuthorization.fromRpc({ ...rpc, isAdmin: true })
+    expect(restored.isAdmin).toBeUndefined()
+    expect(restored.account).toBeUndefined()
+  })
+
+  test('fromRpc: drops orphan account without isAdmin', () => {
+    const authorization = KeyAuthorization.from(
+      { address, chainId: 1n, type: 'secp256k1' },
+      { signature: SignatureEnvelope.from(signature_secp256k1) },
+    )
+    const rpc = KeyAuthorization.toRpc(authorization)
+    const restored = KeyAuthorization.fromRpc({ ...rpc, account })
+    expect(restored.isAdmin).toBeUndefined()
+    expect(restored.account).toBeUndefined()
+  })
+
   test('hash: changes when admin pair is added', () => {
     const plain = KeyAuthorization.from({
       address,

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -534,6 +534,12 @@ export function fromRpc(authorization: Rpc): Signed {
       })
     : undefined
 
+  // TIP-1049 admin fields are paired: emit both or neither; orphan wire
+  // fields are dropped. Separate conditional spreads break `Signed`
+  // assignability without `exactOptionalPropertyTypes` (#290).
+  const adminPair =
+    account !== undefined && isAdmin ? { account, isAdmin: true as const } : {}
+
   return {
     address: keyId,
     chainId: chainId === '0x' ? 0n : Hex.toBigInt(chainId),
@@ -549,8 +555,7 @@ export function fromRpc(authorization: Rpc): Signed {
     signature,
     type: keyType,
     ...(witness !== undefined ? { witness } : {}),
-    ...(isAdmin ? { isAdmin: true } : {}),
-    ...(account !== undefined ? { account } : {}),
+    ...adminPair,
   }
 }
 


### PR DESCRIPTION
Builds the TIP-1049 `account`/`isAdmin` pair in `KeyAuthorization.fromRpc` with a single paired spread, matching `fromTuple`. Separate conditional spreads broke `Signed` assignability for consumers type-checking shipped sources without `exactOptionalPropertyTypes`. Orphan wire fields are now dropped, matching `fromTuple`.

Closes https://github.com/wevm/ox/issues/290
