### PR TITLE
fix(tempo): correct Zone chain ID derivation

### DIFF
--- a/.changeset/calm-zones-rest.md
+++ b/.changeset/calm-zones-rest.md
@@ -1,0 +1,11 @@
+---
+'ox': patch
+---
+
+Corrected Zone chain ID conversion for Presto and Moderato source chains.
+
+```ts
+import { ZoneId } from 'ox/tempo'
+
+ZoneId.toChainId(1, 42_431)
+```

--- a/src/tempo/ZoneId.test-d.ts
+++ b/src/tempo/ZoneId.test-d.ts
@@ -1,0 +1,16 @@
+import { expectTypeOf, test } from 'vitest'
+import * as ZoneId from './ZoneId.js'
+
+test('accepts supported source IDs', () => {
+  expectTypeOf(ZoneId.fromChainId(421_700_001)).toEqualTypeOf<number>()
+  expectTypeOf(
+    ZoneId.fromChainId(1_424_310_001, 42_431),
+  ).toEqualTypeOf<number>()
+  expectTypeOf(ZoneId.toChainId(1)).toEqualTypeOf<number>()
+  expectTypeOf(ZoneId.toChainId(1, 42_431)).toEqualTypeOf<number>()
+
+  // @ts-expect-error Unsupported source ID.
+  ZoneId.fromChainId(421_700_001, 1)
+  // @ts-expect-error Unsupported source ID.
+  ZoneId.toChainId(1, 1)
+})

