### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/bright-dingos-sign.md
+++ b/.changeset/bright-dingos-sign.md
@@ -1,5 +1,0 @@
----
-'ox': patch
----
-
-`viem/tempo`: Updated multisig implementation.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "0.x",
   "changelog": ["@changesets/changelog-github", { "repo": "wevm/ox" }],
   "commit": false,
   "fixed": [],

--- a/.changeset/eth-get-raw-transaction-by-hash.md
+++ b/.changeset/eth-get-raw-transaction-by-hash.md
@@ -1,5 +1,0 @@
----
-"ox": patch
----
-
-Added `eth_getRawTransactionByHash` to `RpcSchema.Eth`.

--- a/.changeset/keyauthorization-fromrpc-type.md
+++ b/.changeset/keyauthorization-fromrpc-type.md
@@ -1,5 +1,0 @@
----
-"ox": patch
----
-
-Fixed `KeyAuthorization.fromRpc` return type mismatch under TypeScript configs without `exactOptionalPropertyTypes`.

--- a/.changeset/zero-width-abi-types.md
+++ b/.changeset/zero-width-abi-types.md
@@ -1,5 +1,0 @@
----
-"ox": patch
----
-
-Fixed `AbiParameters.encode` and `AbiParameters.decode` handling of zero-width types (zero-length fixed arrays and empty tuples).

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,7 +1,7 @@
 name: Changesets
 on:
   push:
-    branches: [main]
+    branches: [main, 0.x]
 
 permissions: {} # each job should declare only the permissions it needs
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ox
 
+## 0.14.31
+
+### Patch Changes
+
+- [#306](https://github.com/wevm/ox/pull/306) [`e13c054`](https://github.com/wevm/ox/commit/e13c054ecd0adf319e2b306400e1564c67051e5a) Thanks [@jxom](https://github.com/jxom)! - `viem/tempo`: Updated multisig implementation.
+
+- [#286](https://github.com/wevm/ox/pull/286) [`56f299f`](https://github.com/wevm/ox/commit/56f299f6c046aea41b55e64f7993b831a206c47c) Thanks [@jxom](https://github.com/jxom)! - Added `eth_getRawTransactionByHash` to `RpcSchema.Eth`.
+
+- [#291](https://github.com/wevm/ox/pull/291) [`5ebb88d`](https://github.com/wevm/ox/commit/5ebb88dfc6139573844d9c6b97eed8c463ee1d3a) Thanks [@jxom](https://github.com/jxom)! - Fixed `KeyAuthorization.fromRpc` return type mismatch under TypeScript configs without `exactOptionalPropertyTypes`.
+
+- [#284](https://github.com/wevm/ox/pull/284) [`c86f635`](https://github.com/wevm/ox/commit/c86f6350f199a0f5a9705083ad545da760e1f5c4) Thanks [@jxom](https://github.com/jxom)! - Fixed `AbiParameters.encode` and `AbiParameters.decode` handling of zero-width types (zero-length fixed arrays and empty tuples).
+
 ## 0.14.30
 
 ### Patch Changes

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ox",
   "description": "Ethereum Standard Library",
-  "version": "0.14.30",
+  "version": "0.14.31",
   "type": "module",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 /** @internal */
-export const version = '0.14.30'
+export const version = '0.14.31'


### PR DESCRIPTION
Releases `ox@0.14.31` from `0.x`, including four pending patch changes. Enables the existing Changesets trusted-publishing workflow on the maintenance branch for this and future 0.x releases.
