### PR TITLE
fix(site): refine mobile module showcase

### DIFF
--- a/site/src/components/Landing.tsx
+++ b/site/src/components/Landing.tsx
@@ -414,7 +414,7 @@ export function Landing({
             </p>
           </div>
           <div
-            className="relative grid grid-cols-[200px_1fr] bg-elevated lg:-mx-[4em] max-md:grid-cols-1"
+            className="relative grid grid-cols-[200px_1fr] bg-elevated lg:-mx-[4em] max-md:-mx-[calc(var(--container-pad)+var(--vocs-spacing-content-px))] max-md:grid-cols-1"
             style={dashedFrame}
           >
             <div className="flex flex-col max-md:hidden">

--- a/site/src/snippets/abi.mdx
+++ b/site/src/snippets/abi.mdx
@@ -11,22 +11,10 @@ const abi = Abi.from([
 abi
 // ^?
 
-
-
-
-
-
-
-
-
-
-
 const data = AbiFunction.encodeData(abi, 'transfer', ['0x7099…', 1000n])
 // @log: '0xa9059cbb000000…00000000000000003e8'
 
 const balance = AbiFunction.decodeResult(abi, 'balanceOf', '0x…0064')
 //    ^?
-
-
 // @log: 100n
 ```


### PR DESCRIPTION
Extend the mobile module showcase precisely to the viewport edges and tighten the ABI Twoslash spacing. Desktop framing and responsive module controls remain unchanged.
