### PR TITLE
fix(docs): repair engine links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@
 - **Source docs first** -- public API documentation usually belongs in TSDoc near the exported source.
 - **Site pages** -- human guides live under `site/src/pages/`.
 - **Generated docs** -- `site/src/pages/api`, `site/src/pages/ercs`, `site/src/pages/tempo`, `site/src/pages/wasm`, `site/src/pages/webauthn`, `site/src/pages/glossary`, and `site/src/pages.gen.ts` are generated outputs. Do not edit them by hand unless explicitly requested.
-- **Check TSDoc when touching docs** -- run `pnpm check:tsdoc` after changing public comments or examples.
+- **Check TSDoc when touching docs** -- run `pnpm docs:gen` after changing public comments or examples.
 - **SEO descriptions are auto-derived** -- every generated docs page emits a `description` frontmatter (used for `<meta name="description">` and OG images), targeting 5-15 words. It is derived from the TSDoc summary (markdown stripped, first paragraph, clamped). Add an optional `@description` TSDoc block tag to a function/namespace/schema to override the auto-derived text with hand-written SEO copy. Hand-written site pages should set their own `description` frontmatter (or a `# Title [description]` heading).
 
 ## Type Conventions

--- a/site/src/pages/guides/engine.md
+++ b/site/src/pages/guides/engine.md
@@ -149,7 +149,7 @@ The engine is process-wide, so this is only safe for synchronous functions — c
 
 ## Caches
 
-[`Caches`](/api/Caches) memoizes values derived from cryptography, such as address checksums. `Engine.set` and `Engine.reset` clear them, so a swapped hash implementation never returns a stale cached value.
+`Caches` memoizes values derived from cryptography, such as address checksums. `Engine.set` and `Engine.reset` clear them, so a swapped hash implementation never returns a stale cached value.
 
 ## Testing
 

--- a/src/wasm/Engine.ts
+++ b/src/wasm/Engine.ts
@@ -46,8 +46,9 @@ export declare namespace load {
  *
  * Reach for this where an engine has to exist as a value: measuring one
  * implementation against another, or installing for the duration of a call.
- * Combining engines does not need it, because {@link ox#Engine.set} merges --
- * `await load()` followed by `Engine.set({ Secp256k1 })` leaves both in place.
+ * Combining engines does not need it, because
+ * [`Engine.set`](/api/Engine/set) merges -- `await load()` followed by
+ * `Engine.set({ Secp256k1 })` leaves both in place.
  *
  * @example
  * ```ts twoslash


### PR DESCRIPTION
Fixes Engine documentation links that caused Vocs' dead-link check to fail. Points WASM references at the core Engine API, removes the unavailable Caches target, and updates doc validation guidance.