### PR TITLE
fix: run checks during versioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,7 @@
 - **TSDoc** -- run `pnpm check:tsdoc` after public documentation changes.
 - **Repo checks** -- run `pnpm check:repo` when package metadata or workspace shape changes.
 - **Docs dev server** -- use `pnpm docs:dev` for documentation UI work.
-- **`pnpm check` mutates** -- it runs `biome check . --fix --unsafe`. Use it only when intentionally applying lint/format fixes.
-- **`pnpm format` mutates** -- it runs `vp fmt`.
+- **`pnpm check` mutates** -- it runs `vp check --fix`. Use it only when intentionally applying lint/format fixes.
 - **`pnpm exports:update` mutates** -- it rewrites `package.json#exports`.
 - **`pnpm docs:gen` and `pnpm docs:build` mutate generated docs output** -- run only when docs generation is part of the task.
 - **`pnpm contracts:build` mutates generated contract artifacts** -- it runs Forge and `contracts/scripts/generate-typed-artifacts.ts`.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "pnpm exports:update && zile",
     "changeset:publish": "zile publish:prepare && changeset publish && zile publish:post",
-    "changeset:version": "changeset version && pnpm version:update && pnpm format",
+    "changeset:version": "changeset version && pnpm version:update && pnpm check",
     "check": "vp check --fix",
     "check:examples": "zile examples:check --fix",
     "check:repo": "sherif",
@@ -17,7 +17,6 @@
     "docs:gen": "pnpm build && pnpm docs:extract",
     "docs:build": "pnpm docs:gen && pnpm --filter site build",
     "exports:update": "node --import tsx ./scripts/exports:update.ts",
-    "format": "vp fmt",
     "knip": "knip --production",
     "postinstall": "git submodule update --init --recursive && pnpm contracts:build && pnpm dev",
     "preinstall": "pnpx only-allow pnpm",


### PR DESCRIPTION
Runs `pnpm check` during Changesets versioning, using the existing formatting, lint, and type-check entrypoint while removing the redundant `format` script.