--- a/src/tempo/ZoneId.test.ts
+++ b/src/tempo/ZoneId.test.ts
@@ -3,40 +3,75 @@ import * as ZoneId from './ZoneId.js'
 
 describe('fromChainId', () => {
   test('default', () => {
-    expect(ZoneId.fromChainId(4_217_000_006)).toBe(6)
+    expect(ZoneId.chainIdBase).toMatchInlineSnapshot(`421700000`)
+    expect(ZoneId.fromChainId(421_700_001)).toMatchInlineSnapshot(`1`)
   })
 
-  test('zone 1', () => {
-    expect(ZoneId.fromChainId(4_217_000_001)).toBe(1)
+  test('Moderato', () => {
+    expect(ZoneId.fromChainId(1_424_310_028, 42_431)).toMatchInlineSnapshot(
+      `28`,
+    )
   })
 
-  test('zone 28', () => {
-    expect(ZoneId.fromChainId(4_217_000_028)).toBe(28)
+  test('unsupported source id', () => {
+    expect(() =>
+      // @ts-expect-error Unsupported source ID.
+      ZoneId.fromChainId(421_700_001, 1),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [ZoneId.UnsupportedSourceIdError: Source chain ID "1" is not supported.
+
+      Supported source chain IDs: 4217, 42431.]
+    `)
   })
 })
 
 describe('toChainId', () => {
   test('default', () => {
-    expect(ZoneId.toChainId(6)).toBe(4_217_000_006)
+    expect(ZoneId.toChainId(1)).toMatchInlineSnapshot(`421700001`)
   })
 
-  test('zone 1', () => {
-    expect(ZoneId.toChainId(1)).toBe(4_217_000_001)
+  test('Moderato', () => {
+    expect(ZoneId.toChainId(28, 42_431)).toMatchInlineSnapshot(`1424310028`)
   })
 
-  test('zone 28', () => {
-    expect(ZoneId.toChainId(28)).toBe(4_217_000_028)
+  test('wraps within the source chain range', () => {
+    expect(ZoneId.toChainId(1_002_610_001)).toMatchInlineSnapshot(`421700001`)
+    expect(ZoneId.toChainId(723_173_649, 42_431)).toMatchInlineSnapshot(
+      `1424310001`,
+    )
+  })
+
+  test('unsupported source id', () => {
+    expect(() =>
+      // @ts-expect-error Unsupported source ID.
+      ZoneId.toChainId(1, 1),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [ZoneId.UnsupportedSourceIdError: Source chain ID "1" is not supported.
+
+      Supported source chain IDs: 4217, 42431.]
+    `)
   })
 })
 
 describe('roundtrip', () => {
   test('fromChainId → toChainId', () => {
-    const chainId = 4_217_000_006
-    expect(ZoneId.toChainId(ZoneId.fromChainId(chainId))).toBe(chainId)
+    const chainId = 421_700_006
+    expect(ZoneId.toChainId(ZoneId.fromChainId(chainId))).toMatchInlineSnapshot(
+      `421700006`,
+    )
   })
 
   test('toChainId → fromChainId', () => {
     const zoneId = 42
-    expect(ZoneId.fromChainId(ZoneId.toChainId(zoneId))).toBe(zoneId)
+    expect(ZoneId.fromChainId(ZoneId.toChainId(zoneId))).toMatchInlineSnapshot(
+      `42`,
+    )
+  })
+
+  test('Moderato', () => {
+    const zoneId = 42
+    const sourceId = 42_431
+    const chainId = ZoneId.toChainId(zoneId, sourceId)
+    expect(ZoneId.fromChainId(chainId, sourceId)).toMatchInlineSnapshot(`42`)
   })
 })

--- a/src/tempo/ZoneId.ts
+++ b/src/tempo/ZoneId.ts
@@ -1,58 +1,94 @@
-import type * as Errors from '../core/Errors.js'
+import * as Errors from '../core/Errors.js'
+
+const chainIdConfig = {
+  4217: {
+    base: 421_700_000,
+    range: 1_002_610_000,
+  },
+  42431: {
+    base: 1_424_310_000,
+    range: 723_173_648,
+  },
+} as const
+
+const defaultSourceId = 4_217
 
 /**
- * Base offset for deriving zone chain IDs.
- *
- * Zone chain IDs are computed as `chainIdBase + zoneId`.
+ * Base offset for deriving Presto zone chain IDs.
  */
-export const chainIdBase = 4_217_000_000 as const
+export const chainIdBase = chainIdConfig[defaultSourceId].base
+
+/** Tempo source chain ID. */
+export type SourceId = keyof typeof chainIdConfig
 
 /**
  * Derives a zone ID from a zone chain ID.
  *
- * Zone chain IDs follow the formula `4_217_000_000 + zoneId`, so a chain ID
- * of `4217000006` corresponds to zone ID `6`.
+ * Zone chain IDs use the base assigned to their Tempo source chain.
  *
  * @example
  * ```ts twoslash
  * import { ZoneId } from 'ox/tempo'
  *
- * const zoneId = ZoneId.fromChainId(4_217_000_006)
- * // @log: 6
+ * const zoneId = ZoneId.fromChainId(421_700_001)
+ * // @log: 1
  * ```
  *
  * @param chainId - The zone chain ID.
+ * @param sourceId - The Tempo source chain ID. Defaults to `4217` (Presto).
  * @returns The zone ID.
  */
-export function fromChainId(chainId: number): number {
-  return chainId - chainIdBase
+export function fromChainId(
+  chainId: number,
+  sourceId: SourceId = defaultSourceId,
+): number {
+  return chainId - getChainIdConfig(sourceId).base
 }
 
 export declare namespace fromChainId {
-  type ErrorType = Errors.GlobalErrorType
+  type ErrorType = typeof UnsupportedSourceIdError | Errors.GlobalErrorType
 }
 
 /**
  * Derives a zone chain ID from a zone ID.
  *
- * Zone chain IDs follow the formula `4_217_000_000 + zoneId`, so zone ID
- * `6` corresponds to chain ID `4217000006`.
+ * Zone chain IDs use the base and range assigned to their Tempo source chain.
  *
  * @example
  * ```ts twoslash
  * import { ZoneId } from 'ox/tempo'
  *
- * const chainId = ZoneId.toChainId(6)
- * // @log: 4217000006
+ * const chainId = ZoneId.toChainId(1)
+ * // @log: 421700001
  * ```
  *
  * @param zoneId - The zone ID.
+ * @param sourceId - The Tempo source chain ID. Defaults to `4217` (Presto).
  * @returns The zone chain ID.
  */
-export function toChainId(zoneId: number): number {
-  return chainIdBase + zoneId
+export function toChainId(
+  zoneId: number,
+  sourceId: SourceId = defaultSourceId,
+): number {
+  const { base, range } = getChainIdConfig(sourceId)
+  return base + (zoneId % range)
 }
 
 export declare namespace toChainId {
-  type ErrorType = Errors.GlobalErrorType
+  type ErrorType = typeof UnsupportedSourceIdError | Errors.GlobalErrorType
+}
+
+/** Thrown when a Tempo source chain ID is unsupported. */
+export class UnsupportedSourceIdError extends Errors.BaseError {
+  override readonly name = 'ZoneId.UnsupportedSourceIdError'
+  constructor({ sourceId }: { sourceId: number }) {
+    super(`Source chain ID "${sourceId}" is not supported.`, {
+      metaMessages: ['Supported source chain IDs: 4217, 42431.'],
+    })
+  }
+}
+
+function getChainIdConfig(sourceId: number) {
+  if (sourceId === 4_217 || sourceId === 42_431) return chainIdConfig[sourceId]
+  throw new UnsupportedSourceIdError({ sourceId })
 }

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -524,18 +524,17 @@ export * as VirtualMaster from './VirtualMaster.js'
 /**
  * Zone ID utilities for converting between zone IDs and zone chain IDs.
  *
- * Zone chain IDs are deterministically derived from zone IDs using the formula
- * `421_700_000 + zoneId`. This module provides helpers to convert between them.
+ * Zone chain IDs use the base and range assigned to their Tempo source chain.
  *
  * @example
  * ```ts twoslash
  * import { ZoneId } from 'ox/tempo'
  *
- * const zoneId = ZoneId.fromChainId(421_700_026)
- * // @log: 26
+ * const zoneId = ZoneId.fromChainId(421_700_001)
+ * // @log: 1
  *
- * const chainId = ZoneId.toChainId(26)
- * // @log: 421700026
+ * const chainId = ZoneId.toChainId(1)
+ * // @log: 421700001
  * ```
  *
  * @category Reference


### PR DESCRIPTION
Backports the `ZoneId` correction from https://github.com/wevm/ox/pull/314 to `0.x`, matching upstream Presto and Moderato bases and ranges while adding typed `sourceId` handling.