### PR TITLE
fix: align engine exports and fuzz scope

### DIFF
--- a/.changeset/calm-engines-export.md
+++ b/.changeset/calm-engines-export.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Re-exported `Engine.InvalidSlotValueError` from the Node and WASM entrypoints.

--- a/src/node/Engine.ts
+++ b/src/node/Engine.ts
@@ -10,6 +10,7 @@ import * as X25519 from './X25519.js'
 export {
   AsyncScopeError,
   get,
+  InvalidSlotValueError,
   reset,
   set,
   UnknownPrimitiveError,

--- a/src/node/_test/Engine.test-d.ts
+++ b/src/node/_test/Engine.test-d.ts
@@ -14,6 +14,9 @@ test('install and engine expose the same precise engine', () => {
 
 test('the Node Engine namespace exposes synchronous core operations', () => {
   expectTypeOf(Engine.get).toEqualTypeOf(CoreEngine.get)
+  expectTypeOf(Engine.InvalidSlotValueError).toEqualTypeOf(
+    CoreEngine.InvalidSlotValueError,
+  )
   expectTypeOf(Engine.reset).toEqualTypeOf(CoreEngine.reset)
   expectTypeOf(Engine.set).toEqualTypeOf(CoreEngine.set)
   expectTypeOf(Engine.with).toEqualTypeOf(CoreEngine.with)

--- a/src/wasm/Engine.ts
+++ b/src/wasm/Engine.ts
@@ -10,6 +10,7 @@ import type * as internal from './internal/instantiate.js'
 export {
   AsyncScopeError,
   get,
+  InvalidSlotValueError,
   reset,
   set,
   UnknownPrimitiveError,

--- a/src/wasm/_test/Engine.test-d.ts
+++ b/src/wasm/_test/Engine.test-d.ts
@@ -14,6 +14,9 @@ test('install and engine expose the same precise engine', () => {
 
 test('the WASM Engine namespace exposes synchronous core operations', () => {
   expectTypeOf(Engine.get).toEqualTypeOf(CoreEngine.get)
+  expectTypeOf(Engine.InvalidSlotValueError).toEqualTypeOf(
+    CoreEngine.InvalidSlotValueError,
+  )
   expectTypeOf(Engine.reset).toEqualTypeOf(CoreEngine.reset)
   expectTypeOf(Engine.set).toEqualTypeOf(CoreEngine.set)
   expectTypeOf(Engine.with).toEqualTypeOf(CoreEngine.with)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -296,9 +296,9 @@ export default defineConfig({
       {
         extends: true,
         test: {
-          // The properties the `fuzz` project runs under Node, put in front of
-          // the native codecs only a browser has. Gated behind `FUZZ=true`
-          // alongside it.
+          // Browser-compatible properties from the `fuzz` project, put in
+          // front of native codecs only a browser has. Gated behind
+          // `FUZZ=true` alongside it.
           name: 'fuzz-browser',
           deps: {
             // Discover every direct fuzz oracle before browsers connect.
@@ -334,7 +334,7 @@ export default defineConfig({
               },
             },
           },
-          include: process.env.FUZZ ? ['src/**/*.fuzz.ts'] : [],
+          include: process.env.FUZZ ? ['src/**/*.fuzz.ts', '!src/node/**'] : [],
           testTimeout: fuzzTimeout,
           browser: {
             enabled: true,


### PR DESCRIPTION
Re-exports `InvalidSlotValueError` from `ox/node` and `ox/wasm`, and excludes Node-only fuzz suites from browser collection. This preserves provider API parity and browser fuzz compatibility after https://github.com/wevm/ox/pull/324.