### PR TITLE
fix(abi): preserve leading NUL bytes in `string` values

### DIFF
--- a/.changeset/calm-pandas-smile.md
+++ b/.changeset/calm-pandas-smile.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Preserved leading NUL bytes when decoding ABI `string` values.

--- a/src/core/_test/AbiParameters.decode.test.ts
+++ b/src/core/_test/AbiParameters.decode.test.ts
@@ -443,6 +443,19 @@ describe('dynamic', () => {
       expect(result).toEqual([''])
     })
 
+    test('leading NUL byte', () => {
+      const result = AbiParameters.decode(
+        AbiParameters.from('string'),
+        '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030061620000000000000000000000000000000000000000000000000000000000',
+      )
+      assertType<readonly [string]>(result)
+      expect(result).toMatchInlineSnapshot(`
+        [
+          "\u0000ab",
+        ]
+      `)
+    })
+
     test('default', () => {
       expect(
         AbiParameters.decode(

--- a/src/core/internal/abiParameters.ts
+++ b/src/core/internal/abiParameters.ts
@@ -407,7 +407,7 @@ export function decodeString(
   }
 
   const data = cursor.readBytes(length, 32)
-  const value = Bytes.toString(Bytes.trimLeft(data))
+  const value = Bytes.toString(data)
 
   // As we have gone wondering, restore to the original position + next slot.
   cursor.setPosition(staticPosition + 32)
@@ -419,7 +419,6 @@ export declare namespace decodeString {
   type ErrorType =
     | Bytes.toNumber.ErrorType
     | Bytes.toString.ErrorType
-    | Bytes.trimLeft.ErrorType
     | Errors.GlobalErrorType
 }
 


### PR DESCRIPTION
Preserves leading NUL bytes when decoding ABI `string` values. The declared dynamic payload length already excludes right padding, so left-trimming discarded valid string content.
