### PR TITLE
ci: publish 0.x releases under `v0`

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,7 +1,7 @@
 name: Changesets
 on:
   push:
-    branches: [main, 0.x]
+    branches: [0.x]
 
 permissions: {} # each job should declare only the permissions it needs
 
@@ -79,7 +79,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           createGithubReleases: true
-          publish: pnpm changeset:publish
+          publish: pnpm changeset:publish:v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:types": "tsc --project ./tsconfig.build.json --declarationDir ./src/_types --emitDeclarationOnly --declaration --declarationMap",
     "changeset:prepublish": "pnpm version:update && pnpm build && tsx scripts/prepublish.ts",
     "changeset:publish": "pnpm changeset:prepublish && changeset publish",
+    "changeset:publish:v0": "pnpm changeset:prepublish && changeset publish --tag v0",
     "changeset:version": "changeset version && pnpm version:update && pnpm format",
     "check": "biome check . --fix --unsafe",
     "check:repo": "sherif",


### PR DESCRIPTION
Publishes 0.x releases under the `v0` npm tag while preserving Changesets version PRs, preventing maintenance releases from replacing the main-line `latest` tag.
