### PR TITLE
feat(tempo): add `EarnShares` utilities

### DIFF
--- a/.changeset/earn-shares-main.md
+++ b/.changeset/earn-shares-main.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Added `EarnShares` utilities for Tempo vault share conversions, fee share calculation, and slippage bounds.

--- a/package.json
+++ b/package.json
@@ -640,6 +640,11 @@
       "types": "./dist/tempo/Channel.d.ts",
       "default": "./dist/tempo/Channel.js"
     },
+    "./tempo/EarnShares": {
+      "src": "./src/tempo/EarnShares.ts",
+      "types": "./dist/tempo/EarnShares.d.ts",
+      "default": "./dist/tempo/EarnShares.js"
+    },
     "./tempo/KeyAuthorization": {
       "src": "./src/tempo/KeyAuthorization.ts",
       "types": "./dist/tempo/KeyAuthorization.d.ts",

--- a/src/tempo/EarnShares.test.ts
+++ b/src/tempo/EarnShares.test.ts
@@ -1,0 +1,120 @@
+import { EarnShares } from 'ox/tempo'
+import { describe, expect, test } from 'vite-plus/test'
+
+const anchor = { engineShares: 3n, shareSupply: 2n } as const
+
+describe('toAmount', () => {
+  test('default', () => {
+    expect(EarnShares.toAmount(anchor, 7n)).toBe(4n)
+  })
+
+  test('behavior: rounds down', () => {
+    expect(EarnShares.toAmount({ engineShares: 3n, shareSupply: 1n }, 2n)).toBe(
+      0n,
+    )
+  })
+})
+
+describe('toAmountUp', () => {
+  test('default', () => {
+    expect(EarnShares.toAmountUp(anchor, 7n)).toBe(5n)
+  })
+
+  test('behavior: exact conversions do not round up', () => {
+    expect(EarnShares.toAmountUp(anchor, 3n)).toBe(2n)
+  })
+})
+
+describe('toVenueAmount', () => {
+  test('default', () => {
+    expect(EarnShares.toVenueAmount(anchor, 7n)).toBe(10n)
+  })
+
+  test('behavior: identity at the initial 1:1 anchor', () => {
+    expect(
+      EarnShares.toVenueAmount({ engineShares: 1n, shareSupply: 1n }, 12_345n),
+    ).toBe(12_345n)
+  })
+})
+
+describe('feeShares', () => {
+  test('default', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 1_100n,
+        shareSupply: 1_000n,
+        totalFeeAssets: 100n,
+      }),
+    ).toBe(100n)
+  })
+
+  test('behavior: zero fee mints nothing', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 1_100n,
+        shareSupply: 1_000n,
+        totalFeeAssets: 0n,
+      }),
+    ).toBe(0n)
+  })
+
+  test('behavior: fee at or above active assets mints nothing', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 100n,
+        shareSupply: 1_000n,
+        totalFeeAssets: 100n,
+      }),
+    ).toBe(0n)
+  })
+
+  test('behavior: rounds down', () => {
+    expect(
+      EarnShares.feeShares({
+        activeAssets: 1_000n,
+        shareSupply: 999n,
+        totalFeeAssets: 100n,
+      }),
+    ).toBe(111n)
+  })
+})
+
+describe('minimumOutput', () => {
+  test('default', () => {
+    expect(EarnShares.minimumOutput(1_000_000n, 50)).toBe(995_000n)
+  })
+
+  test('behavior: zero slippage returns the expected output', () => {
+    expect(EarnShares.minimumOutput(1_000_000n, 0)).toBe(1_000_000n)
+  })
+
+  test('behavior: floors to 1n', () => {
+    expect(EarnShares.minimumOutput(1n, 9_999)).toBe(1n)
+  })
+
+  test('error: non-positive expected output', () => {
+    expect(() =>
+      EarnShares.minimumOutput(0n, 50),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[EarnShares.InvalidExpectedOutputError: Expected output \`0\` must be greater than zero.]`,
+    )
+  })
+
+  test('error: out-of-range slippage', () => {
+    expect(() => EarnShares.minimumOutput(1_000_000n, 10_000))
+      .toThrowErrorMatchingInlineSnapshot(`
+      [EarnShares.InvalidSlippageError: Slippage tolerance \`10000\` is invalid.
+
+      Slippage must be a whole number from 0 through 9999 basis points.]
+    `)
+  })
+
+  test('error: non-integer slippage', () => {
+    expect(() => EarnShares.minimumOutput(1_000_000n, 0.5))
+      .toThrowErrorMatchingInlineSnapshot(`
+      [EarnShares.InvalidSlippageError: Slippage tolerance \`0.5\` is invalid.
+
+      Slippage must be a whole number from 0 through 9999 basis points.]
+    `)
+  })
+})

--- a/src/tempo/EarnShares.ts
+++ b/src/tempo/EarnShares.ts
@@ -1,0 +1,235 @@
+import * as Errors from '../core/Errors.js'
+
+/** Basis-point denominator used by slippage bounds. */
+export const basisPointScale = 10_000
+
+/**
+ * Tempo Earn `VaultAdapter` conversion anchor.
+ *
+ * The adapter prices vault shares against venue shares through this pair:
+ * `engineShares` venue shares are worth `shareSupply` vault shares. It is initialised
+ * 1:1 and restated on `contribute` and `migrateEngine`.
+ *
+ * These conversions are raw and fee-blind; they ignore pending fee dilution
+ * and are unsuitable for user-facing value (use the adapter's `previewRedeem`).
+ */
+export type Anchor = {
+  /** Venue shares held by the engine at the anchor point. */
+  engineShares: bigint
+  /** Vault share supply at the anchor point. */
+  shareSupply: bigint
+}
+
+/**
+ * Converts venue shares to a vault share amount at the anchor rate, rounding down.
+ *
+ * Mirrors `VaultAdapter.sharesToTokens`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const shareAmount = EarnShares.toAmount(
+ *   { engineShares: 3n, shareSupply: 2n },
+ *   7n
+ * )
+ * // @log: 4n
+ * ```
+ *
+ * @param anchor - The conversion anchor.
+ * @param venueShareAmount - Venue share amount, base units.
+ * @returns Vault share amount, rounded down.
+ */
+export function toAmount(anchor: Anchor, venueShareAmount: bigint): bigint {
+  return (venueShareAmount * anchor.shareSupply) / anchor.engineShares
+}
+
+export declare namespace toAmount {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts venue shares to a vault share amount at the anchor rate, rounding up.
+ *
+ * Mirrors the adapter's ceiling conversion used by exact-asset exits.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const shareAmount = EarnShares.toAmountUp(
+ *   { engineShares: 3n, shareSupply: 2n },
+ *   7n
+ * )
+ * // @log: 5n
+ * ```
+ *
+ * @param anchor - The conversion anchor.
+ * @param venueShareAmount - Venue share amount, base units.
+ * @returns Vault share amount, rounded up.
+ */
+export function toAmountUp(anchor: Anchor, venueShareAmount: bigint): bigint {
+  const { engineShares, shareSupply } = anchor
+  return (venueShareAmount * shareSupply + engineShares - 1n) / engineShares
+}
+
+export declare namespace toAmountUp {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Converts a vault share amount to venue shares at the anchor rate, rounding down.
+ *
+ * Mirrors `VaultAdapter.tokensToShares`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const venueShareAmount = EarnShares.toVenueAmount(
+ *   { engineShares: 3n, shareSupply: 2n },
+ *   7n
+ * )
+ * // @log: 10n
+ * ```
+ *
+ * @param anchor - The conversion anchor.
+ * @param shareAmount - Vault share amount, base units.
+ * @returns Venue share amount, rounded down.
+ */
+export function toVenueAmount(anchor: Anchor, shareAmount: bigint): bigint {
+  return (shareAmount * anchor.engineShares) / anchor.shareSupply
+}
+
+export declare namespace toVenueAmount {
+  type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Computes the dilution-correct vault shares minted for an asset-denominated fee.
+ *
+ * Mirrors `FeeMath`:
+ * `feeShares = floor(fee * shareSupply / (activeAssets - fee))`, zero when the
+ * fee is zero or not smaller than the active assets. Minting this amount to the
+ * fee ledger prices the fee at post-mint value per share.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const shares = EarnShares.feeShares({
+ *   activeAssets: 1_100n,
+ *   shareSupply: 1_000n,
+ *   totalFeeAssets: 100n
+ * })
+ * // @log: 100n
+ * ```
+ *
+ * @param options - Fee accrual inputs.
+ * @returns Vault shares to mint for the fee, rounded down.
+ */
+export function feeShares(options: feeShares.Options): bigint {
+  const { activeAssets, shareSupply, totalFeeAssets } = options
+  if (totalFeeAssets === 0n || totalFeeAssets >= activeAssets) return 0n
+  return (totalFeeAssets * shareSupply) / (activeAssets - totalFeeAssets)
+}
+
+export declare namespace feeShares {
+  export type Options = {
+    /** Assets backing the active (non-queued) supply, base units. */
+    activeAssets: bigint
+    /** Active vault share supply, base units. */
+    shareSupply: bigint
+    /** Total fee liability in asset units. */
+    totalFeeAssets: bigint
+  }
+  export type ErrorType = Errors.GlobalErrorType
+}
+
+/**
+ * Lowers an expected output by a basis-point slippage tolerance, flooring to `1n`.
+ *
+ * Suitable for lower bounds such as a deposit's minimum shares or a redeem's
+ * minimum assets; not for upper bounds such as an exact withdrawal's maximum
+ * shares.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const minimumShares = EarnShares.minimumOutput(
+ *   1_000_000n,
+ *   50
+ * )
+ * // @log: 995_000n
+ * ```
+ *
+ * @param expectedAmount - Expected output in base units.
+ * @param slippageBps - Allowed slippage in basis points from `0` through `9_999`.
+ * @returns The minimum accepted output, floored to `1n`.
+ * @throws `InvalidExpectedOutputError` when `expectedAmount` is not positive.
+ * @throws `InvalidSlippageError` when `slippageBps` is outside its valid range.
+ */
+export function minimumOutput(
+  expectedAmount: bigint,
+  slippageBps: number,
+): bigint {
+  if (expectedAmount <= 0n)
+    throw new InvalidExpectedOutputError({ expectedAmount })
+  if (
+    !Number.isInteger(slippageBps) ||
+    slippageBps < 0 ||
+    slippageBps >= basisPointScale
+  )
+    throw new InvalidSlippageError({ slippageBps })
+  const scale = BigInt(basisPointScale)
+  const bounded = (expectedAmount * (scale - BigInt(slippageBps))) / scale
+  return bounded === 0n ? 1n : bounded
+}
+
+export declare namespace minimumOutput {
+  type ErrorType =
+    | InvalidExpectedOutputError
+    | InvalidSlippageError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Error thrown when an expected output is not positive.
+ */
+export class InvalidExpectedOutputError extends Errors.BaseError {
+  override readonly name = 'EarnShares.InvalidExpectedOutputError'
+
+  constructor(options: InvalidExpectedOutputError.Options) {
+    super(
+      `Expected output \`${options.expectedAmount}\` must be greater than zero.`,
+    )
+  }
+}
+
+export declare namespace InvalidExpectedOutputError {
+  export type Options = {
+    expectedAmount: bigint
+  }
+}
+
+/**
+ * Error thrown when a slippage tolerance is not an integer from `0` through `9_999`.
+ */
+export class InvalidSlippageError extends Errors.BaseError {
+  override readonly name = 'EarnShares.InvalidSlippageError'
+
+  constructor(options: InvalidSlippageError.Options) {
+    super(`Slippage tolerance \`${options.slippageBps}\` is invalid.`, {
+      metaMessages: [
+        `Slippage must be a whole number from 0 through ${basisPointScale - 1} basis points.`,
+      ],
+    })
+  }
+}
+
+export declare namespace InvalidSlippageError {
+  export type Options = {
+    slippageBps: number
+  }
+}

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -69,6 +69,28 @@ export * as AuthorizationTempo from './AuthorizationTempo.js'
  */
 export * as Channel from './Channel.js'
 /**
+ * Tempo Earn `VaultAdapter` share math: raw vault-share and venue-share conversions
+ * at the anchor rate, the dilution-correct fee-share formula, and the
+ * `minimumOutput` slippage floor.
+ *
+ * Conversions are fee-blind mirrors of the adapter's anchor arithmetic; use the
+ * adapter's `previewRedeem` for user-facing value.
+ *
+ * @example
+ * ```ts twoslash
+ * import { EarnShares } from 'ox/tempo'
+ *
+ * const shareAmount = EarnShares.toAmount(
+ *   { engineShares: 3n, shareSupply: 2n },
+ *   7n
+ * )
+ * // @log: 4n
+ * ```
+ *
+ * @category Reference
+ */
+export * as EarnShares from './EarnShares.js'
+/**
  * Tempo key authorization utilities for provisioning and signing access keys.
  *
  * Access keys allow a root key (e.g., a passkey) to delegate transaction signing to secondary


### PR DESCRIPTION
Adds `EarnShares` to `main` with vault and venue share conversions, fee dilution math, and slippage bounds, matching the finalized 0.x API.
