### PR TITLE
feat(tempo): add `EarnShares` share math

### DIFF
--- a/.changeset/earn-shares.md
+++ b/.changeset/earn-shares.md
@@ -1,0 +1,12 @@
+---
+"ox": patch
+---
+
+Added `EarnShares` to `ox/tempo`: raw EarnToken/venue-share conversions at the vault anchor rate, the dilution-correct fee-share formula, and a `minimumOutput` slippage floor.
+
+```ts
+import { EarnShares } from 'ox/tempo'
+
+const tokens = EarnShares.toTokens({ engineShares: 3n, supply: 2n }, 7n)
+const minimumShares = EarnShares.minimumOutput(1_000_000n, 50n)
+```

--- a/src/tempo/EarnShares.test.ts
+++ b/src/tempo/EarnShares.test.ts
@@ -1,0 +1,110 @@
+import { EarnShares } from 'ox/tempo'
+import { describe, expect, test } from 'vitest'
+
+const anchor = { engineShares: 3n, supply: 2n } as const
+
+describe('fromTokens', () => {
+  test('default', () => {
+    expect(EarnShares.fromTokens(anchor, 7n)).toBe(10n)
+  })
+
+  test('behavior: identity at the initial 1:1 anchor', () => {
+    expect(
+      EarnShares.fromTokens({ engineShares: 1n, supply: 1n }, 12_345n),
+    ).toBe(12_345n)
+  })
+})
+
+describe('toTokens', () => {
+  test('default', () => {
+    expect(EarnShares.toTokens(anchor, 7n)).toBe(4n)
+  })
+
+  test('behavior: rounds down', () => {
+    expect(EarnShares.toTokens({ engineShares: 3n, supply: 1n }, 2n)).toBe(0n)
+  })
+})
+
+describe('toTokensUp', () => {
+  test('default', () => {
+    expect(EarnShares.toTokensUp(anchor, 7n)).toBe(5n)
+  })
+
+  test('behavior: exact conversions do not round up', () => {
+    expect(EarnShares.toTokensUp(anchor, 3n)).toBe(2n)
+  })
+})
+
+describe('feeShares', () => {
+  test('default', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 1_100n,
+        supply: 1_000n,
+        totalFeeAssets: 100n,
+      }),
+    ).toBe(100n)
+  })
+
+  test('behavior: zero fee mints nothing', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 1_100n,
+        supply: 1_000n,
+        totalFeeAssets: 0n,
+      }),
+    ).toBe(0n)
+  })
+
+  test('behavior: fee at or above active assets mints nothing', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 100n,
+        supply: 1_000n,
+        totalFeeAssets: 100n,
+      }),
+    ).toBe(0n)
+  })
+
+  test('behavior: rounds down', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 1_000n,
+        supply: 999n,
+        totalFeeAssets: 100n,
+      }),
+    ).toBe(111n)
+  })
+})
+
+describe('minimumOutput', () => {
+  test('default', () => {
+    expect(EarnShares.minimumOutput(1_000_000n, 50n)).toBe(995_000n)
+  })
+
+  test('behavior: zero slippage returns the expected output', () => {
+    expect(EarnShares.minimumOutput(1_000_000n, 0n)).toBe(1_000_000n)
+  })
+
+  test('behavior: floors to 1n', () => {
+    expect(EarnShares.minimumOutput(1n, 9_999n)).toBe(1n)
+  })
+
+  test('error: non-positive expected output', () => {
+    expect(() =>
+      EarnShares.minimumOutput(0n, 50n),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[EarnShares.InvalidExpectedOutputError: Expected output \`0\` must be greater than zero.]`,
+    )
+  })
+
+  test('error: out-of-range slippage', () => {
+    expect(() =>
+      EarnShares.minimumOutput(1_000_000n, 10_000n),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [EarnShares.InvalidSlippageError: Slippage tolerance \`10000\` is invalid.
+
+      Slippage must be at least 0 and below 10000 basis points.]
+    `)
+  })
+})

--- a/src/tempo/EarnShares.ts
+++ b/src/tempo/EarnShares.ts
@@ -1,0 +1,222 @@
+import * as Errors from '../core/Errors.js'
+
+/** Basis-point denominator used by slippage bounds. */
+export const basisPointScale = 10_000n
+
+/**
+ * Tempo Earn `VaultAdapter` conversion anchor.
+ *
+ * The adapter prices EarnToken against venue shares through this pair:
+ * `engineShares` venue shares are worth `supply` EarnToken. It is initialised
+ * 1:1 and restated on `contribute` and `migrateEngine`.
+ *
+ * Adapter vocabulary applies throughout this module: "tokens" are EarnToken
+ * (TIP-20) units and "shares" are venue shares. These conversions are raw and
+ * fee-blind; they ignore pending fee dilution and are unsuitable for
+ * user-facing value (use the adapter's `previewRedeem`).
+ */
+export type Anchor = {
+  /** Venue shares held by the engine at the anchor point. */
+  engineShares: bigint
+  /** EarnToken (TIP-20) supply at the anchor point. */
+  supply: bigint
+}
+
+/**
+ * Converts EarnToken units to venue shares at the anchor rate, rounding down.
+ *
+ * Mirrors `VaultAdapter.tokensToShares`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const shares = EarnShares.fromTokens(
+ *   { engineShares: 3n, supply: 2n },
+ *   7n,
+ * )
+ * // @log: 10n
+ * ```
+ *
+ * @param anchor - The conversion anchor.
+ * @param tokens - EarnToken amount, base units.
+ * @returns Venue shares, rounded down.
+ */
+export function fromTokens(anchor: Anchor, tokens: bigint): bigint {
+  return (tokens * anchor.engineShares) / anchor.supply
+}
+
+export declare namespace fromTokens {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts venue shares to EarnToken units at the anchor rate, rounding down.
+ *
+ * Mirrors `VaultAdapter.sharesToTokens`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const tokens = EarnShares.toTokens(
+ *   { engineShares: 3n, supply: 2n },
+ *   7n,
+ * )
+ * // @log: 4n
+ * ```
+ *
+ * @param anchor - The conversion anchor.
+ * @param shares - Venue share amount, base units.
+ * @returns EarnToken units, rounded down.
+ */
+export function toTokens(anchor: Anchor, shares: bigint): bigint {
+  return (shares * anchor.supply) / anchor.engineShares
+}
+
+export declare namespace toTokens {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts venue shares to EarnToken units at the anchor rate, rounding up.
+ *
+ * Mirrors the adapter's ceiling conversion used by exact-asset exits.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const tokens = EarnShares.toTokensUp(
+ *   { engineShares: 3n, supply: 2n },
+ *   7n,
+ * )
+ * // @log: 5n
+ * ```
+ *
+ * @param anchor - The conversion anchor.
+ * @param shares - Venue share amount, base units.
+ * @returns EarnToken units, rounded up.
+ */
+export function toTokensUp(anchor: Anchor, shares: bigint): bigint {
+  const { engineShares, supply } = anchor
+  return (shares * supply + engineShares - 1n) / engineShares
+}
+
+export declare namespace toTokensUp {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Computes the dilution-correct EarnToken minted for an asset-denominated fee.
+ *
+ * Mirrors `FeeMath`: `feeShares = floor(fee * supply / (activeAssets - fee))`,
+ * zero when the fee is zero or not smaller than the active assets. Minting this
+ * amount to the fee ledger prices the fee at post-mint value per share.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const shares = EarnShares.feeShares({
+ *   activeAssets: 1_100n,
+ *   supply: 1_000n,
+ *   totalFeeAssets: 100n,
+ * })
+ * // @log: 100n
+ * ```
+ *
+ * @param options - Fee accrual inputs.
+ * @returns EarnToken to mint for the fee, rounded down.
+ */
+export function feeShares(options: feeShares.Options): bigint {
+  const { activeAssets, supply, totalFeeAssets } = options
+  if (totalFeeAssets === 0n || totalFeeAssets >= activeAssets) return 0n
+  return (totalFeeAssets * supply) / (activeAssets - totalFeeAssets)
+}
+
+export declare namespace feeShares {
+  export type Options = {
+    /** Assets backing the active (non-queued) supply, base units. */
+    activeAssets: bigint
+    /** Active EarnToken supply, base units. */
+    supply: bigint
+    /** Total fee liability in asset units. */
+    totalFeeAssets: bigint
+  }
+  export type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Lowers an expected output by a basis-point slippage tolerance, flooring to `1n`.
+ *
+ * Suitable for lower bounds such as a deposit's minimum shares or a redeem's
+ * minimum assets; not for upper bounds such as an exact withdrawal's maximum
+ * shares.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const minimumShares = EarnShares.minimumOutput(1_000_000n, 50n)
+ * // @log: 995_000n
+ * ```
+ *
+ * @param expected - Expected output in base units.
+ * @param slippageBps - Allowed slippage in basis points from `0n` through `9_999n`.
+ * @returns The minimum accepted output, floored to `1n`.
+ * @throws `InvalidExpectedOutputError` when `expected` is not positive.
+ * @throws `InvalidSlippageError` when `slippageBps` is outside its valid range.
+ */
+export function minimumOutput(expected: bigint, slippageBps: bigint): bigint {
+  if (expected <= 0n) throw new InvalidExpectedOutputError({ expected })
+  if (slippageBps < 0n || slippageBps >= basisPointScale)
+    throw new InvalidSlippageError({ slippageBps })
+  const bounded = (expected * (basisPointScale - slippageBps)) / basisPointScale
+  return bounded === 0n ? 1n : bounded
+}
+
+export declare namespace minimumOutput {
+  type ErrorType =
+    | InvalidExpectedOutputError
+    | InvalidSlippageError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Error thrown when an expected output is not positive.
+ */
+export class InvalidExpectedOutputError extends Errors.BaseError {
+  override readonly name = 'EarnShares.InvalidExpectedOutputError'
+
+  constructor(options: InvalidExpectedOutputError.Options) {
+    super(`Expected output \`${options.expected}\` must be greater than zero.`)
+  }
+}
+
+export declare namespace InvalidExpectedOutputError {
+  export type Options = {
+    expected: bigint
+  }
+}
+
+/**
+ * Error thrown when a slippage tolerance is outside `0n` through `9_999n`.
+ */
+export class InvalidSlippageError extends Errors.BaseError {
+  override readonly name = 'EarnShares.InvalidSlippageError'
+
+  constructor(options: InvalidSlippageError.Options) {
+    super(`Slippage tolerance \`${options.slippageBps}\` is invalid.`, {
+      metaMessages: [
+        `Slippage must be at least 0 and below ${basisPointScale} basis points.`,
+      ],
+    })
+  }
+}
+
+export declare namespace InvalidSlippageError {
+  export type Options = {
+    slippageBps: bigint
+  }
+}

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -63,6 +63,28 @@ export * as AuthorizationTempo from './AuthorizationTempo.js'
  */
 export * as Channel from './Channel.js'
 /**
+ * Tempo Earn `VaultAdapter` share math: raw EarnToken/venue-share conversions
+ * at the anchor rate, the dilution-correct fee-share formula, and the
+ * `minimumOutput` slippage floor.
+ *
+ * Conversions are fee-blind mirrors of the adapter's anchor arithmetic; use the
+ * adapter's `previewRedeem` for user-facing value.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const tokens = EarnShares.toTokens(
+ *   { engineShares: 3n, supply: 2n },
+ *   7n,
+ * )
+ * // @log: 4n
+ * ```
+ *
+ * @category Reference
+ */
+export * as EarnShares from './EarnShares.js'
+/**
  * Tempo key authorization utilities for provisioning and signing access keys.
  *
  * Access keys allow a root key (e.g., a passkey) to delegate transaction signing to secondary


### PR DESCRIPTION
Adds `EarnShares` to `ox/tempo`: raw EarnToken/venue-share conversions at the vault anchor rate, the dilution-correct fee-share formula, and a `minimumOutput` slippage floor for lower bounds.
