### PR TITLE
feat(engine): expand blake3, bls, and hd key support

### DIFF
--- a/.changeset/fresh-hd-key-engine.md
+++ b/.changeset/fresh-hd-key-engine.md
@@ -1,0 +1,17 @@
+---
+'ox': patch
+---
+
+Added an `HdKey` engine boundary for seed import, extended-key import, and derivation.
+
+```ts
+import { Engine } from 'ox'
+import { hdKey } from './hd-key-engine.js'
+
+type CompleteHdKey = {
+  [name in keyof Engine.HdKey]-?: NonNullable<Engine.HdKey[name]>
+}
+
+const completeHdKey: CompleteHdKey = hdKey
+Engine.set({ HdKey: completeHdKey })
+```

--- a/.changeset/preserve-serialized-bls.md
+++ b/.changeset/preserve-serialized-bls.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Preserved serialized BLS inputs and outputs across engine calls to avoid redundant point conversions.

--- a/.changeset/public-blake3-hash.md
+++ b/.changeset/public-blake3-hash.md
@@ -1,0 +1,11 @@
+---
+'ox': patch
+---
+
+Added `Hash.blake3` for BLAKE3 hashing through Ox's default or an installed engine implementation.
+
+```ts
+import { Hash } from 'ox'
+
+const digest = Hash.blake3('0xdeadbeef')
+```

--- a/scripts/bench:engines.ts
+++ b/scripts/bench:engines.ts
@@ -19,6 +19,7 @@ import * as bls from '../src/core/internal/bls.js'
 import * as ed25519 from '../src/core/internal/ed25519.js'
 import * as engineContract from '../src/core/internal/engine.js'
 import * as hash from '../src/core/internal/hash.js'
+import * as hdKey from '../src/core/internal/hdKey.js'
 import * as keystore from '../src/core/internal/keystore.js'
 import * as mnemonic from '../src/core/internal/mnemonic.js'
 import * as p256 from '../src/core/internal/p256.js'
@@ -291,6 +292,25 @@ for (const size of hashSizes) {
   sync('Hash', 'sha256', case_, () => hash.sha256(input))
 }
 
+const hdKeySeed = bytes(32)
+const hdKeyVersions = { private: 0x0488_ade4, public: 0x0488_b21e }
+const hdKeyRoot = hdKey.fromSeed(hdKeySeed, hdKeyVersions)
+
+sync('HdKey', 'derive', "m/44'/60'/0'/0/0", () =>
+  hdKey.derive(
+    hdKeyRoot.privateExtendedKey,
+    "m/44'/60'/0'/0/0",
+    hdKeyVersions,
+    hdKeyVersions,
+  ),
+)
+sync('HdKey', 'fromExtendedKey', 'private extended key', () =>
+  hdKey.fromExtendedKey(hdKeyRoot.privateExtendedKey, hdKeyVersions),
+)
+sync('HdKey', 'fromSeed', '32 B seed', () =>
+  hdKey.fromSeed(hdKeySeed, hdKeyVersions),
+)
+
 const aesKey = bytes(16, 97)
 const aesIv = bytes(16, 53)
 const aesPlaintext = bytes(4096)
@@ -408,8 +428,14 @@ for (const [slot, primitives] of Object.entries(engineContract.primitives))
     )
       throw new Error(`Missing benchmark for ${slot}.${primitive}`)
 
+const nodeInitializationStart = performance.now()
 const node = await nodeEngine()
+const nodeInitializationNs = (performance.now() - nodeInitializationStart) * 1e6
+
+const wasmInitializationStart = performance.now()
 const wasm = await wasmEngine()
+const wasmInitializationNs = (performance.now() - wasmInitializationStart) * 1e6
+
 const rustRows = rust()
 
 const headers = [
@@ -424,6 +450,16 @@ const headers = [
 
 console.log(
   'Best-observed time per call. Lower is better; Alloy is reference only.',
+)
+console.log(
+  '\nFirst engine factory call after module loading; each provider initializes once.',
+)
+table(
+  ['provider', 'initialization'],
+  [
+    ['ox/node', format(nodeInitializationNs)],
+    ['ox/wasm', format(wasmInitializationNs)],
+  ],
 )
 
 for (const slot of engineContract.slots) {

--- a/site/src/pages/guides/engine.md
+++ b/site/src/pages/guides/engine.md
@@ -260,20 +260,6 @@ Binary values cross engine boundaries as raw `Uint8Array` values. Ox performs
 rather than relying on a side-effect import: Ox declares `sideEffects: false`,
 so a bundler may drop an import that appears unused.
 
-The `HdKey` slot receives BIP-32 seeds and extended private keys as trusted
-inputs and returns plain records rather than provider objects. Existing HD-key
-values resolve the currently installed implementation whenever `derive` is
-called, so scoped overrides and engine swaps do not retain provider instances.
-On derivation, `versions` selects the returned node's version bytes; providers
-must read the source private version from the encoded key independently.
-Providers must accept non-zero-offset seed views without mutation or retention
-and return fresh, owned buffers and version records.
-
-Serialized `Bls` implementations are responsible for matching Ox's default
-validation of compressed lengths, canonical encodings, curve membership,
-subgroups, and infinity. Providers must not mutate or retain input views and
-must return fresh, exact-length byte arrays.
-
 **Benefits**
 
 - Supports synchronous native libraries and policy-required providers.
@@ -300,10 +286,16 @@ Run the engine comparison with:
 pnpm bench:engines
 ```
 
-Run the BLS boundary benchmarks in Node and supported browsers with:
+Run focused benchmarks for the added public hash, serialized BLS, and HD-key
+paths with:
 
 ```sh
-pnpm bench --project core src/core/Bls.bench.ts src/core/Bls_crypto.bench.ts
+pnpm bench --project core src/core/Hash.bench.ts src/core/Bls.bench.ts src/core/Bls_crypto.bench.ts src/core/HdKey.bench.ts
+```
+
+Run the BLS boundary benchmarks in supported browsers with:
+
+```sh
 pnpm bench --project browser src/core/Bls.bench.ts --testNamePattern 'Bls\.(getPublicKey|sign|verify)'
 ```
 
@@ -327,31 +319,6 @@ engine. The provider columns count the primitives each implementation supplies:
 harness never times Ox's fallback under another engine's name.
 `alloy-primitives` provides Keccak256 only; it is a native reference, not an Ox
 engine.
-
-The harness reports the first provider factory call separately from steady
-state. A fresh process on the benchmark host, after module loading, measured:
-
-| Provider  | Initialization |
-| --------- | -------------- |
-| `ox/node` | 221.08 µs      |
-| `ox/wasm` | 5.22 ms        |
-
-Each provider initializes once, so these single-call measurements are startup
-costs rather than throughput distributions. WASM compilation is memoized after
-the first successful call.
-
-A separate Playwright run records the serialized BLS boundary in every
-supported browser. These rows compare the fastest serialized representation
-with the structured-object path:
-
-| Browser        | `getPublicKey` output | `sign` output | `verify` input |
-| -------------- | --------------------- | ------------- | -------------- |
-| Chromium 145   | 1.87×                 | 1.11×         | 1.10×          |
-| Firefox 146    | 2.48×                 | 1.29×         | 1.14×          |
-| WebKit 26      | 1.84×                 | 1.08×         | 1.07×          |
-
-Browser benchmark timers are coarser than Node's, especially for short calls;
-use these as directional conversion-cost measurements.
 
 Local runs on an Apple M4 Max with Node.js 25.9.0 and Rust 1.93.1, using 50 ms
 warmups, 200 ms measurement budgets, and three repeats, produced the following

--- a/site/src/pages/guides/engine.md
+++ b/site/src/pages/guides/engine.md
@@ -35,7 +35,7 @@ No setup is required:
 ```ts twoslash
 import { Hash } from 'ox'
 
-const digest = Hash.keccak256('0xdeadbeef')
+const digest = Hash.blake3('0xdeadbeef')
 ```
 
 Ox's defaults use the
@@ -94,12 +94,12 @@ await Engine.install({
   Hash: Hash.engine(),
 })
 
-const digest = Hash.sha256('0xdeadbeef')
+const digest = Hash.blake3('0xdeadbeef')
 ```
 
 `Engine.install` awaits all supplied slot promises together, then installs the
 resolved modules atomically. `Hash.engine()` returns the raw `Hash` slot;
-`Hash.sha256()` remains the normal formatted public API.
+`Hash.blake3()` remains the normal formatted public API.
 
 **Benefits**
 
@@ -260,6 +260,20 @@ Binary values cross engine boundaries as raw `Uint8Array` values. Ox performs
 rather than relying on a side-effect import: Ox declares `sideEffects: false`,
 so a bundler may drop an import that appears unused.
 
+The `HdKey` slot receives BIP-32 seeds and extended private keys as trusted
+inputs and returns plain records rather than provider objects. Existing HD-key
+values resolve the currently installed implementation whenever `derive` is
+called, so scoped overrides and engine swaps do not retain provider instances.
+On derivation, `versions` selects the returned node's version bytes; providers
+must read the source private version from the encoded key independently.
+Providers must accept non-zero-offset seed views without mutation or retention
+and return fresh, owned buffers and version records.
+
+Serialized `Bls` implementations are responsible for matching Ox's default
+validation of compressed lengths, canonical encodings, curve membership,
+subgroups, and infinity. Providers must not mutate or retain input views and
+must return fresh, exact-length byte arrays.
+
 **Benefits**
 
 - Supports synchronous native libraries and policy-required providers.
@@ -269,8 +283,8 @@ so a bundler may drop an import that appears unused.
 
 **Trade-offs**
 
-- The engine author owns algorithm semantics, output lengths, key formats, and
-  error behavior.
+- The engine author owns algorithm semantics, validation, output lengths, key
+  formats, and error behavior.
 - Most engine functions are synchronous. Only explicitly asynchronous
   contracts such as `scryptAsync` may return promises.
 - Overrides are module-instance-global, so initialization order and concurrent
@@ -286,7 +300,14 @@ Run the engine comparison with:
 pnpm bench:engines
 ```
 
-The harness covers every engine slot and all 38 primitives in Ox's default
+Run the BLS boundary benchmarks in Node and supported browsers with:
+
+```sh
+pnpm bench --project core src/core/Bls.bench.ts src/core/Bls_crypto.bench.ts
+pnpm bench --project browser src/core/Bls.bench.ts --testNamePattern 'Bls\.(getPublicKey|sign|verify)'
+```
+
+The harness covers every engine slot and all 41 primitives in Ox's default
 engine. The provider columns count the primitives each implementation supplies:
 
 | Slot          | Primitives | `ox` | `ox/node` | `ox/wasm` | `alloy (Rust)` |
@@ -294,17 +315,43 @@ engine. The provider columns count the primitives each implementation supplies:
 | `Bls`         | 5          | 5    | n/a       | n/a       | n/a            |
 | `Ed25519`     | 6          | 6    | 3         | 4         | n/a            |
 | `Hash`        | 5          | 5    | 3         | 5         | 1              |
+| `HdKey`       | 3          | 3    | n/a       | n/a       | n/a            |
 | `Keystore`    | 6          | 6    | 4         | 1         | n/a            |
 | `Mnemonic`    | 1          | 1    | 1         | 1         | n/a            |
 | `P256`        | 6          | 6    | 1         | n/a       | n/a            |
 | `Secp256k1`   | 6          | 6    | n/a       | n/a       | n/a            |
 | `X25519`      | 3          | 3    | 2         | 2         | n/a            |
-| **Total**     | **38**     | **38** | **14**    | **13**    | **1**          |
+| **Total**     | **41**     | **41** | **14**    | **13**    | **1**          |
 
 `n/a` means the provider does not implement a primitive in that slot. The
 harness never times Ox's fallback under another engine's name.
 `alloy-primitives` provides Keccak256 only; it is a native reference, not an Ox
 engine.
+
+The harness reports the first provider factory call separately from steady
+state. A fresh process on the benchmark host, after module loading, measured:
+
+| Provider  | Initialization |
+| --------- | -------------- |
+| `ox/node` | 221.08 µs      |
+| `ox/wasm` | 5.22 ms        |
+
+Each provider initializes once, so these single-call measurements are startup
+costs rather than throughput distributions. WASM compilation is memoized after
+the first successful call.
+
+A separate Playwright run records the serialized BLS boundary in every
+supported browser. These rows compare the fastest serialized representation
+with the structured-object path:
+
+| Browser        | `getPublicKey` output | `sign` output | `verify` input |
+| -------------- | --------------------- | ------------- | -------------- |
+| Chromium 145   | 1.87×                 | 1.11×         | 1.10×          |
+| Firefox 146    | 2.48×                 | 1.29×         | 1.14×          |
+| WebKit 26      | 1.84×                 | 1.08×         | 1.07×          |
+
+Browser benchmark timers are coarser than Node's, especially for short calls;
+use these as directional conversion-cost measurements.
 
 Local runs on an Apple M4 Max with Node.js 25.9.0 and Rust 1.93.1, using 50 ms
 warmups, 200 ms measurement budgets, and three repeats, produced the following
@@ -371,8 +418,10 @@ signature, and key lengths rather than checking only that a call succeeds.
 
 Ox's built-in engines add independent conformance coverage for NIST AES-CTR,
 RFC 7914 PBKDF2, RFC 8032 Ed25519, all 196 ZIP-215 verification cases, RFC 7748
-X25519, libsodium's low-order X25519 corpus, official BLAKE3 vectors, and
-English and Japanese BIP-39 vectors. Differential fuzz tests also cover
+X25519, libsodium's low-order X25519 corpus, official BLAKE3 vectors, published
+BIP-32 vectors, the
+[Ethereum BLS12-381 signature suite](https://github.com/ethereum/bls12-381-tests/releases/tag/v0.1.0),
+and English and Japanese BIP-39 vectors. Differential fuzz tests also cover
 subviews, input immutability, output ownership, interleaved providers, memory
 growth, and boundary-sized inputs. WASM conformance runs in Chromium, Firefox,
 and WebKit as well as Node.js.
@@ -380,9 +429,10 @@ and WebKit as well as Node.js.
 ## Security
 
 Treat an engine as trusted code. Depending on the slot, it can receive HMAC
-keys, private keys, passwords, mnemonic phrases, and plaintext keystore
-material. `Engine.install` and `Engine.set` validate slot and primitive names,
-but they cannot validate correctness, constant-time behavior, or key handling.
+keys, private keys, BIP-32 seeds and extended private keys, passwords, mnemonic
+phrases, and plaintext keystore material. `Engine.install` and `Engine.set`
+validate slot and primitive names, but they cannot validate correctness,
+constant-time behavior, or key handling.
 
 Ox's default engine uses audited cryptographic implementations. The WASM engine
 does not promise protection from timing or cache side channels. WebAssembly has

--- a/site/src/snippets/hash.mdx
+++ b/site/src/snippets/hash.mdx
@@ -4,6 +4,9 @@ import { Bytes, Hash, Hex } from 'ox'
 
 const message = Hex.fromString('hello world')
 
+Hash.blake3(message)
+// @log: '0xd74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24'
+
 Hash.keccak256(message)
 // @log: '0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad'
 

--- a/src/core/Bls.bench.ts
+++ b/src/core/Bls.bench.ts
@@ -1,11 +1,14 @@
 import { bench, describe } from 'vp/test'
 import * as Bls from './Bls.js'
+import * as BlsPoint from './BlsPoint.js'
 import * as Hex from './Hex.js'
 
 const payload = Hex.fromBytes(new Uint8Array(32).fill(0xab))
+const privateKey =
+  '0x527f85c60ed7402247da21f1835cea651d0954fc15b7288f096d3608400cb6ac'
 
 function makeSignatures(count: number) {
-  const signatures: ReturnType<typeof Bls.sign>[] = []
+  const signatures: BlsPoint.G2[] = []
   for (let i = 0; i < count; i++) {
     const privateKey = Bls.randomPrivateKey()
     signatures.push(Bls.sign({ payload, privateKey }))
@@ -16,8 +19,79 @@ function makeSignatures(count: number) {
 const sig10 = makeSignatures(10)
 const sig100 = makeSignatures(100)
 const sig1000 = makeSignatures(1000)
+const sig10Bytes = sig10.map(BlsPoint.toBytes)
+const sig10Hex = sig10.map(BlsPoint.toHex)
+
+const publicKeyObject = Bls.getPublicKey({ privateKey })
+const publicKeyBytes = Bls.getPublicKey({ as: 'Bytes', privateKey })
+const publicKeyHex = Bls.getPublicKey({ as: 'Hex', privateKey })
+const signatureObject = Bls.sign({ payload, privateKey })
+const signatureBytes = Bls.sign({ as: 'Bytes', payload, privateKey })
+const signatureHex = Bls.sign({ as: 'Hex', payload, privateKey })
+
+describe('Bls.getPublicKey', () => {
+  bench('Object output', () => {
+    Bls.getPublicKey({ privateKey })
+  })
+
+  bench('Bytes output', () => {
+    Bls.getPublicKey({ as: 'Bytes', privateKey })
+  })
+
+  bench('Hex output', () => {
+    Bls.getPublicKey({ as: 'Hex', privateKey })
+  })
+})
+
+describe('Bls.sign', () => {
+  bench('Object output', () => {
+    Bls.sign({ payload, privateKey })
+  })
+
+  bench('Bytes output', () => {
+    Bls.sign({ as: 'Bytes', payload, privateKey })
+  })
+
+  bench('Hex output', () => {
+    Bls.sign({ as: 'Hex', payload, privateKey })
+  })
+})
+
+describe('Bls.verify', () => {
+  bench('Object input', () => {
+    Bls.verify({
+      payload,
+      publicKey: publicKeyObject,
+      signature: signatureObject,
+    })
+  })
+
+  bench('Bytes input', () => {
+    Bls.verify({
+      payload,
+      publicKey: publicKeyBytes,
+      signature: signatureBytes,
+    })
+  })
+
+  bench('Hex input', () => {
+    Bls.verify({
+      payload,
+      publicKey: publicKeyHex,
+      signature: signatureHex,
+    })
+  })
+})
 
 describe('Bls.aggregate', () => {
+  bench('10 serialized Bytes signatures', () => {
+    Bls.aggregate(sig10Bytes, { group: 'G2' })
+  })
+
+  bench('10 serialized Hex signatures', () => {
+    Bls.aggregate(sig10Hex, { group: 'G2' })
+  })
+
   bench('10 signatures', () => {
     Bls.aggregate(sig10)
   })

--- a/src/core/Bls.ts
+++ b/src/core/Bls.ts
@@ -7,33 +7,45 @@ import * as Hex from './Hex.js'
 import * as engine from './internal/bls.js'
 import type { OneOf } from './internal/types.js'
 
-/**
- * Coerces a serialized or structured BLS point into a structured
- * {@link ox#BlsPoint.BlsPoint}.
- *
- * @internal
- */
-function normalizeBlsPoint<group extends 'G1' | 'G2'>(
-  value: Hex.Hex | Bytes.Bytes | BlsPoint.BlsPoint,
-  group: group,
-): BlsPoint.BlsPoint {
-  if (typeof value === 'string') return BlsPoint.fromHex(value, group)
-  if (value instanceof Uint8Array) return BlsPoint.fromBytes(value, group)
-  return value
-}
-
-/**
- * Formats a structured BLS point as the requested representation.
- *
- * @internal
- */
-function formatBlsPoint<point extends BlsPoint.BlsPoint>(
-  point: point,
+/** @internal */
+function formatBlsPoint(
+  point: Bytes.Bytes,
+  group: 'G1' | 'G2',
   as: 'Hex' | 'Bytes' | 'Object',
 ): unknown {
-  if (as === 'Hex') return BlsPoint.toHex(point as BlsPoint.G1 | BlsPoint.G2)
-  if (as === 'Bytes')
-    return BlsPoint.toBytes(point as BlsPoint.G1 | BlsPoint.G2)
+  if (as === 'Hex') return Hex.fromBytes(point)
+  if (as === 'Bytes') return point
+  return BlsPoint.fromBytes(point, group)
+}
+
+/** @internal */
+function serializeBlsPoint(
+  point: Hex.Hex | Bytes.Bytes | BlsPoint.BlsPoint,
+): Bytes.Bytes {
+  if (typeof point === 'string') return Hex.toBytes(point)
+  if (point instanceof Uint8Array) return point
+  return BlsPoint.toBytes(point as BlsPoint.G1 | BlsPoint.G2)
+}
+
+/** @internal */
+function validateSerializedBlsPoint(
+  point: Hex.Hex | Bytes.Bytes,
+  group: 'G1' | 'G2',
+): void {
+  if (typeof point === 'string') BlsPoint.fromHex(point, group)
+  else BlsPoint.fromBytes(point, group)
+}
+
+/** @internal */
+function assertBlsPointSize(
+  point: Bytes.Bytes,
+  group: 'G1' | 'G2',
+): Bytes.Bytes {
+  const expectedLength = group === 'G1' ? 48 : 96
+  if (point.length !== expectedLength)
+    throw new Errors.BaseError(
+      `Expected ${expectedLength} bytes for a ${group} point, received ${point.length}.`,
+    )
   return point
 }
 
@@ -104,38 +116,75 @@ export function aggregate(
       'Bls.aggregate expects a non-empty array of points.',
     )
 
-  // Normalize once -- accept structured points, hex strings, or `Uint8Array`s.
   const groupHint = options.group
-  const normalized: BlsPoint.BlsPoint[] = points.map((point) => {
+  const groups = points.map((point) => {
     if (typeof point === 'string' || point instanceof Uint8Array) {
       if (!groupHint)
         throw new Errors.BaseError(
           'Bls.aggregate requires `options.group` (`"G1"` or `"G2"`) when passing serialized points.',
         )
-      return normalizeBlsPoint(point, groupHint)
+      return groupHint
     }
-    return point
+    return typeof point.x === 'string' ? 'G1' : 'G2'
   })
 
   // A single point aggregates to itself. The engine is not consulted because
   // there is no addition to perform, only the identity.
-  if (normalized.length === 1) return normalized[0]!
+  if (points.length === 1) {
+    const point = points[0]!
+    if (typeof point === 'string')
+      return BlsPoint.fromHex(point, groups[0]!) as BlsPoint.BlsPoint
+    if (point instanceof Uint8Array)
+      return BlsPoint.fromBytes(point, groups[0]!) as BlsPoint.BlsPoint
+    return point
+  }
 
-  const isG1 = typeof normalized[0]!.x === 'string'
-  for (let i = 1; i < normalized.length; i++) {
-    if ((typeof normalized[i]!.x === 'string') !== isG1)
+  const groupName = groups[0]!
+  for (let i = 1; i < groups.length; i++) {
+    if (groups[i] !== groupName) {
+      // Preserve eager serialized validation on this error path. Valid inputs
+      // stay serialized, while malformed inputs still win over the mixed-group
+      // error in their original array order.
+      for (const [index, point] of points.entries()) {
+        if (typeof point === 'string') BlsPoint.fromHex(point, groups[index]!)
+        else if (point instanceof Uint8Array)
+          BlsPoint.fromBytes(point, groups[index]!)
+      }
       throw new Errors.BaseError(
         'Bls.aggregate expects all points to be from the same group (G1 or G2).',
       )
+    }
   }
 
-  const groupName = isG1 ? 'G1' : 'G2'
-  const point = engine.aggregate(
-    normalized.map((point) =>
-      BlsPoint.toBytes(point as BlsPoint.G1 | BlsPoint.G2),
-    ),
-    groupName,
+  // The previous implementation decoded every serialized member before
+  // serializing structured members. Retain that error order only for mixed
+  // representations; fully serialized arrays stay on the fast path.
+  const hasStructured = points.some(
+    (point) => typeof point !== 'string' && !(point instanceof Uint8Array),
   )
+  if (hasStructured)
+    for (const point of points)
+      if (typeof point === 'string' || point instanceof Uint8Array)
+        validateSerializedBlsPoint(point, groupName)
+
+  const serialized: Bytes.Bytes[] = []
+  for (const [index, point] of points.entries()) {
+    try {
+      serialized.push(assertBlsPointSize(serializeBlsPoint(point), groupName))
+    } catch (error) {
+      // A later cheap serialization error must not outrank an earlier
+      // malformed point. Decode only the failed prefix on this error path.
+      if (!hasStructured)
+        for (let i = 0; i <= index; i++)
+          validateSerializedBlsPoint(
+            points[i] as Hex.Hex | Bytes.Bytes,
+            groupName,
+          )
+      throw error
+    }
+  }
+
+  const point = engine.aggregate(serialized, groupName)
   return BlsPoint.fromBytes(point, groupName) as BlsPoint.BlsPoint
 }
 
@@ -349,9 +398,11 @@ export function getPublicKey<
 export function getPublicKey(options: getPublicKey.Options): unknown {
   const { as = 'Object', privateKey, size = 'short-key:long-sig' } = options
   const groupName = size === 'short-key:long-sig' ? 'G1' : 'G2'
-  const point = engine.getPublicKey(Bytes.from(privateKey), groupName)
-  const publicKey = BlsPoint.fromBytes(point, groupName) as BlsPoint.BlsPoint
-  return formatBlsPoint(publicKey, as)
+  const point = assertBlsPointSize(
+    engine.getPublicKey(Bytes.from(privateKey), groupName),
+    groupName,
+  )
+  return formatBlsPoint(point, groupName, as)
 }
 
 export declare namespace getPublicKey {
@@ -501,15 +552,14 @@ export function sign(options: sign.Options): unknown {
 
   const signatureGroupName: 'G1' | 'G2' =
     size === 'short-key:long-sig' ? 'G2' : 'G1'
-  const signature = engine.sign(Bytes.from(payload), Bytes.from(privateKey), {
-    dst: suite ? Bytes.fromString(suite) : undefined,
-    group: signatureGroupName,
-  })
-  const result = BlsPoint.fromBytes(
-    signature,
+  const signature = assertBlsPointSize(
+    engine.sign(Bytes.from(payload), Bytes.from(privateKey), {
+      dst: suite ? Bytes.fromString(suite) : undefined,
+      group: signatureGroupName,
+    }),
     signatureGroupName,
-  ) as BlsPoint.BlsPoint
-  return formatBlsPoint(result, as)
+  )
+  return formatBlsPoint(signature, signatureGroupName, as)
 }
 
 export declare namespace sign {
@@ -648,28 +698,75 @@ export function verify(options: verify.Options): boolean {
     : signatureByteLength(signatureRaw as Hex.Hex | Bytes.Bytes) === 48
       ? 'G1'
       : 'G2'
-  const publicKeyGroup: 'G1' | 'G2' = signatureGroup === 'G1' ? 'G2' : 'G1'
+  const publicKeyGroup = signatureGroup === 'G1' ? 'G2' : 'G1'
 
-  const signature = (
-    signatureIsStructured
-      ? (signatureRaw as BlsPoint.BlsPoint)
-      : normalizeBlsPoint(signatureRaw as Hex.Hex | Bytes.Bytes, signatureGroup)
-  ) as BlsPoint.BlsPoint<any>
-  const publicKey = (
-    publicKeyIsStructured
-      ? (publicKeyRaw as BlsPoint.BlsPoint)
-      : normalizeBlsPoint(publicKeyRaw as Hex.Hex | Bytes.Bytes, publicKeyGroup)
-  ) as BlsPoint.BlsPoint<any>
+  // Preserve the previous eager validation order when representations are
+  // mixed. Fully serialized pairs stay serialized until the provider.
+  if (signatureIsStructured !== publicKeyIsStructured) {
+    if (!signatureIsStructured)
+      validateSerializedBlsPoint(
+        signatureRaw as Hex.Hex | Bytes.Bytes,
+        signatureGroup,
+      )
+    if (!publicKeyIsStructured)
+      validateSerializedBlsPoint(
+        publicKeyRaw as Hex.Hex | Bytes.Bytes,
+        publicKeyGroup,
+      )
+  }
 
-  return engine.verify(
-    BlsPoint.toBytes(signature as BlsPoint.G1 | BlsPoint.G2),
-    Bytes.from(payload),
-    BlsPoint.toBytes(publicKey as BlsPoint.G1 | BlsPoint.G2),
-    {
-      dst: suite ? Bytes.fromString(suite) : undefined,
-      signatureGroup,
-    },
-  )
+  const signature = signatureIsStructured
+    ? BlsPoint.toBytes(signatureRaw as BlsPoint.G1 | BlsPoint.G2)
+    : assertBlsPointSize(
+        Bytes.from(signatureRaw as Hex.Hex | Bytes.Bytes),
+        signatureGroup,
+      )
+  let payloadBytes: Bytes.Bytes
+  try {
+    payloadBytes = Bytes.from(payload)
+  } catch (error) {
+    // Serialized points used to be decoded before payload coercion. Only pay
+    // that cost on this invalid-payload path so their errors still win.
+    if (!signatureIsStructured && !publicKeyIsStructured) {
+      validateSerializedBlsPoint(
+        signatureRaw as Hex.Hex | Bytes.Bytes,
+        signatureGroup,
+      )
+      validateSerializedBlsPoint(
+        publicKeyRaw as Hex.Hex | Bytes.Bytes,
+        publicKeyGroup,
+      )
+    }
+    throw error
+  }
+  let publicKey: Bytes.Bytes
+  try {
+    publicKey = publicKeyIsStructured
+      ? BlsPoint.toBytes(publicKeyRaw as BlsPoint.G1 | BlsPoint.G2)
+      : assertBlsPointSize(
+          Bytes.from(publicKeyRaw as Hex.Hex | Bytes.Bytes),
+          publicKeyGroup,
+        )
+  } catch (error) {
+    // As above, a later cheap public-key error must not outrank a malformed
+    // serialized signature.
+    if (!signatureIsStructured && !publicKeyIsStructured) {
+      validateSerializedBlsPoint(
+        signatureRaw as Hex.Hex | Bytes.Bytes,
+        signatureGroup,
+      )
+      validateSerializedBlsPoint(
+        publicKeyRaw as Hex.Hex | Bytes.Bytes,
+        publicKeyGroup,
+      )
+    }
+    throw error
+  }
+
+  return engine.verify(signature, payloadBytes, publicKey, {
+    dst: suite ? Bytes.fromString(suite) : undefined,
+    signatureGroup,
+  })
 }
 
 export declare namespace verify {

--- a/src/core/Bls_crypto.bench.ts
+++ b/src/core/Bls_crypto.bench.ts
@@ -1,5 +1,6 @@
 import { bench, describe } from 'vp/test'
 import * as Bls from './Bls.js'
+import * as BlsPoint from './BlsPoint.js'
 
 const sizes = [1, 10, 100, 1000] as const
 
@@ -11,13 +12,25 @@ const max = Math.max(...sizes)
 const allPublicKeys = Array.from({ length: max }, () =>
   Bls.getPublicKey({ privateKey: Bls.randomPrivateKey() }),
 )
+const allPublicKeyBytes = allPublicKeys.map(BlsPoint.toBytes)
+const allPublicKeyHex = allPublicKeys.map(BlsPoint.toHex)
 
 for (const size of sizes) {
   const points = allPublicKeys.slice(0, size)
+  const bytes = allPublicKeyBytes.slice(0, size)
+  const hex = allPublicKeyHex.slice(0, size)
 
   describe(`Bls.aggregate (${size} points)`, () => {
-    bench('aggregate', () => {
+    bench('Object input', () => {
       Bls.aggregate(points)
+    })
+
+    bench('Bytes input', () => {
+      Bls.aggregate(bytes, { group: 'G1' })
+    })
+
+    bench('Hex input', () => {
+      Bls.aggregate(hex, { group: 'G1' })
     })
   })
 }

--- a/src/core/Engine.ts
+++ b/src/core/Engine.ts
@@ -9,6 +9,9 @@ export type {
   Eddsa,
   Engine,
   Hash,
+  HdKey,
+  HdKeyNode,
+  HdKeyVersions,
   Keystore,
   Mnemonic,
 } from './internal/engine.js'

--- a/src/core/Hash.bench.ts
+++ b/src/core/Hash.bench.ts
@@ -9,6 +9,16 @@ for (const size of sizes) {
   const bytes = Bytes.random(size)
   const hex = Hex.fromBytes(bytes)
 
+  describe(`Hash.blake3 (${size} bytes input)`, () => {
+    bench('Bytes.Bytes input', () => {
+      Hash.blake3(bytes)
+    })
+
+    bench('Hex.Hex input', () => {
+      Hash.blake3(hex)
+    })
+  })
+
   describe(`Hash.sha256 (${size} bytes input)`, () => {
     bench('Bytes.Bytes input', () => {
       Hash.sha256(bytes)

--- a/src/core/Hash.ts
+++ b/src/core/Hash.ts
@@ -4,6 +4,65 @@ import * as Hex from './Hex.js'
 import * as engine from './internal/hash.js'
 
 /**
+ * Calculates the [BLAKE3](https://github.com/BLAKE3-team/BLAKE3) hash of a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
+ *
+ * Backed by `blake3` from [`@noble/hashes`](https://github.com/paulmillr/noble-hashes), an audited & minimal JS hashing library, unless another implementation is installed with {@link ox#Engine.set}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Hash } from 'ox'
+ *
+ * Hash.blake3('0xdeadbeef')
+ * // @log: '0x53147f3ce49ed4f60dfa5b9654c36ba6103c11f5737df3dabd4cbd296c4161bd'
+ * ```
+ *
+ * @example
+ * ### Configure Return Type
+ *
+ * ```ts twoslash
+ * import { Hash } from 'ox'
+ *
+ * Hash.blake3('0xdeadbeef', { as: 'Bytes' })
+ * // @log: Uint8Array [...]
+ * ```
+ *
+ * @param value - {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
+ * @param options - Options.
+ * @returns BLAKE3 hash.
+ */
+export function blake3<
+  value extends Hex.Hex | Bytes.Bytes,
+  as extends 'Hex' | 'Bytes' =
+    | (value extends Hex.Hex ? 'Hex' : never)
+    | (value extends Bytes.Bytes ? 'Bytes' : never),
+>(
+  value: value | Hex.Hex | Bytes.Bytes,
+  options: blake3.Options<as> = {},
+): blake3.ReturnType<as> {
+  const isBytes = value instanceof Uint8Array
+  const { as = isBytes ? 'Bytes' : 'Hex' } = options
+  const bytes = engine.blake3(isBytes ? value : Bytes.from(value))
+  if (as === 'Bytes') return bytes as never
+  return Hex.fromBytes(bytes) as never
+}
+
+export declare namespace blake3 {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> = {
+    /** The return type. Defaults to the input format. */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Calculates the [Keccak256](https://en.wikipedia.org/wiki/SHA-3) hash of a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
  *
  * Backed by `keccak_256` from [`@noble/hashes`](https://github.com/paulmillr/noble-hashes), an audited & minimal JS hashing library, unless another implementation is installed with {@link ox#Engine.set}.

--- a/src/core/HdKey.bench.ts
+++ b/src/core/HdKey.bench.ts
@@ -1,0 +1,33 @@
+import { bench, describe } from 'vp/test'
+import * as HdKey from './HdKey.js'
+import * as Hex from './Hex.js'
+
+const seedBytes = Uint8Array.from({ length: 64 }, (_, index) => index)
+const seedHex = Hex.fromBytes(seedBytes)
+const root = HdKey.fromSeed(seedBytes)
+
+describe('HdKey.fromSeed', () => {
+  bench('Bytes.Bytes input (64 bytes)', () => {
+    HdKey.fromSeed(seedBytes)
+  })
+
+  bench('Hex.Hex input (64 bytes)', () => {
+    HdKey.fromSeed(seedHex)
+  })
+})
+
+describe('HdKey.fromExtendedKey', () => {
+  bench('private extended key', () => {
+    HdKey.fromExtendedKey(root.privateExtendedKey)
+  })
+})
+
+describe('HdKey.derive', () => {
+  bench("m/0'", () => {
+    root.derive("m/0'")
+  })
+
+  bench("m/44'/60'/0'/0/0", () => {
+    root.derive("m/44'/60'/0'/0/0")
+  })
+})

--- a/src/core/HdKey.ts
+++ b/src/core/HdKey.ts
@@ -1,9 +1,17 @@
-import { HDKey, type Versions } from '@scure/bip32'
 import * as Bytes from './Bytes.js'
-import type * as Errors from './Errors.js'
-import type * as Hex from './Hex.js'
+import * as Errors from './Errors.js'
+import * as Hex from './Hex.js'
 import * as internal from './internal/hdKey.js'
-import type * as PublicKey from './PublicKey.js'
+import type { HdKeyNode, HdKeyVersions } from './internal/engine.js'
+import * as PublicKey from './PublicKey.js'
+
+const defaultVersions = {
+  private: 0x0488_ade4,
+  public: 0x0488_b21e,
+} satisfies Versions
+
+/** BIP-32 version bytes for private and public extended keys. */
+export type Versions = HdKeyVersions
 
 /** Root type for a Hierarchical Deterministic (HD) Key. */
 export type HdKey = {
@@ -16,6 +24,52 @@ export type HdKey = {
   publicKey: PublicKey.PublicKey<false>
   publicExtendedKey: string
   versions: Versions
+}
+
+/** @internal */
+function fromNode(node: HdKeyNode): HdKey {
+  assertNodeBytes(node.identifier, 'identifier', 20)
+  assertNodeBytes(node.privateKey, 'private key', 32)
+  assertNodeBytes(node.publicKey, 'public key', 65)
+  const versions = { ...node.versions }
+  const sourceVersions = { ...node.versions }
+  const privateExtendedKey = node.privateExtendedKey
+  return {
+    derive: createDerive(privateExtendedKey, versions, sourceVersions),
+    depth: node.depth,
+    identifier: Hex.fromBytes(node.identifier),
+    index: node.index,
+    privateKey: Hex.fromBytes(node.privateKey),
+    privateExtendedKey,
+    publicKey: PublicKey.fromBytes(node.publicKey),
+    publicExtendedKey: node.publicExtendedKey,
+    versions,
+  }
+}
+
+/** @internal */
+function assertNodeBytes(
+  value: Bytes.Bytes,
+  name: string,
+  expectedLength: number,
+): void {
+  Bytes.assert(value)
+  if (value.length !== expectedLength)
+    throw new Errors.BaseError(
+      `Expected ${expectedLength} bytes for an HD key ${name}, received ${value.length}.`,
+    )
+}
+
+/** @internal */
+function createDerive(
+  privateExtendedKey: string,
+  versions: Versions,
+  sourceVersions: Versions,
+): HdKey['derive'] {
+  return (path) =>
+    fromNode(
+      internal.derive(privateExtendedKey, path, versions, sourceVersions),
+    )
 }
 
 /**
@@ -32,15 +86,27 @@ export type HdKey = {
  * ```
  *
  * @param extendedKey - The extended private key.
+ * @param options - Creation options.
  * @returns The HD Key.
  */
-export function fromExtendedKey(extendedKey: string): HdKey {
-  const key = HDKey.fromExtendedKey(extendedKey)
-  return internal.fromScure(key)
+export function fromExtendedKey(
+  extendedKey: string,
+  options: fromExtendedKey.Options = {},
+): HdKey {
+  const versions = { ...(options.versions ?? defaultVersions) }
+  return fromNode(internal.fromExtendedKey(extendedKey, versions))
 }
 
 export declare namespace fromExtendedKey {
-  type ErrorType = internal.fromScure.ErrorType | Errors.GlobalErrorType
+  type Options = {
+    /** The versions to use for the HD Key. */
+    versions?: Versions | undefined
+  }
+
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
+    | PublicKey.fromBytes.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -57,14 +123,20 @@ export declare namespace fromExtendedKey {
  * ```
  *
  * @param json - The JSON object containing an extended private key (`xpriv`).
+ * @param options - Creation options.
  * @returns The HD Key.
  */
-export function fromJson(json: { xpriv: string }): HdKey {
-  return internal.fromScure(HDKey.fromJSON(json))
+export function fromJson(
+  json: { xpriv: string },
+  options: fromJson.Options = {},
+): HdKey {
+  return fromExtendedKey(json.xpriv, options)
 }
 
 export declare namespace fromJson {
-  type ErrorType = internal.fromScure.ErrorType | Errors.GlobalErrorType
+  type Options = fromExtendedKey.Options
+
+  type ErrorType = fromExtendedKey.ErrorType | Errors.GlobalErrorType
 }
 
 /**
@@ -105,9 +177,8 @@ export function fromSeed(
   seed: Hex.Hex | Bytes.Bytes,
   options: fromSeed.Options = {},
 ): HdKey {
-  const { versions } = options
-  const key = HDKey.fromMasterSeed(Bytes.from(seed), versions)
-  return internal.fromScure(key)
+  const versions = { ...(options.versions ?? defaultVersions) }
+  return fromNode(internal.fromSeed(Bytes.from(seed), versions))
 }
 
 export declare namespace fromSeed {
@@ -118,7 +189,8 @@ export declare namespace fromSeed {
 
   type ErrorType =
     | Bytes.from.ErrorType
-    | internal.fromScure.ErrorType
+    | Hex.fromBytes.ErrorType
+    | PublicKey.fromBytes.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/core/_test/Bls.test.ts
+++ b/src/core/_test/Bls.test.ts
@@ -1,8 +1,35 @@
-import { Bls, Hex } from 'ox'
+import { Bls, BlsPoint, Bytes, Engine, Hex } from 'ox'
 import { describe, expect, it, test } from 'vp/test'
 
 const privateKey =
   '0x527f85c60ed7402247da21f1835cea651d0954fc15b7288f096d3608400cb6ac'
+const otherPrivateKey =
+  '0x68f9b6c6e0a1f9e7a02e5a6eaae8aa5c4b6b9e1a8f5d8c7b6a5f4e3d2c1b0a9f'
+const payload = '0xdeadbeef'
+
+function offsetView(bytes: Bytes.Bytes) {
+  const buffer = new Uint8Array(bytes.length + 4)
+  buffer.set(bytes, 2)
+  return buffer.subarray(2, -2)
+}
+
+function compressedBytes(length: number) {
+  const bytes = new Uint8Array(length)
+  bytes[0] = 0x80
+  return bytes
+}
+
+const g1Infinity = new Uint8Array(48)
+g1Infinity[0] = 0xc0
+const g2Infinity = new Uint8Array(96)
+g2Infinity[0] = 0xc0
+
+const g1NonSubgroup = Hex.toBytes(
+  '0x800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+)
+const g2NonSubgroup = Hex.toBytes(
+  '0x800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+)
 
 describe('aggregate', () => {
   test('default', () => {
@@ -64,6 +91,25 @@ describe('aggregate', () => {
     expect(Bls.aggregate([publicKey])).toBe(publicKey)
   })
 
+  test('behavior: serialized single-element array returns an object without consulting the engine', () => {
+    const publicKey = Bls.getPublicKey({ privateKey, as: 'Bytes' })
+    let called = false
+    const result = Engine.with(
+      {
+        Bls: {
+          aggregate: () => {
+            called = true
+            return publicKey
+          },
+        },
+      },
+      () => Bls.aggregate([publicKey], { group: 'G1' }),
+    )
+
+    expect(called).toBe(false)
+    expect(result).toEqual(BlsPoint.fromBytes(publicKey, 'G1'))
+  })
+
   test('error: mixed groups', () => {
     const g1 = Bls.getPublicKey({ privateKey })
     const g2 = Bls.getPublicKey({
@@ -74,6 +120,44 @@ describe('aggregate', () => {
       Bls.aggregate([g1, g2 as any]),
     ).toThrowErrorMatchingInlineSnapshot(
       `[BaseError: Bls.aggregate expects all points to be from the same group (G1 or G2).]`,
+    )
+  })
+
+  test('error: mixed structured and serialized groups', () => {
+    const g1 = Bls.getPublicKey({ privateKey })
+    const g2 = Bls.getPublicKey({
+      as: 'Bytes',
+      privateKey,
+      size: 'long-key:short-sig',
+    })
+    expect(() =>
+      Bls.aggregate([g1, g2], { group: 'G2' }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[BaseError: Bls.aggregate expects all points to be from the same group (G1 or G2).]`,
+    )
+  })
+
+  test('error: malformed serialized input precedes mixed groups', () => {
+    const g1 = Bls.getPublicKey({ privateKey })
+    expect(() =>
+      Bls.aggregate([g1, new Uint8Array(96)], { group: 'G2' }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G2 point: expected 192 bytes]`,
+    )
+  })
+
+  test('error: malformed serialized input precedes structured serialization', () => {
+    const malformedStructured = {
+      x: '0x00',
+      y: '0x00',
+      z: '0x00',
+    } as BlsPoint.G1
+    expect(() =>
+      Bls.aggregate([malformedStructured, new Uint8Array(48)], {
+        group: 'G1',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G1 point: expected 96 bytes]`,
     )
   })
 })
@@ -255,96 +339,642 @@ describe('verify', () => {
 })
 
 describe('as option / serialized inputs', () => {
-  const privateKey =
-    '0x527f85c60ed7402247da21f1835cea651d0954fc15b7288f096d3608400cb6ac'
+  test.each([
+    {
+      group: 'G1',
+      size: 'short-key:long-sig',
+    },
+    {
+      group: 'G2',
+      size: 'long-key:short-sig',
+    },
+  ] as const)(
+    'getPublicKey: $group is equivalent as Object, Bytes, and Hex',
+    ({ group, size }) => {
+      const object = Bls.getPublicKey({ privateKey, size })
+      const bytes = Bls.getPublicKey({ as: 'Bytes', privateKey, size })
+      const hex = Bls.getPublicKey({ as: 'Hex', privateKey, size })
 
-  test("getPublicKey: as 'Hex' returns hex string", () => {
-    const pkHex = Bls.getPublicKey({ privateKey, as: 'Hex' })
-    expect(typeof pkHex).toBe('string')
-    expect((pkHex as Hex.Hex).startsWith('0x')).toBe(true)
-  })
+      expect(bytes).toEqual(BlsPoint.toBytes(object))
+      expect(hex).toBe(BlsPoint.toHex(object))
+      expect(BlsPoint.fromBytes(bytes, group)).toEqual(object)
+    },
+  )
 
-  test("getPublicKey: as 'Bytes' returns Uint8Array", () => {
-    const pkBytes = Bls.getPublicKey({ privateKey, as: 'Bytes' })
-    expect(pkBytes).toBeInstanceOf(Uint8Array)
-  })
+  test.each([
+    {
+      group: 'G2',
+      size: 'short-key:long-sig',
+    },
+    {
+      group: 'G1',
+      size: 'long-key:short-sig',
+    },
+  ] as const)(
+    'sign: $group is equivalent as Object, Bytes, and Hex',
+    ({ group, size }) => {
+      const object = Bls.sign({ payload, privateKey, size })
+      const bytes = Bls.sign({ as: 'Bytes', payload, privateKey, size })
+      const hex = Bls.sign({ as: 'Hex', payload, privateKey, size })
 
-  test('getPublicKey default as remains Object', () => {
-    const pk = Bls.getPublicKey({ privateKey })
-    expect(typeof pk).toBe('object')
-    expect('z' in pk).toBe(true)
-  })
+      expect(bytes).toEqual(BlsPoint.toBytes(object))
+      expect(hex).toBe(BlsPoint.toHex(object))
+      expect(BlsPoint.fromBytes(bytes, group)).toEqual(object)
+    },
+  )
 
-  test("sign: as 'Hex' returns hex string", () => {
-    const sigHex = Bls.sign({
-      payload: '0xdeadbeef',
-      privateKey,
-      as: 'Hex',
-    })
-    expect(typeof sigHex).toBe('string')
-  })
+  test.each([
+    {
+      size: 'short-key:long-sig',
+    },
+    {
+      size: 'long-key:short-sig',
+    },
+  ] as const)(
+    'verify accepts every public key and signature representation ($size)',
+    ({ size }) => {
+      const publicKeys = [
+        Bls.getPublicKey({ privateKey, size }),
+        Bls.getPublicKey({ as: 'Bytes', privateKey, size }),
+        Bls.getPublicKey({ as: 'Hex', privateKey, size }),
+      ] as const
+      const signatures = [
+        Bls.sign({ payload, privateKey, size }),
+        Bls.sign({ as: 'Bytes', payload, privateKey, size }),
+        Bls.sign({ as: 'Hex', payload, privateKey, size }),
+      ] as const
 
-  test("sign: as 'Bytes' returns Uint8Array", () => {
-    const sigBytes = Bls.sign({
-      payload: '0xdeadbeef',
-      privateKey,
-      as: 'Bytes',
-    })
-    expect(sigBytes).toBeInstanceOf(Uint8Array)
-  })
-
-  test('verify accepts Hex publicKey + Hex signature', () => {
-    const pkHex = Bls.getPublicKey({ privateKey, as: 'Hex' })
-    const sigHex = Bls.sign({
-      payload: '0xdeadbeef',
-      privateKey,
-      as: 'Hex',
-    })
-    expect(
-      Bls.verify({
-        payload: '0xdeadbeef',
-        publicKey: pkHex,
-        signature: sigHex,
-      }),
-    ).toBe(true)
-  })
-
-  test('verify accepts Bytes publicKey + Bytes signature', () => {
-    const pkBytes = Bls.getPublicKey({ privateKey, as: 'Bytes' })
-    const sigBytes = Bls.sign({
-      payload: '0xdeadbeef',
-      privateKey,
-      as: 'Bytes',
-    })
-    expect(
-      Bls.verify({
-        payload: '0xdeadbeef',
-        publicKey: pkBytes,
-        signature: sigBytes,
-      }),
-    ).toBe(true)
-  })
+      for (const publicKey of publicKeys)
+        for (const signature of signatures)
+          expect(
+            Bls.verify({
+              payload,
+              publicKey: publicKey as never,
+              signature: signature as never,
+            }),
+          ).toBe(true)
+    },
+  )
 
   test('aggregate accepts hex inputs with group hint', () => {
     const a = Bls.getPublicKey({ privateKey, as: 'Hex' })
     const b = Bls.getPublicKey({
-      privateKey:
-        '0x68f9b6c6e0a1f9e7a02e5a6eaae8aa5c4b6b9e1a8f5d8c7b6a5f4e3d2c1b0a9f',
+      privateKey: otherPrivateKey,
       as: 'Hex',
     })
     const aggregated = Bls.aggregate([a, b], { group: 'G1' })
     // Should match aggregating from structured inputs.
     const aObj = Bls.getPublicKey({ privateKey })
     const bObj = Bls.getPublicKey({
-      privateKey:
-        '0x68f9b6c6e0a1f9e7a02e5a6eaae8aa5c4b6b9e1a8f5d8c7b6a5f4e3d2c1b0a9f',
+      privateKey: otherPrivateKey,
     })
     const aggregatedObj = Bls.aggregate([aObj, bObj])
     expect(aggregated).toEqual(aggregatedObj)
   })
 
+  test.each([
+    {
+      group: 'G1',
+      size: 'short-key:long-sig',
+    },
+    {
+      group: 'G2',
+      size: 'long-key:short-sig',
+    },
+  ] as const)(
+    'aggregate accepts mixed $group representations',
+    ({ group, size }) => {
+      const points = [
+        Bls.getPublicKey({ privateKey, size }),
+        Bls.getPublicKey({
+          as: 'Bytes',
+          privateKey: otherPrivateKey,
+          size,
+        }),
+        Bls.getPublicKey({ as: 'Hex', privateKey, size }),
+      ] as const
+      const expected = Bls.aggregate(
+        points.map((point) =>
+          typeof point === 'string'
+            ? BlsPoint.fromHex(point, group)
+            : point instanceof Uint8Array
+              ? BlsPoint.fromBytes(point, group)
+              : point,
+        ),
+      )
+
+      expect(Bls.aggregate(points, { group })).toEqual(expected)
+    },
+  )
+
   test('aggregate throws if serialized inputs without group hint', () => {
     const a = Bls.getPublicKey({ privateKey, as: 'Hex' })
-    expect(() => Bls.aggregate([a])).toThrow()
+    expect(() => Bls.aggregate([a])).toThrowErrorMatchingInlineSnapshot(
+      `[BaseError: Bls.aggregate requires \`options.group\` (\`"G1"\` or \`"G2"\`) when passing serialized points.]`,
+    )
+  })
+})
+
+describe('serialized engine handoff', () => {
+  test('getPublicKey and sign reject wrong-length custom-engine outputs', () => {
+    Engine.with(
+      {
+        Bls: {
+          getPublicKey: (_, group) => compressedBytes(group === 'G1' ? 47 : 95),
+          sign: (_, __, { group }) => compressedBytes(group === 'G1' ? 47 : 95),
+        },
+      },
+      () => {
+        expect(() =>
+          Bls.getPublicKey({ as: 'Bytes', privateKey }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[BaseError: Expected 48 bytes for a G1 point, received 47.]`,
+        )
+        expect(() =>
+          Bls.getPublicKey({
+            as: 'Bytes',
+            privateKey,
+            size: 'long-key:short-sig',
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[BaseError: Expected 96 bytes for a G2 point, received 95.]`,
+        )
+        expect(() =>
+          Bls.sign({ as: 'Bytes', payload, privateKey }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[BaseError: Expected 96 bytes for a G2 point, received 95.]`,
+        )
+        expect(() =>
+          Bls.sign({
+            as: 'Bytes',
+            payload,
+            privateKey,
+            size: 'long-key:short-sig',
+          }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[BaseError: Expected 48 bytes for a G1 point, received 47.]`,
+        )
+      },
+    )
+  })
+
+  test('getPublicKey and sign return serialized custom-engine outputs directly', () => {
+    const g1 = new Uint8Array(48)
+    const g2 = new Uint8Array(96)
+
+    Engine.with(
+      {
+        Bls: {
+          getPublicKey: (_, group) => (group === 'G1' ? g1 : g2),
+          sign: (_, __, { group }) => (group === 'G1' ? g1 : g2),
+        },
+      },
+      () => {
+        expect(Bls.getPublicKey({ as: 'Bytes', privateKey })).toBe(g1)
+        expect(Bls.getPublicKey({ as: 'Hex', privateKey })).toBe(
+          Hex.fromBytes(g1),
+        )
+        expect(() =>
+          Bls.getPublicKey({ privateKey }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[Error: invalid G1 point: expected 96 bytes]`,
+        )
+
+        expect(
+          Bls.getPublicKey({
+            as: 'Bytes',
+            privateKey,
+            size: 'long-key:short-sig',
+          }),
+        ).toBe(g2)
+
+        expect(Bls.sign({ as: 'Bytes', payload, privateKey })).toBe(g2)
+        expect(Bls.sign({ as: 'Hex', payload, privateKey })).toBe(
+          Hex.fromBytes(g2),
+        )
+        expect(() =>
+          Bls.sign({ payload, privateKey }),
+        ).toThrowErrorMatchingInlineSnapshot(
+          `[Error: invalid G2 point: expected 192 bytes]`,
+        )
+        expect(
+          Bls.sign({
+            as: 'Bytes',
+            payload,
+            privateKey,
+            size: 'long-key:short-sig',
+          }),
+        ).toBe(g1)
+      },
+    )
+  })
+
+  test('aggregate forwards serialized byte views directly', () => {
+    const first = offsetView(
+      Bls.getPublicKey({ as: 'Bytes', privateKey }),
+    ) as BlsPoint.G1Bytes
+    const second = offsetView(
+      Bls.getPublicKey({ as: 'Bytes', privateKey: otherPrivateKey }),
+    ) as BlsPoint.G1Bytes
+    const before = [first.slice(), second.slice()]
+    const result = BlsPoint.toBytes(
+      Bls.aggregate([
+        BlsPoint.fromBytes(first, 'G1'),
+        BlsPoint.fromBytes(second, 'G1'),
+      ]),
+    )
+    let received: readonly Uint8Array[] | undefined
+
+    Engine.with(
+      {
+        Bls: {
+          aggregate: (points) => {
+            received = points
+            return result
+          },
+        },
+      },
+      () => Bls.aggregate([first, second], { group: 'G1' }),
+    )
+
+    expect(received?.[0]).toBe(first)
+    expect(received?.[1]).toBe(second)
+    expect(first).toEqual(before[0])
+    expect(second).toEqual(before[1])
+  })
+
+  test('verify forwards serialized byte views directly', () => {
+    const publicKey = offsetView(
+      Bls.getPublicKey({ as: 'Bytes', privateKey }),
+    ) as BlsPoint.G1Bytes
+    const signature = offsetView(
+      Bls.sign({ as: 'Bytes', payload, privateKey }),
+    ) as BlsPoint.G2Bytes
+    const publicKeyBefore = publicKey.slice()
+    const signatureBefore = signature.slice()
+    let received:
+      | {
+          publicKey: Uint8Array
+          signature: Uint8Array
+        }
+      | undefined
+
+    const verified = Engine.with(
+      {
+        Bls: {
+          verify: (signature, _payload, publicKey) => {
+            received = { publicKey, signature }
+            return true
+          },
+        },
+      },
+      () => Bls.verify({ payload, publicKey, signature }),
+    )
+
+    expect(verified).toBe(true)
+    expect(received?.publicKey).toBe(publicKey)
+    expect(received?.signature).toBe(signature)
+    expect(publicKey).toEqual(publicKeyBefore)
+    expect(signature).toEqual(signatureBefore)
+  })
+
+  test('default serialized outputs are fresh and caller-owned', () => {
+    const publicKeyA = Bls.getPublicKey({ as: 'Bytes', privateKey })
+    const publicKeyB = Bls.getPublicKey({ as: 'Bytes', privateKey })
+    const signatureA = Bls.sign({ as: 'Bytes', payload, privateKey })
+    const signatureB = Bls.sign({ as: 'Bytes', payload, privateKey })
+    const publicKeyB_ = publicKeyB.slice()
+    const signatureB_ = signatureB.slice()
+
+    publicKeyA.fill(0)
+    signatureA.fill(0)
+
+    expect(publicKeyA).not.toBe(publicKeyB)
+    expect(signatureA).not.toBe(signatureB)
+    expect(publicKeyB).toEqual(publicKeyB_)
+    expect(signatureB).toEqual(signatureB_)
+  })
+
+  test('default operations do not mutate serialized input views', () => {
+    const publicKeyA = offsetView(
+      Bls.getPublicKey({ as: 'Bytes', privateKey }),
+    ) as BlsPoint.G1Bytes
+    const publicKeyB = offsetView(
+      Bls.getPublicKey({ as: 'Bytes', privateKey: otherPrivateKey }),
+    ) as BlsPoint.G1Bytes
+    const signature = offsetView(
+      Bls.sign({ as: 'Bytes', payload, privateKey }),
+    ) as BlsPoint.G2Bytes
+    const before = [publicKeyA.slice(), publicKeyB.slice(), signature.slice()]
+
+    Bls.aggregate([publicKeyA, publicKeyB], { group: 'G1' })
+    Bls.verify({ payload, publicKey: publicKeyA, signature })
+
+    expect(publicKeyA).toEqual(before[0])
+    expect(publicKeyB).toEqual(before[1])
+    expect(signature).toEqual(before[2])
+  })
+})
+
+describe('serialized validation', () => {
+  test('aggregate: wrong lengths retain Ox errors for G1 and G2', () => {
+    expect(() =>
+      Bls.aggregate([compressedBytes(47), compressedBytes(47)], {
+        group: 'G1',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[BaseError: Expected 48 bytes for a G1 point, received 47.]`,
+    )
+    expect(() =>
+      Bls.aggregate([compressedBytes(95), compressedBytes(95)], {
+        group: 'G2',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[BaseError: Expected 96 bytes for a G2 point, received 95.]`,
+    )
+  })
+
+  test('aggregate: malformed points precede later wrong lengths', () => {
+    expect(() =>
+      Bls.aggregate([new Uint8Array(48), new Uint8Array(47)], {
+        group: 'G1',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G1 point: expected 96 bytes]`,
+    )
+  })
+
+  test('aggregate: malformed G1 is rejected by the default provider', () => {
+    const malformed = new Uint8Array(48)
+    expect(() =>
+      Bls.aggregate([malformed, malformed], { group: 'G1' }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G1 point: expected 96 bytes]`,
+    )
+  })
+
+  test('aggregate: malformed G2 is rejected by the default provider', () => {
+    const malformed = new Uint8Array(96)
+    expect(() =>
+      Bls.aggregate([malformed, malformed], { group: 'G2' }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G2 point: expected 192 bytes]`,
+    )
+  })
+
+  test('aggregate: subgroup failures are rejected for G1 and G2', () => {
+    expect(() =>
+      Bls.aggregate([g1NonSubgroup, g1NonSubgroup], { group: 'G1' }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: bad point: not in prime-order subgroup]`,
+    )
+    expect(() =>
+      Bls.aggregate([g2NonSubgroup, g2NonSubgroup], { group: 'G2' }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: bad point: not in prime-order subgroup]`,
+    )
+  })
+
+  test('aggregate: canonical infinity remains accepted', () => {
+    expect(
+      BlsPoint.toBytes(
+        Bls.aggregate([g1Infinity, g1Infinity], {
+          group: 'G1',
+        }) as BlsPoint.G1,
+      ),
+    ).toEqual(g1Infinity)
+    expect(
+      BlsPoint.toBytes(
+        Bls.aggregate([g2Infinity, g2Infinity], {
+          group: 'G2',
+        }) as BlsPoint.G2,
+      ),
+    ).toEqual(g2Infinity)
+  })
+
+  test('verify: malformed points are rejected by the default provider', () => {
+    const publicKey = Bls.getPublicKey({ as: 'Bytes', privateKey })
+    const signature = Bls.sign({ as: 'Bytes', payload, privateKey })
+
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey,
+        signature: new Uint8Array(96),
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G2 point: expected 192 bytes]`,
+    )
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: new Uint8Array(48),
+        signature,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G1 point: expected 96 bytes]`,
+    )
+  })
+
+  test('verify: wrong lengths are checked signature-first before the engine', () => {
+    let called = false
+    expect(() =>
+      Engine.with(
+        {
+          Bls: {
+            verify: () => {
+              called = true
+              return false
+            },
+          },
+        },
+        () =>
+          Bls.verify({
+            payload,
+            publicKey: compressedBytes(47),
+            signature: compressedBytes(95),
+          }),
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[BaseError: Expected 96 bytes for a G2 point, received 95.]`,
+    )
+    expect(called).toBe(false)
+  })
+
+  test('verify: malformed signatures precede public-key length errors', () => {
+    expect(() =>
+      Bls.verify({
+        payload: new Uint8Array(32),
+        publicKey: new Uint8Array(47),
+        signature: new Uint8Array(96),
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G2 point: expected 192 bytes]`,
+    )
+  })
+
+  test('verify: the default provider validates the signature first', () => {
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: new Uint8Array(48),
+        signature: new Uint8Array(96),
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G2 point: expected 192 bytes]`,
+    )
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: new Uint8Array(96),
+        signature: new Uint8Array(48),
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G1 point: expected 96 bytes]`,
+    )
+  })
+
+  test('verify: serialized point errors precede invalid payloads', () => {
+    expect(() =>
+      Bls.verify({
+        payload: '0x0',
+        publicKey: Bls.getPublicKey({ as: 'Bytes', privateKey }),
+        signature: new Uint8Array(96),
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G2 point: expected 192 bytes]`,
+    )
+  })
+
+  test('verify: mismatched structured groups retain provider errors', () => {
+    const g1PublicKey = Bls.getPublicKey({ privateKey })
+    const g2PublicKey = Bls.getPublicKey({
+      privateKey,
+      size: 'long-key:short-sig',
+    })
+    const g2Signature = Bls.sign({ payload, privateKey })
+    const g1Signature = Bls.sign({
+      payload,
+      privateKey,
+      size: 'long-key:short-sig',
+    })
+
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g2PublicKey,
+        signature: g2Signature,
+      } as never),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G1 point: expected 48 bytes]`,
+    )
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g1PublicKey,
+        signature: g1Signature,
+      } as never),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid G2 point: expected 96 bytes]`,
+    )
+  })
+
+  test('verify: subgroup failures are rejected for both group orientations', () => {
+    const g1PublicKey = Bls.getPublicKey({ as: 'Bytes', privateKey })
+    const g2Signature = Bls.sign({ as: 'Bytes', payload, privateKey })
+    const g2PublicKey = Bls.getPublicKey({
+      as: 'Bytes',
+      privateKey,
+      size: 'long-key:short-sig',
+    })
+    const g1Signature = Bls.sign({
+      as: 'Bytes',
+      payload,
+      privateKey,
+      size: 'long-key:short-sig',
+    })
+
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g1NonSubgroup,
+        signature: g2Signature,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: bad point: not in prime-order subgroup]`,
+    )
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g2PublicKey,
+        signature: g1NonSubgroup,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: bad point: not in prime-order subgroup]`,
+    )
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g1PublicKey,
+        signature: g2NonSubgroup,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: bad point: not in prime-order subgroup]`,
+    )
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g2NonSubgroup,
+        signature: g1Signature,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: bad point: not in prime-order subgroup]`,
+    )
+  })
+
+  test('verify: canonical infinity retains the default ZERO error', () => {
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g1Infinity,
+        signature: g2Infinity,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: pairing is not available for ZERO point]`,
+    )
+    expect(() =>
+      Bls.verify({
+        payload,
+        publicKey: g2Infinity,
+        signature: g1Infinity,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: pairing is not available for ZERO point]`,
+    )
+  })
+
+  test('custom engines own serialized validation', () => {
+    const malformed = new Uint8Array(96)
+    let received: Uint8Array | undefined
+
+    const verified = Engine.with(
+      {
+        Bls: {
+          verify: (signature) => {
+            received = signature
+            return false
+          },
+        },
+      },
+      () =>
+        Bls.verify({
+          payload,
+          publicKey: Bls.getPublicKey({ as: 'Bytes', privateKey }),
+          signature: malformed,
+        }),
+    )
+
+    expect(verified).toBe(false)
+    expect(received).toBe(malformed)
   })
 })

--- a/src/core/_test/Bls.vectors.test.ts
+++ b/src/core/_test/Bls.vectors.test.ts
@@ -1,0 +1,66 @@
+import { Bls, BlsPoint } from 'ox'
+import { describe, expect, test } from 'vp/test'
+
+/**
+ * Selected Ethereum BLS12-381 test-suite v0.1.0 vectors, independently
+ * generated with py_ecc and milagro.
+ *
+ * Source: https://github.com/ethereum/bls12-381-tests/releases/tag/v0.1.0
+ */
+const vector = {
+  aggregate: {
+    input: [
+      '0x91347bccf740d859038fcdcaf233eeceb2a436bcaaee9b2aa3bfb70efe29dfb2677562ccbea1c8e061fb9971b0753c240622fab78489ce96768259fc01360346da5b9f579e5da0d941e4c6ba18a0e64906082375394f337fa1af2b7127b0d121',
+      '0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df',
+      '0xae82747ddeefe4fd64cf9cedb9b04ae3e8a43420cd255e3c7cd06a8d88b7c7f8638543719981c5d16fa3527c468c25f0026704a6951bde891360c7e8d12ddee0559004ccdbe6046b55bae1b257ee97f7cdb955773d7cf29adf3ccbb9975e4eb9',
+    ],
+    output:
+      '0x9712c3edd73a209c742b8250759db12549b3eaf43b5ca61376d9f30e2747dbcf842d8b2ac0901d2a093713e20284a7670fcf6954e9ab93de991bb9b313e664785a075fc285806fa5224c82bde146561b446ccfc706a64b8579513cfc4ff1d930',
+  },
+  payload: '0xabababababababababababababababababababababababababababababababab',
+  privateKey:
+    '0x47b8192d77bf871b62e87859d653922725724a5c031afeabc60bcef5ff665138',
+  publicKey:
+    '0xb301803f8b5ac4a1133581fc676dfedc60d891dd5fa99028805e5ea5b08d3491af75d0707adab3b70c6a6a580217bf81',
+  signature:
+    '0x9674e2228034527f4c083206032b020310face156d4a4685e2fcaec2f6f3665aa635d90347b6ce124eb879266b1e801d185de36a0a289b85e9039662634f2eea1e02e670bc7ab849d006a70b2f93b84597558a05b879c8d445f387a5d5b653df',
+  suite: 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_',
+} as const
+
+describe('Ethereum BLS12-381 vectors', () => {
+  test('getPublicKey', () => {
+    expect(Bls.getPublicKey({ as: 'Hex', privateKey: vector.privateKey })).toBe(
+      vector.publicKey,
+    )
+  })
+
+  test('sign', () => {
+    expect(
+      Bls.sign({
+        as: 'Hex',
+        payload: vector.payload,
+        privateKey: vector.privateKey,
+        suite: vector.suite,
+      }),
+    ).toBe(vector.signature)
+  })
+
+  test('verify', () => {
+    expect(
+      Bls.verify({
+        payload: vector.payload,
+        publicKey: vector.publicKey,
+        signature: vector.signature,
+        suite: vector.suite,
+      }),
+    ).toBe(true)
+  })
+
+  test('aggregate', () => {
+    expect(
+      BlsPoint.toHex(
+        Bls.aggregate(vector.aggregate.input, { group: 'G2' }) as BlsPoint.G2,
+      ),
+    ).toBe(vector.aggregate.output)
+  })
+})

--- a/src/core/_test/Engine.fuzz.ts
+++ b/src/core/_test/Engine.fuzz.ts
@@ -42,6 +42,10 @@ afterEach(() => {
  */
 const callSites = [
   {
+    name: 'Hash.blake3',
+    run: (bytes: Uint8Array) => Hash.blake3(bytes),
+  },
+  {
     name: 'Hash.keccak256',
     run: (bytes: Uint8Array) => Hash.keccak256(bytes),
   },

--- a/src/core/_test/Engine.test-d.ts
+++ b/src/core/_test/Engine.test-d.ts
@@ -128,6 +128,16 @@ describe('Engine', () => {
     >()
   })
 
+  test('the HdKey slot uses the portable BIP-32 contract', () => {
+    expectTypeOf<Engine.Engine['HdKey']>().toEqualTypeOf<
+      Engine.HdKey | undefined
+    >()
+    expectTypeOf<Engine.HdKeyNode['privateKey']>().toEqualTypeOf<Uint8Array>()
+    expectTypeOf<
+      Engine.HdKeyNode['versions']
+    >().toEqualTypeOf<Engine.HdKeyVersions>()
+  })
+
   test('every slot is optional', () => {
     expectTypeOf<Engine.Engine>().toEqualTypeOf<Partial<Engine.Engine>>()
   })

--- a/src/core/_test/Engine.test.ts
+++ b/src/core/_test/Engine.test.ts
@@ -7,6 +7,7 @@ import {
   Ed25519,
   Engine,
   Hash,
+  HdKey,
   Hex,
   Keystore,
   Mnemonic,
@@ -16,6 +17,7 @@ import {
 } from 'ox'
 import { describe, expect, test, vi } from 'vp/test'
 import {
+  hdKey as hdKeyEngine,
   identity as identityEngine,
   sentinel as sentinelEngine,
 } from '../../../test/engines.js'
@@ -149,6 +151,7 @@ describe('set', () => {
   test('behavior: identity engine changes nothing', () => {
     const expected = {
       blake3: merkelize(),
+      blake3Public: Hash.blake3(payload),
       blsPublicKey: Bls.getPublicKey({ privateKey }),
       blsSignature: Bls.sign({ payload, privateKey }),
       ed25519PublicKey: Ed25519.getPublicKey({ privateKey }),
@@ -170,6 +173,7 @@ describe('set', () => {
 
     expect({
       blake3: merkelize(),
+      blake3Public: Hash.blake3(payload),
       blsPublicKey: Bls.getPublicKey({ privateKey }),
       blsSignature: Bls.sign({ payload, privateKey }),
       ed25519PublicKey: Ed25519.getPublicKey({ privateKey }),
@@ -255,7 +259,7 @@ describe('set', () => {
       `
       [Engine.UnknownSlotError: \`Keccak\` is not a valid engine slot.
 
-      Valid slots: Bls, Ed25519, Hash, Keystore, Mnemonic, P256, Secp256k1, X25519]
+      Valid slots: Bls, Ed25519, Hash, HdKey, Keystore, Mnemonic, P256, Secp256k1, X25519]
     `,
     )
   })
@@ -267,6 +271,16 @@ describe('set', () => {
       [Engine.UnknownPrimitiveError: \`keccak_256\` is not a valid primitive for the \`Hash\` slot.
 
       Valid primitives: blake3, hmacSha256, keccak256, ripemd160, sha256]
+    `)
+  })
+
+  test('error: unknown HD key primitive', () => {
+    expect(() =>
+      Engine.set({ HdKey: { deriveChild: () => undefined } } as never),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Engine.UnknownPrimitiveError: \`deriveChild\` is not a valid primitive for the \`HdKey\` slot.
+
+      Valid primitives: derive, fromExtendedKey, fromSeed]
     `)
   })
 
@@ -336,7 +350,7 @@ describe('reset', () => {
       .toThrowErrorMatchingInlineSnapshot(`
       [Engine.UnknownSlotError: \`Hsah\` is not a valid engine slot.
 
-      Valid slots: Bls, Ed25519, Hash, Keystore, Mnemonic, P256, Secp256k1, X25519]
+      Valid slots: Bls, Ed25519, Hash, HdKey, Keystore, Mnemonic, P256, Secp256k1, X25519]
     `)
 
     // The override the caller meant to remove is still installed, which is the
@@ -422,6 +436,11 @@ describe('interception', () => {
       'Hash.hmac256',
       { Hash: { hmacSha256: () => new Uint8Array(32).fill(1) } },
       () => Hash.hmac256('0xbeef', payload, { as: 'Bytes' }),
+    ],
+    [
+      'Hash.blake3',
+      { Hash: { blake3: () => new Uint8Array(32).fill(1) } },
+      () => Hash.blake3(payload, { as: 'Bytes' }),
     ],
     [
       'BinaryStateTree.merkelize',
@@ -526,6 +545,27 @@ describe('interception', () => {
       'Mnemonic.toSeed',
       { Mnemonic: { toSeed: () => new Uint8Array(64).fill(1) } },
       () => Mnemonic.toSeed(mnemonic),
+    ],
+    [
+      'HdKey.fromSeed',
+      { HdKey: { fromSeed: hdKeyEngine.fromSeed } },
+      () => HdKey.fromSeed('0x00000000000000000000000000000000'),
+    ],
+    [
+      'HdKey.fromExtendedKey',
+      { HdKey: { fromExtendedKey: hdKeyEngine.fromExtendedKey } },
+      () =>
+        HdKey.fromExtendedKey(
+          'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+        ),
+    ],
+    [
+      'HdKey.derive',
+      { HdKey: { derive: hdKeyEngine.derive } },
+      () =>
+        HdKey.fromExtendedKey(
+          'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+        ).derive('m/1'),
     ],
   ] as const satisfies readonly (readonly [
     string,

--- a/src/core/_test/Hash.test-d.ts
+++ b/src/core/_test/Hash.test-d.ts
@@ -1,0 +1,18 @@
+import { type Bytes, Hash, type Hex } from 'ox'
+import { describe, expectTypeOf, test } from 'vp/test'
+
+describe('blake3', () => {
+  test('default', () => {
+    expectTypeOf(Hash.blake3('0x')).toEqualTypeOf<Hex.Hex>()
+    expectTypeOf(Hash.blake3(new Uint8Array())).toEqualTypeOf<Bytes.Bytes>()
+  })
+
+  test('as', () => {
+    expectTypeOf(
+      Hash.blake3('0x', { as: 'Bytes' }),
+    ).toEqualTypeOf<Bytes.Bytes>()
+    expectTypeOf(
+      Hash.blake3(new Uint8Array(), { as: 'Hex' }),
+    ).toEqualTypeOf<Hex.Hex>()
+  })
+})

--- a/src/core/_test/Hash.test.ts
+++ b/src/core/_test/Hash.test.ts
@@ -1,5 +1,103 @@
-import { Hash } from 'ox'
+import { Engine, Hash } from 'ox'
 import { describe, expect, test } from 'vp/test'
+
+describe('blake3', () => {
+  test('default', () => {
+    expect(Hash.blake3('0x')).toMatchInlineSnapshot(
+      `"0xaf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"`,
+    )
+
+    expect(Hash.blake3(new Uint8Array())).toMatchInlineSnapshot(`
+      Uint8Array [
+        175,
+        19,
+        73,
+        185,
+        245,
+        249,
+        161,
+        166,
+        160,
+        64,
+        77,
+        234,
+        54,
+        220,
+        201,
+        73,
+        155,
+        203,
+        37,
+        201,
+        173,
+        193,
+        18,
+        183,
+        204,
+        154,
+        147,
+        202,
+        228,
+        31,
+        50,
+        98,
+      ]
+    `)
+  })
+
+  test('as: Hex', () => {
+    expect(Hash.blake3(new Uint8Array(), { as: 'Hex' })).toMatchInlineSnapshot(
+      `"0xaf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"`,
+    )
+  })
+
+  test('as: Bytes', () => {
+    expect(Hash.blake3('0x', { as: 'Bytes' })).toMatchInlineSnapshot(`
+      Uint8Array [
+        175,
+        19,
+        73,
+        185,
+        245,
+        249,
+        161,
+        166,
+        160,
+        64,
+        77,
+        234,
+        54,
+        220,
+        201,
+        73,
+        155,
+        203,
+        37,
+        201,
+        173,
+        193,
+        18,
+        183,
+        204,
+        154,
+        147,
+        202,
+        228,
+        31,
+        50,
+        98,
+      ]
+    `)
+  })
+
+  test('behavior: routes through the installed engine', () => {
+    Engine.set({ Hash: { blake3: () => new Uint8Array(32).fill(1) } })
+
+    expect(Hash.blake3('0x')).toMatchInlineSnapshot(
+      `"0x0101010101010101010101010101010101010101010101010101010101010101"`,
+    )
+  })
+})
 
 describe('hmac256', () => {
   test('default', () => {
@@ -530,6 +628,7 @@ describe('validate', () => {
 test('exports', () => {
   expect(Object.keys(Hash)).toMatchInlineSnapshot(`
     [
+      "blake3",
       "keccak256",
       "hmac256",
       "ripemd160",

--- a/src/core/_test/Hash.vectors.test.ts
+++ b/src/core/_test/Hash.vectors.test.ts
@@ -1,7 +1,6 @@
 import { Hash } from 'ox'
 import { describe, expect, test } from 'vp/test'
 import * as vectors from '../../../test/vectors/hashes/index.js'
-import * as hash from '../internal/hash.js'
 
 /**
  * Published vectors against ox's default (`@noble/hashes`) implementations.
@@ -15,7 +14,7 @@ import * as hash from '../internal/hash.js'
 describe('blake3', () => {
   test(`matches ${vectors.blake3.length} official BLAKE3 vectors`, () => {
     for (const { digest, message } of vectors.blake3)
-      expect(hash.blake3(message)).toEqual(digest)
+      expect(Hash.blake3(message, { as: 'Bytes' })).toEqual(digest)
   })
 })
 

--- a/src/core/_test/HdKey.test-d.ts
+++ b/src/core/_test/HdKey.test-d.ts
@@ -1,0 +1,60 @@
+import { Engine, HdKey } from 'ox'
+import { describe, expectTypeOf, test } from 'vp/test'
+
+const versions = {
+  private: 0x0488_ade4,
+  public: 0x0488_b21e,
+}
+
+describe('Versions', () => {
+  test('is the engine version-byte contract', () => {
+    expectTypeOf<HdKey.Versions>().toEqualTypeOf<Engine.HdKeyVersions>()
+  })
+})
+
+describe('fromExtendedKey', () => {
+  test('accepts custom versions', () => {
+    expectTypeOf(
+      HdKey.fromExtendedKey('xprv', { versions }),
+    ).toEqualTypeOf<HdKey.HdKey>()
+  })
+})
+
+describe('fromJson', () => {
+  test('accepts custom versions', () => {
+    expectTypeOf(
+      HdKey.fromJson({ xpriv: 'xprv' }, { versions }),
+    ).toEqualTypeOf<HdKey.HdKey>()
+  })
+})
+
+describe('Engine', () => {
+  test('uses plain portable node data', () => {
+    expectTypeOf<Engine.HdKeyNode>().toEqualTypeOf<{
+      depth: number
+      identifier: Uint8Array
+      index: number
+      privateKey: Uint8Array
+      privateExtendedKey: string
+      publicKey: Uint8Array
+      publicExtendedKey: string
+      versions: Engine.HdKeyVersions
+    }>()
+  })
+
+  test('defines all three operations over the portable node', () => {
+    expectTypeOf<NonNullable<Engine.HdKey['derive']>>().toEqualTypeOf<
+      (
+        privateExtendedKey: string,
+        path: string,
+        versions: Engine.HdKeyVersions,
+      ) => Engine.HdKeyNode
+    >()
+    expectTypeOf<NonNullable<Engine.HdKey['fromExtendedKey']>>().toEqualTypeOf<
+      (extendedKey: string, versions: Engine.HdKeyVersions) => Engine.HdKeyNode
+    >()
+    expectTypeOf<NonNullable<Engine.HdKey['fromSeed']>>().toEqualTypeOf<
+      (seed: Uint8Array, versions: Engine.HdKeyVersions) => Engine.HdKeyNode
+    >()
+  })
+})

--- a/src/core/_test/HdKey.test.ts
+++ b/src/core/_test/HdKey.test.ts
@@ -1,13 +1,23 @@
-import { Address, HdKey, Mnemonic } from 'ox'
+import { Address, Engine, HdKey, Hex, Mnemonic } from 'ox'
 import { describe, expect, test } from 'vp/test'
 import { accounts } from '../../../test/constants/accounts.js'
+import { hdKey as hdKeyEngine } from '../../../test/engines.js'
 import * as exports from '../HdKey.js'
 
 const seed = Mnemonic.toSeed(
   'test test test test test test test test test test test junk',
 )
+const vectorSeed = '0x000102030405060708090a0b0c0d0e0f'
 const extendedKey = HdKey.fromSeed(seed).privateExtendedKey
 const json = { xpriv: HdKey.fromSeed(seed).privateExtendedKey }
+const versions = {
+  private: 0x0488_ade4,
+  public: 0x0488_b21e,
+}
+const testnetVersions = {
+  private: 0x0435_8394,
+  public: 0x0435_87cf,
+}
 
 describe('fromExtendedKey', () => {
   test('default', () => {
@@ -26,6 +36,30 @@ describe('fromExtendedKey', () => {
       )
     }
   })
+
+  test('options: versions', () => {
+    const hdKey = HdKey.fromSeed(vectorSeed, {
+      versions: testnetVersions,
+    })
+    const restored = HdKey.fromExtendedKey(hdKey.privateExtendedKey, {
+      versions: testnetVersions,
+    })
+
+    expect({
+      privateExtendedKey: restored.privateExtendedKey,
+      publicExtendedKey: restored.publicExtendedKey,
+      versions: restored.versions,
+    }).toMatchInlineSnapshot(`
+      {
+        "privateExtendedKey": "tprv8ZgxMBicQKsPeDgjzdC36fs6bMjGApWDNLR9erAXMs5skhMv36j9MV5ecvfavji5khqjWaWSFhN3YcCUUdiKH6isR4Pwy3U5y5egddBr16m",
+        "publicExtendedKey": "tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp",
+        "versions": {
+          "private": 70615956,
+          "public": 70617039,
+        },
+      }
+    `)
+  })
 })
 
 describe('fromJson', () => {
@@ -42,6 +76,19 @@ describe('fromJson', () => {
         accounts[index]!.address,
       )
     }
+  })
+
+  test('options: versions', () => {
+    const hdKey = HdKey.fromSeed(vectorSeed, {
+      versions: testnetVersions,
+    })
+    const restored = HdKey.fromJson(
+      { xpriv: hdKey.privateExtendedKey },
+      { versions: testnetVersions },
+    )
+
+    expect(restored.privateExtendedKey).toBe(hdKey.privateExtendedKey)
+    expect(restored.publicExtendedKey).toBe(hdKey.publicExtendedKey)
   })
 })
 
@@ -79,6 +126,152 @@ describe('fromSeed', () => {
         accounts[index]!.address,
       )
     }
+  })
+
+  test('behavior: preserves an offset view without mutating its backing array', () => {
+    const bytes = Hex.toBytes(`0xffff${vectorSeed.slice(2)}eeee`)
+    const view = bytes.subarray(2, -2)
+    const before = Uint8Array.from(bytes)
+
+    const hdKey = HdKey.fromSeed(view)
+
+    expect(bytes).toEqual(before)
+    expect(hdKey.privateExtendedKey).toMatchInlineSnapshot(
+      `"xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"`,
+    )
+  })
+})
+
+describe('Engine', () => {
+  test('behavior: routes every operation through a complete custom engine', () => {
+    Engine.set({ HdKey: hdKeyEngine })
+
+    const fromSeed = HdKey.fromSeed(seed)
+    const fromExtendedKey = HdKey.fromExtendedKey(fromSeed.privateExtendedKey)
+    const fromJson = HdKey.fromJson({ xpriv: fromSeed.privateExtendedKey })
+    const derived = fromSeed.derive('m/123')
+
+    expect({
+      derived: derived.privateExtendedKey,
+      fromExtendedKey: fromExtendedKey.privateExtendedKey,
+      fromJson: fromJson.privateExtendedKey,
+      fromSeed: fromSeed.privateExtendedKey,
+    }).toMatchInlineSnapshot(`
+      {
+        "derived": "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+        "fromExtendedKey": "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+        "fromJson": "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+        "fromSeed": "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+      }
+    `)
+  })
+
+  test('behavior: an existing key resolves the current engine for every derive', () => {
+    const hdKey = HdKey.fromSeed(vectorSeed)
+    const before = hdKey.derive('m/1').privateExtendedKey
+
+    Engine.set({ HdKey: { derive: hdKeyEngine.derive } })
+
+    expect(hdKey.derive('m/1').privateExtendedKey).not.toBe(before)
+    expect(hdKey.derive('m/1').privateExtendedKey).toBe(
+      'xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7',
+    )
+  })
+
+  test('behavior: mutated versions apply to recursive derivation', () => {
+    const hdKey = HdKey.fromSeed(vectorSeed)
+    Object.assign(hdKey.versions, testnetVersions)
+
+    const derived = hdKey.derive("m/0'")
+
+    expect(derived.privateExtendedKey.startsWith('tprv')).toBe(true)
+    expect(derived.publicExtendedKey.startsWith('tpub')).toBe(true)
+    expect(derived.versions).toEqual(testnetVersions)
+  })
+
+  test('behavior: a node from a partial engine derives after reset', () => {
+    Engine.set({ HdKey: { fromSeed: hdKeyEngine.fromSeed } })
+    const hdKey = HdKey.fromSeed(seed)
+
+    Engine.reset('HdKey')
+
+    expect(hdKey.derive("m/0'").privateExtendedKey).toMatchInlineSnapshot(
+      `"xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7"`,
+    )
+  })
+
+  test('behavior: a scoped derive restores the previous implementation', () => {
+    const hdKey = HdKey.fromSeed(vectorSeed)
+    const expected = hdKey.derive('m/1').privateExtendedKey
+
+    const scoped = Engine.with(
+      { HdKey: { derive: hdKeyEngine.derive } },
+      () => hdKey.derive('m/1').privateExtendedKey,
+    )
+
+    expect(scoped).not.toBe(expected)
+    expect(hdKey.derive('m/1').privateExtendedKey).toBe(expected)
+  })
+
+  test('behavior: materialization detaches provider buffers and versions', () => {
+    const node = hdKeyEngine.fromSeed(Hex.toBytes(vectorSeed), versions)
+    Engine.set({ HdKey: { fromSeed: () => node } })
+
+    const hdKey = HdKey.fromSeed(vectorSeed)
+    node.identifier.fill(0)
+    node.privateKey.fill(0)
+    node.publicKey.fill(0)
+    node.versions.private = 0
+
+    expect({
+      identifier: hdKey.identifier,
+      privateKey: hdKey.privateKey,
+      publicKey: hdKey.publicKey,
+      versions: hdKey.versions,
+    }).toMatchInlineSnapshot(`
+      {
+        "identifier": "0x3442193e1bb70916e914552172cd4e2dbc9df811",
+        "privateKey": "0xe8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35",
+        "publicKey": {
+          "prefix": 4,
+          "x": "0x39a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
+          "y": "0x3cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281",
+        },
+        "versions": {
+          "private": 76066276,
+          "public": 76067358,
+        },
+      }
+    `)
+  })
+
+  test('error: rejects malformed provider node lengths', () => {
+    const node = hdKeyEngine.fromSeed(Hex.toBytes(vectorSeed), versions)
+
+    Engine.set({
+      HdKey: {
+        fromSeed: () => ({ ...node, publicKey: node.publicKey.slice(0, 33) }),
+      },
+    })
+
+    expect(() => HdKey.fromSeed(vectorSeed)).toThrowErrorMatchingInlineSnapshot(
+      `[BaseError: Expected 65 bytes for an HD key public key, received 33.]`,
+    )
+  })
+
+  test('behavior: the HdKey provider owns its public key', () => {
+    Engine.set({
+      HdKey: { fromSeed: hdKeyEngine.fromSeed },
+      Secp256k1: { getPublicKey: () => new Uint8Array(65) },
+    })
+
+    expect(HdKey.fromSeed(seed).publicKey).toMatchInlineSnapshot(`
+      {
+        "prefix": 4,
+        "x": "0x39a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
+        "y": "0x3cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281",
+      }
+    `)
   })
 })
 

--- a/src/core/_test/HdKey.vectors.test.ts
+++ b/src/core/_test/HdKey.vectors.test.ts
@@ -1,0 +1,356 @@
+import { HDKey as ScureHdKey, __TESTS } from '@scure/bip32'
+import { HdKey, Hex } from 'ox'
+import { describe, expect, test } from 'vp/test'
+import * as internal from '../internal/hdKey.js'
+
+const seed = '0x000102030405060708090a0b0c0d0e0f'
+const versions = {
+  private: 0x0488_ade4,
+  public: 0x0488_b21e,
+}
+
+/**
+ * BIP-32 test vector 1.
+ *
+ * Source: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+ */
+const vector = [
+  {
+    path: 'm',
+    privateExtendedKey:
+      'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+    publicExtendedKey:
+      'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8',
+  },
+  {
+    path: "m/0'",
+    privateExtendedKey:
+      'xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7',
+    publicExtendedKey:
+      'xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw',
+  },
+  {
+    path: "m/0'/1",
+    privateExtendedKey:
+      'xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs',
+    publicExtendedKey:
+      'xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ',
+  },
+  {
+    path: "m/0'/1/2'",
+    privateExtendedKey:
+      'xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM',
+    publicExtendedKey:
+      'xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5',
+  },
+  {
+    path: "m/0'/1/2'/2",
+    privateExtendedKey:
+      'xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334',
+    publicExtendedKey:
+      'xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV',
+  },
+  {
+    path: "m/0'/1/2'/2/1000000000",
+    privateExtendedKey:
+      'xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76',
+    publicExtendedKey:
+      'xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy',
+  },
+] as const
+
+/**
+ * BIP-32 test vectors 2-4.
+ *
+ * Source: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+ */
+const vectors = [
+  {
+    number: 2,
+    seed: '0xfffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542',
+    nodes: [
+      {
+        path: 'm',
+        privateExtendedKey:
+          'xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U',
+        publicExtendedKey:
+          'xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB',
+      },
+      {
+        path: 'm/0',
+        privateExtendedKey:
+          'xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt',
+        publicExtendedKey:
+          'xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH',
+      },
+      {
+        path: "m/0/2147483647'",
+        privateExtendedKey:
+          'xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9',
+        publicExtendedKey:
+          'xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a',
+      },
+      {
+        path: "m/0/2147483647'/1",
+        privateExtendedKey:
+          'xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef',
+        publicExtendedKey:
+          'xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon',
+      },
+      {
+        path: "m/0/2147483647'/1/2147483646'",
+        privateExtendedKey:
+          'xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc',
+        publicExtendedKey:
+          'xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL',
+      },
+      {
+        path: "m/0/2147483647'/1/2147483646'/2",
+        privateExtendedKey:
+          'xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j',
+        publicExtendedKey:
+          'xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt',
+      },
+    ],
+  },
+  {
+    number: 3,
+    seed: '0x4b381541583be4423346c643850da4b320e46a87ae3d2a4e6da11eba819cd4acba45d239319ac14f863b8d5ab5a0d0c64d2e8a1e7d1457df2e5a3c51c73235be',
+    nodes: [
+      {
+        path: 'm',
+        privateExtendedKey:
+          'xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6',
+        publicExtendedKey:
+          'xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13',
+      },
+      {
+        path: "m/0'",
+        privateExtendedKey:
+          'xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L',
+        publicExtendedKey:
+          'xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y',
+      },
+    ],
+  },
+  {
+    number: 4,
+    seed: '0x3ddd5602285899a946114506157c7997e5444528f3003f6134712147db19b678',
+    nodes: [
+      {
+        path: 'm',
+        privateExtendedKey:
+          'xprv9s21ZrQH143K48vGoLGRPxgo2JNkJ3J3fqkirQC2zVdk5Dgd5w14S7fRDyHH4dWNHUgkvsvNDCkvAwcSHNAQwhwgNMgZhLtQC63zxwhQmRv',
+        publicExtendedKey:
+          'xpub661MyMwAqRbcGczjuMoRm6dXaLDEhW1u34gKenbeYqAix21mdUKJyuyu5F1rzYGVxyL6tmgBUAEPrEz92mBXjByMRiJdba9wpnN37RLLAXa',
+      },
+      {
+        path: "m/0'",
+        privateExtendedKey:
+          'xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G',
+        publicExtendedKey:
+          'xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m',
+      },
+      {
+        path: "m/0'/1'",
+        privateExtendedKey:
+          'xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1',
+        publicExtendedKey:
+          'xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt',
+      },
+    ],
+  },
+] as const
+
+/**
+ * BIP-32 test vector 5.
+ *
+ * Source: https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
+ */
+const invalidExtendedKeys = [
+  [
+    'public version with private key',
+    'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6LBpB85b3D2yc8sfvZU521AAwdZafEz7mnzBBsz4wKY5fTtTQBm',
+  ],
+  [
+    'private version with public key',
+    'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGTQQD3dC4H2D5GBj7vWvSQaaBv5cxi9gafk7NF3pnBju6dwKvH',
+  ],
+  [
+    'public key prefix 04',
+    'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Txnt3siSujt9RCVYsx4qHZGc62TG4McvMGcAUjeuwZdduYEvFn',
+  ],
+  [
+    'private key prefix 04',
+    'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFGpWnsj83BHtEy5Zt8CcDr1UiRXuWCmTQLxEK9vbz5gPstX92JQ',
+  ],
+  [
+    'public key prefix 01',
+    'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6N8ZMMXctdiCjxTNq964yKkwrkBJJwpzZS4HS2fxvyYUA4q2Xe4',
+  ],
+  [
+    'private key prefix 01',
+    'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD9y5gkZ6Eq3Rjuahrv17fEQ3Qen6J',
+  ],
+  [
+    'private zero depth with parent fingerprint',
+    'xprv9s2SPatNQ9Vc6GTbVMFPFo7jsaZySyzk7L8n2uqKXJen3KUmvQNTuLh3fhZMBoG3G4ZW1N2kZuHEPY53qmbZzCHshoQnNf4GvELZfqTUrcv',
+  ],
+  [
+    'public zero depth with parent fingerprint',
+    'xpub661no6RGEX3uJkY4bNnPcw4URcQTrSibUZ4NqJEw5eBkv7ovTwgiT91XX27VbEXGENhYRCf7hyEbWrR3FewATdCEebj6znwMfQkhRYHRLpJ',
+  ],
+  [
+    'private zero depth with index',
+    'xprv9s21ZrQH4r4TsiLvyLXqM9P7k1K3EYhA1kkD6xuquB5i39AU8KF42acDyL3qsDbU9NmZn6MsGSUYZEsuoePmjzsB3eFKSUEh3Gu1N3cqVUN',
+  ],
+  [
+    'public zero depth with index',
+    'xpub661MyMwAuDcm6CRQ5N4qiHKrJ39Xe1R1NyfouMKTTWcguwVcfrZJaNvhpebzGerh7gucBvzEQWRugZDuDXjNDRmXzSZe4c7mnTK97pTvGS8',
+  ],
+  [
+    'unknown private version',
+    'DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHGMQzT7ayAmfo4z3gY5KfbrZWZ6St24UVf2Qgo6oujFktLHdHY4',
+  ],
+  [
+    'unknown public version',
+    'DMwo58pR1QLEFihHiXPVykYB6fJmsTeHvyTp7hRThAtCX8CvYzgPcn8XnmdfHPmHJiEDXkTiJTVV9rHEBUem2mwVbbNfvT2MTcAqj3nesx8uBf9',
+  ],
+  [
+    'private key zero',
+    'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx',
+  ],
+  [
+    'private key curve order',
+    'xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzFAzHGBP2UuGCqWLTAPLcMtD5SDKr24z3aiUvKr9bJpdrcLg1y3G',
+  ],
+  [
+    'invalid public key',
+    'xpub661MyMwAqRbcEYS8w7XLSVeEsBXy79zSzH1J8vCdxAZningWLdN3zgtU6Q5JXayek4PRsn35jii4veMimro1xefsM58PgBMrvdYre8QyULY',
+  ],
+  [
+    'invalid checksum',
+    'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHL',
+  ],
+] as const
+
+describe('BIP-32 test vector 1', () => {
+  test('matches every private and public extended key', () => {
+    const root = HdKey.fromSeed(seed)
+    for (const expected of vector) {
+      const node = root.derive(expected.path)
+      expect(node.privateExtendedKey).toBe(expected.privateExtendedKey)
+      expect(node.publicExtendedKey).toBe(expected.publicExtendedKey)
+    }
+  })
+
+  test('imports every private extended key', () => {
+    for (const expected of vector) {
+      const node = HdKey.fromExtendedKey(expected.privateExtendedKey)
+      expect(node.privateExtendedKey).toBe(expected.privateExtendedKey)
+      expect(node.publicExtendedKey).toBe(expected.publicExtendedKey)
+    }
+  })
+})
+
+for (const vector of vectors) {
+  describe(`BIP-32 test vector ${vector.number}`, () => {
+    test('matches every private and public extended key', () => {
+      const root = HdKey.fromSeed(vector.seed)
+      for (const expected of vector.nodes) {
+        const node = root.derive(expected.path)
+        expect(node.privateExtendedKey).toBe(expected.privateExtendedKey)
+        expect(node.publicExtendedKey).toBe(expected.publicExtendedKey)
+      }
+    })
+
+    test('imports every private extended key', () => {
+      for (const expected of vector.nodes) {
+        const node = HdKey.fromExtendedKey(expected.privateExtendedKey)
+        expect(node.privateExtendedKey).toBe(expected.privateExtendedKey)
+        expect(node.publicExtendedKey).toBe(expected.publicExtendedKey)
+      }
+    })
+  })
+}
+
+describe('BIP-32 test vector 5', () => {
+  test.each(invalidExtendedKeys)('rejects %s', (_name, extendedKey) => {
+    expect(() => HdKey.fromExtendedKey(extendedKey)).toThrowError()
+  })
+})
+
+describe('derive', () => {
+  test('behavior: accepts the highest normal and hardened indices', () => {
+    const root = HdKey.fromSeed(seed)
+
+    expect({
+      firstHardened: root.derive("m/0'").index,
+      highestHardened: root.derive("m/2147483647'").index,
+      highestNormal: root.derive('m/2147483647').index,
+    }).toMatchInlineSnapshot(`
+      {
+        "firstHardened": 2147483648,
+        "highestHardened": 4294967295,
+        "highestNormal": 2147483647,
+      }
+    `)
+  })
+
+  test('error: rejects malformed and out-of-range paths', () => {
+    const root = HdKey.fromSeed(seed)
+
+    expect(() => root.derive('0/1')).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Path must start with "m" or "M"]`,
+    )
+    expect(() =>
+      root.derive('m/2147483648'),
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: Invalid index]`)
+    expect(() => root.derive('m/-1')).toThrowErrorMatchingInlineSnapshot(
+      `[Error: invalid child index: -1]`,
+    )
+  })
+
+  test('behavior: the default retries the next index for an invalid child', () => {
+    const key = ScureHdKey.fromMasterSeed(Hex.toBytes(seed))
+    const invalidTweak = Hex.toBytes(
+      `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141${'00'.repeat(32)}`,
+    )
+
+    const child = internal.fromScure(
+      __TESTS.deriveChildWithI(key, 0, invalidTweak),
+    )
+
+    expect(child.index).toMatchInlineSnapshot('1')
+    expect(child.privateExtendedKey).toBe(
+      HdKey.fromSeed(seed).derive('m/1').privateExtendedKey,
+    )
+  })
+})
+
+describe('node ownership', () => {
+  test('behavior: the default returns fresh result buffers', () => {
+    const first = internal.fromSeed(Hex.toBytes(seed), versions)
+    const second = internal.fromSeed(Hex.toBytes(seed), versions)
+
+    expect({
+      identifier: first.identifier === second.identifier,
+      identifierLength: first.identifier.length,
+      privateKey: first.privateKey === second.privateKey,
+      privateKeyLength: first.privateKey.length,
+      publicKey: first.publicKey === second.publicKey,
+      publicKeyLength: first.publicKey.length,
+      versions: first.versions === second.versions,
+    }).toMatchInlineSnapshot(`
+      {
+        "identifier": false,
+        "identifierLength": 20,
+        "privateKey": false,
+        "privateKeyLength": 32,
+        "publicKey": false,
+        "publicKeyLength": 65,
+        "versions": false,
+      }
+    `)
+  })
+})

--- a/src/core/internal/bls.ts
+++ b/src/core/internal/bls.ts
@@ -60,31 +60,44 @@ const verifyDefault: Complete<Bls>['verify'] = (
   const { dst, signatureGroup } = options
   const shortSignature = signatureGroup === 'G1'
   const curve = shortSignature ? bls.G1 : bls.G2
-  const payloadPoint = curve.hashToCurve(
-    payload,
-    dst ? { DST: dst } : undefined,
-  )
-  const pairing = shortSignature
-    ? bls.pairingBatch([
+  // Parse both points before hashing the payload, with the signature first, to
+  // preserve public malformed-input precedence.
+  const pairing = (() => {
+    if (shortSignature) {
+      const signaturePoint = bls.G1.Point.fromBytes(signature)
+      const publicKeyPoint = bls.G2.Point.fromBytes(publicKey)
+      const payloadPoint = curve.hashToCurve(
+        payload,
+        dst ? { DST: dst } : undefined,
+      )
+      return bls.pairingBatch([
         {
           g1: payloadPoint as InstanceType<typeof bls.G1.Point>,
-          g2: bls.G2.Point.fromBytes(publicKey),
+          g2: publicKeyPoint,
         },
         {
-          g1: bls.G1.Point.fromBytes(signature),
+          g1: signaturePoint,
           g2: bls.G2.Point.BASE.negate(),
         },
       ])
-    : bls.pairingBatch([
-        {
-          g1: bls.G1.Point.fromBytes(publicKey).negate(),
-          g2: payloadPoint as InstanceType<typeof bls.G2.Point>,
-        },
-        {
-          g1: bls.G1.Point.BASE,
-          g2: bls.G2.Point.fromBytes(signature),
-        },
-      ])
+    }
+    const signaturePoint = bls.G2.Point.fromBytes(signature)
+    const publicKeyPoint = bls.G1.Point.fromBytes(publicKey)
+    const payloadPoint = curve.hashToCurve(
+      payload,
+      dst ? { DST: dst } : undefined,
+    )
+    return bls.pairingBatch([
+      {
+        g1: publicKeyPoint.negate(),
+        g2: payloadPoint as InstanceType<typeof bls.G2.Point>,
+      },
+      {
+        g1: bls.G1.Point.BASE,
+        g2: signaturePoint,
+      },
+    ])
+  })()
   return bls.fields.Fp12.eql(pairing, bls.fields.Fp12.ONE)
 }
 

--- a/src/core/internal/engine.ts
+++ b/src/core/internal/engine.ts
@@ -39,6 +39,83 @@ export type Hash = {
 }
 
 /**
+ * BIP-32 version bytes.
+ *
+ * @internal
+ */
+export type HdKeyVersions = {
+  /** Version used to serialize private extended keys. */
+  private: number
+  /** Version used to serialize public extended keys. */
+  public: number
+}
+
+/**
+ * A fully materialized private BIP-32 node.
+ *
+ * Providers return plain data rather than an object with methods so an
+ * {@link Engine} swap cannot leave a provider-owned class or closure attached
+ * to an existing public HD key.
+ *
+ * @internal
+ */
+export type HdKeyNode = {
+  /** Node depth. */
+  depth: number
+  /** 20-byte HASH160 identifier. */
+  identifier: Uint8Array
+  /** Child index. */
+  index: number
+  /** 32-byte private key. */
+  privateKey: Uint8Array
+  /** Base58Check-encoded private extended key. */
+  privateExtendedKey: string
+  /** Uncompressed 65-byte SEC1 public key. */
+  publicKey: Uint8Array
+  /** Base58Check-encoded public extended key. */
+  publicExtendedKey: string
+  /** Version bytes used by the node. */
+  versions: HdKeyVersions
+}
+
+/**
+ * BIP-32 private-node operations.
+ *
+ * The private extended key is the portable derivation state: it contains the
+ * private key, chain code, depth, parent fingerprint, and child index without
+ * exposing a provider-owned object across calls.
+ *
+ * Providers must accept non-zero-offset seed views without retaining or
+ * mutating them. Returned buffers and version records must be fresh, have the
+ * documented lengths, and remain valid after the provider returns.
+ *
+ * @internal
+ */
+export type HdKey = {
+  /**
+   * Derives a node at a BIP-32 path.
+   *
+   * `versions` selects the returned node's version bytes. Providers must read
+   * the source private version from `privateExtendedKey` independently.
+   */
+  derive?:
+    | ((
+        privateExtendedKey: string,
+        path: string,
+        versions: HdKeyVersions,
+      ) => HdKeyNode)
+    | undefined
+  /** Imports a Base58Check-encoded private extended key. */
+  fromExtendedKey?:
+    | ((extendedKey: string, versions: HdKeyVersions) => HdKeyNode)
+    | undefined
+  /** Derives a master node from a 16- to 64-byte seed. */
+  fromSeed?:
+    | ((seed: Uint8Array, versions: HdKeyVersions) => HdKeyNode)
+    | undefined
+}
+
+/**
  * Short-Weierstrass ECDSA. Shared by the `Secp256k1` and `P256` slots.
  *
  * Signatures are always low-S normalized and always returned in 65-byte
@@ -212,7 +289,14 @@ export type Mnemonic = {
  * Points cross this boundary in their compressed serialized form (48 bytes for
  * G1, 96 for G2), never as projective coordinate triples -- an engine backed by
  * a native library cannot be expected to reproduce another library's internal
- * point representation.
+ * point representation. Providers must accept non-zero-offset views without
+ * retaining or mutating them, and return fresh, exact-length byte arrays.
+ *
+ * Serialized inputs are trusted only after the provider validates their
+ * canonical compressed encoding, curve and prime-order subgroup membership,
+ * and infinity behavior exactly as Ox's default does. Aggregation validates
+ * points in array order. Verification validates the signature before the
+ * public key.
  *
  * @internal
  */
@@ -269,6 +353,8 @@ export type Engine = {
   Ed25519?: Eddsa | undefined
   /** Implementation for [`Hash`](/api/Hash). */
   Hash?: Hash | undefined
+  /** Implementation for [`HdKey`](/api/HdKey). */
+  HdKey?: HdKey | undefined
   /** Implementation for [`Keystore`](/api/Keystore). */
   Keystore?: Keystore | undefined
   /** Implementation for [`Mnemonic`](/api/Mnemonic). */
@@ -303,6 +389,7 @@ export const slots = [
   'Bls',
   'Ed25519',
   'Hash',
+  'HdKey',
   'Keystore',
   'Mnemonic',
   'P256',
@@ -332,6 +419,7 @@ export const primitives = {
     'verify',
   ],
   Hash: ['blake3', 'hmacSha256', 'keccak256', 'ripemd160', 'sha256'],
+  HdKey: ['derive', 'fromExtendedKey', 'fromSeed'],
   Keystore: [
     'aesCtrDecrypt',
     'aesCtrEncrypt',

--- a/src/core/internal/hdKey.ts
+++ b/src/core/internal/hdKey.ts
@@ -1,25 +1,90 @@
-import type { HDKey } from '@scure/bip32'
-import type * as Errors from '../Errors.js'
-import type * as HdKey from '../HdKey.js'
+import { HDKey as ScureHdKey } from '@scure/bip32'
 import * as Hex from '../Hex.js'
-import * as Secp256k1 from '../Secp256k1.js'
+import {
+  type Complete,
+  type HdKey,
+  type HdKeyNode,
+  type HdKeyVersions,
+  overrides,
+} from './engine.js'
+import * as secp256k1 from './secp256k1.js'
+
+type Derive = (
+  privateExtendedKey: string,
+  path: string,
+  versions: HdKeyVersions,
+  sourceVersions: HdKeyVersions,
+) => HdKeyNode
+
+/**
+ * Resolvers for the `HdKey` slot, and ox's defaults for it, backed by
+ * `@scure/bip32`.
+ *
+ * The default materializes each provider node before it crosses the engine
+ * boundary. No `@scure/bip32` class instance survives the call.
+ */
 
 /** @internal */
-export function fromScure(key: HDKey): HdKey.HdKey {
+export function fromScure(key: ScureHdKey): HdKeyNode {
+  const privateKey = key.privateKey
+  if (!privateKey) {
+    // Preserve the previous xpub rejection from public materialization.
+    Hex.fromBytes(privateKey!)
+    throw new Error('No private key')
+  }
   return {
-    derive: (path) => fromScure(key.derive(path)),
     depth: key.depth,
-    identifier: Hex.fromBytes(key.identifier!),
+    identifier: Uint8Array.from(key.identifier!),
     index: key.index,
-    privateKey: Hex.fromBytes(key.privateKey!),
+    privateKey: Uint8Array.from(privateKey),
     privateExtendedKey: key.privateExtendedKey,
-    publicKey: Secp256k1.getPublicKey({ privateKey: key.privateKey! }),
+    publicKey: secp256k1.getPublicKey(privateKey),
     publicExtendedKey: key.publicExtendedKey,
-    versions: key.versions,
+    versions: { ...key.versions },
   }
 }
 
-/** @internal */
-export declare namespace fromScure {
-  type ErrorType = Errors.GlobalErrorType
+const deriveDefault: Derive = (
+  privateExtendedKey,
+  path,
+  versions,
+  sourceVersions,
+) => {
+  const key = ScureHdKey.fromExtendedKey(privateExtendedKey, sourceVersions)
+  Object.assign(key.versions, versions)
+  return fromScure(key.derive(path))
 }
+
+const fromExtendedKeyDefault: Complete<HdKey>['fromExtendedKey'] = (
+  extendedKey,
+  versions,
+) => fromScure(ScureHdKey.fromExtendedKey(extendedKey, versions))
+
+const fromSeedDefault: Complete<HdKey>['fromSeed'] = (seed, versions) =>
+  fromScure(ScureHdKey.fromMasterSeed(seed, versions))
+
+/** @internal */
+export const derive: Derive = (
+  privateExtendedKey,
+  path,
+  versions,
+  sourceVersions,
+) => {
+  const override = overrides.HdKey?.derive
+  if (override) return override(privateExtendedKey, path, versions)
+  return deriveDefault(privateExtendedKey, path, versions, sourceVersions)
+}
+
+/** @internal */
+export const fromExtendedKey: Complete<HdKey>['fromExtendedKey'] = (
+  extendedKey,
+  versions,
+) =>
+  (overrides.HdKey?.fromExtendedKey ?? fromExtendedKeyDefault)(
+    extendedKey,
+    versions,
+  )
+
+/** @internal */
+export const fromSeed: Complete<HdKey>['fromSeed'] = (seed, versions) =>
+  (overrides.HdKey?.fromSeed ?? fromSeedDefault)(seed, versions)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1604,14 +1604,14 @@ export * as Fee from './core/Fee.js'
  */
 export * as Filter from './core/Filter.js'
 /**
- * Utility functions for hashing (keccak256, sha256, etc).
+ * Utility functions for BLAKE3, Keccak256, SHA-256, and other hashes.
  *
  * @example
  * ```ts twoslash
  * import { Hash } from 'ox'
  *
- * const value = Hash.keccak256('0xdeadbeef')
- * // '0xd4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1'
+ * const value = Hash.blake3('0xdeadbeef')
+ * // '0x53147f3ce49ed4f60dfa5b9654c36ba6103c11f5737df3dabd4cbd296c4161bd'
  * ```
  *
  * @category Crypto
@@ -1622,7 +1622,7 @@ export * as Hash from './core/Hash.js'
  *
  * :::info
  *
- * The `HdKey` module is a friendly wrapper over [`@scure/bip32`](https://github.com/paulmillr/scure-bip32), an **audited** implementation of [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) HD Wallets.
+ * The `HdKey` module defaults to [`@scure/bip32`](https://github.com/paulmillr/scure-bip32), an **audited** implementation of [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) HD Wallets. Its implementation can be replaced with {@link ox#Engine.set}.
  *
  * :::
  *

--- a/src/node/Engine.ts
+++ b/src/node/Engine.ts
@@ -24,6 +24,9 @@ export type {
   Eddsa,
   Engine,
   Hash,
+  HdKey,
+  HdKeyNode,
+  HdKeyVersions,
   Keystore,
   Mnemonic,
 } from '../core/Engine.js'

--- a/src/node/Hash.ts
+++ b/src/node/Hash.ts
@@ -12,9 +12,9 @@ export * from '../core/Hash.js'
  * which installs every implementation this entrypoint provides. Reach for this
  * to install or hold the `Hash` slot on its own.
  *
- * Node's `sha3-256` is not Ethereum Keccak256, so this engine deliberately
- * omits `keccak256`. Any earlier override remains installed; otherwise Ox uses
- * its default implementation.
+ * Node does not provide BLAKE3, and its `sha3-256` is not Ethereum Keccak256, so
+ * this engine deliberately omits `blake3` and `keccak256`. Any earlier override
+ * remains installed; otherwise Ox uses its default implementation.
  *
  * @example
  * ```ts twoslash

--- a/src/node/_test/Engine.test-d.ts
+++ b/src/node/_test/Engine.test-d.ts
@@ -13,6 +13,9 @@ test('install and engine expose the same precise engine', () => {
 })
 
 test('the Node Engine namespace exposes synchronous core operations', () => {
+  expectTypeOf<Engine.HdKey>().toEqualTypeOf<CoreEngine.HdKey>()
+  expectTypeOf<Engine.HdKeyNode>().toEqualTypeOf<CoreEngine.HdKeyNode>()
+  expectTypeOf<Engine.HdKeyVersions>().toEqualTypeOf<CoreEngine.HdKeyVersions>()
   expectTypeOf(Engine.get).toEqualTypeOf(CoreEngine.get)
   expectTypeOf(Engine.InvalidSlotValueError).toEqualTypeOf(
     CoreEngine.InvalidSlotValueError,

--- a/src/node/_test/Engine.test.ts
+++ b/src/node/_test/Engine.test.ts
@@ -78,6 +78,9 @@ describe('install', () => {
   test('behavior: leaves unsupported primitives on the default', async () => {
     await Engine.install()
 
+    expect(Hash.blake3('0x')).toMatchInlineSnapshot(
+      `"0xaf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"`,
+    )
     expect(Hash.keccak256('0xdeadbeef')).toMatchInlineSnapshot(
       `"0xd4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1"`,
     )

--- a/src/node/_test/Hash.test-d.ts
+++ b/src/node/_test/Hash.test-d.ts
@@ -27,6 +27,7 @@ test('the result is the raw slot, so `Engine.install` accepts it', () => {
 })
 
 test('the Node namespace exposes the public Hash API', () => {
+  expectTypeOf(NodeHash.blake3).toEqualTypeOf(CoreHash.blake3)
   expectTypeOf(NodeHash.sha256).toEqualTypeOf(CoreHash.sha256)
   expectTypeOf<typeof NodeHash>().not.toHaveProperty('create')
 })

--- a/src/wasm/Engine.ts
+++ b/src/wasm/Engine.ts
@@ -24,6 +24,9 @@ export type {
   Eddsa,
   Engine,
   Hash,
+  HdKey,
+  HdKeyNode,
+  HdKeyVersions,
   Keystore,
   Mnemonic,
 } from '../core/Engine.js'

--- a/src/wasm/Hash.ts
+++ b/src/wasm/Hash.ts
@@ -35,7 +35,7 @@ const digestSize = { keccak256: 32, ripemd160: 20, sha256: 32 }
  *
  * await Engine.install({ Hash: Hash.engine() })
  *
- * Hash.keccak256('0xdeadbeef')
+ * Hash.blake3('0xdeadbeef')
  * ```
  *
  * @returns The WASM implementation of the `Hash` slot.

--- a/src/wasm/_test/Engine.test-d.ts
+++ b/src/wasm/_test/Engine.test-d.ts
@@ -13,6 +13,9 @@ test('install and engine expose the same precise engine', () => {
 })
 
 test('the WASM Engine namespace exposes synchronous core operations', () => {
+  expectTypeOf<Engine.HdKey>().toEqualTypeOf<CoreEngine.HdKey>()
+  expectTypeOf<Engine.HdKeyNode>().toEqualTypeOf<CoreEngine.HdKeyNode>()
+  expectTypeOf<Engine.HdKeyVersions>().toEqualTypeOf<CoreEngine.HdKeyVersions>()
   expectTypeOf(Engine.get).toEqualTypeOf(CoreEngine.get)
   expectTypeOf(Engine.InvalidSlotValueError).toEqualTypeOf(
     CoreEngine.InvalidSlotValueError,

--- a/src/wasm/_test/Hash.browser.test.ts
+++ b/src/wasm/_test/Hash.browser.test.ts
@@ -44,6 +44,9 @@ describe('engine', () => {
   test('behavior: ox uses the WASM implementation once installed', async () => {
     await Engine.install({ Hash: WasmHash.engine() })
     try {
+      expect(Hash.blake3('0xdeadbeef')).toBe(
+        '0x53147f3ce49ed4f60dfa5b9654c36ba6103c11f5737df3dabd4cbd296c4161bd',
+      )
       expect(Hash.keccak256('0xdeadbeef')).toBe(
         '0xd4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1',
       )

--- a/src/wasm/_test/Hash.test-d.ts
+++ b/src/wasm/_test/Hash.test-d.ts
@@ -28,6 +28,7 @@ test('the result is the raw slot, so `Engine.install` accepts it', () => {
 })
 
 test('the WASM namespace exposes the public Hash API', () => {
+  expectTypeOf(WasmHash.blake3).toEqualTypeOf(CoreHash.blake3)
   expectTypeOf(WasmHash.sha256).toEqualTypeOf(CoreHash.sha256)
   expectTypeOf<typeof WasmHash>().not.toHaveProperty('create')
 })

--- a/src/wasm/_test/Hash.test.ts
+++ b/src/wasm/_test/Hash.test.ts
@@ -292,8 +292,8 @@ describe('Engine.install', () => {
   test('behavior: ox uses the WASM implementation once installed', async () => {
     await Engine.install({ Hash: engine })
     try {
-      expect(Engine.get().Hash?.blake3?.(Bytes.from('0xdeadbeef'))).toEqual(
-        blake3(Bytes.from('0xdeadbeef')),
+      expect(Hash.blake3('0xdeadbeef')).toBe(
+        '0x53147f3ce49ed4f60dfa5b9654c36ba6103c11f5737df3dabd4cbd296c4161bd',
       )
       expect(Hash.keccak256('0xdeadbeef')).toBe(
         '0xd4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1',

--- a/test/engines.ts
+++ b/test/engines.ts
@@ -11,7 +11,83 @@ import { scrypt, scryptAsync } from '@noble/hashes/scrypt.js'
 import { sha256 } from '@noble/hashes/sha2.js'
 import { keccak_256 } from '@noble/hashes/sha3.js'
 import { mnemonicToSeedSync } from '@scure/bip39'
-import type { Engine } from 'ox'
+import { Hex, type Engine } from 'ox'
+
+type HdKeyFixture = Omit<
+  Engine.HdKeyNode,
+  'identifier' | 'privateKey' | 'publicKey' | 'versions'
+> & {
+  identifier: Hex.Hex
+  privateKey: Hex.Hex
+  publicKey: Hex.Hex
+}
+
+const hdKeyRoot = {
+  depth: 0,
+  identifier: '0x3442193e1bb70916e914552172cd4e2dbc9df811',
+  index: 0,
+  privateKey:
+    '0xe8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
+  privateExtendedKey:
+    'xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi',
+  publicKey:
+    '0x0439a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c23cbe7ded0e7ce6a594896b8f62888fdbc5c8821305e2ea42bf01e37300116281',
+  publicExtendedKey:
+    'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8',
+} as const satisfies HdKeyFixture
+
+const hdKeyChild = {
+  depth: 1,
+  identifier: '0x5c1bd648ed23aa5fd50ba52b2457c11e9e80a6a7',
+  index: 0x8000_0000,
+  privateKey:
+    '0xedb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea',
+  privateExtendedKey:
+    'xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7',
+  publicKey:
+    '0x045a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc567f717885be239daadce76b568958305183ad616ff74ed4dc219a74c26d35f839',
+  publicExtendedKey:
+    'xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw',
+} as const satisfies HdKeyFixture
+
+function materializeHdKey(
+  fixture: HdKeyFixture,
+  versions: Engine.HdKeyVersions,
+): Engine.HdKeyNode {
+  return {
+    ...fixture,
+    identifier: Hex.toBytes(fixture.identifier),
+    privateKey: Hex.toBytes(fixture.privateKey),
+    publicKey: Hex.toBytes(fixture.publicKey),
+    versions: { ...versions },
+  }
+}
+
+type CompleteHdKey = {
+  [key in keyof Engine.HdKey]-?: NonNullable<Engine.HdKey[key]>
+}
+
+/**
+ * Complete portable-node test engine with no dependency on `@scure/bip32`.
+ *
+ * It returns fixed official BIP-32 vector nodes so tests can prove every
+ * operation is routed without reaching the default provider.
+ */
+export const hdKey = {
+  derive: (privateExtendedKey, path, versions) => {
+    if (path === 'm')
+      return materializeHdKey(
+        privateExtendedKey === hdKeyChild.privateExtendedKey
+          ? hdKeyChild
+          : hdKeyRoot,
+        versions,
+      )
+    return materializeHdKey(hdKeyChild, versions)
+  },
+  fromExtendedKey: (_extendedKey, versions) =>
+    materializeHdKey(hdKeyChild, versions),
+  fromSeed: (_seed, versions) => materializeHdKey(hdKeyRoot, versions),
+} satisfies CompleteHdKey
 
 /**
  * An engine whose every slot delegates to the same `@noble/*` implementation ox
@@ -55,28 +131,39 @@ export const identity: Engine.Engine = {
     verify: (signature, payload, publicKey, { dst, signatureGroup }) => {
       const shortSignature = signatureGroup === 'G1'
       const curve = shortSignature ? bls.G1 : bls.G2
-      const payloadPoint = curve.hashToCurve(
-        payload,
-        dst ? { DST: dst } : undefined,
-      )
-      const pairing = shortSignature
-        ? bls.pairingBatch([
+      const pairing = (() => {
+        if (shortSignature) {
+          const signaturePoint = bls.G1.Point.fromBytes(signature)
+          const publicKeyPoint = bls.G2.Point.fromBytes(publicKey)
+          const payloadPoint = curve.hashToCurve(
+            payload,
+            dst ? { DST: dst } : undefined,
+          )
+          return bls.pairingBatch([
             {
               g1: payloadPoint as InstanceType<typeof bls.G1.Point>,
-              g2: bls.G2.Point.fromBytes(publicKey),
+              g2: publicKeyPoint,
             },
             {
-              g1: bls.G1.Point.fromBytes(signature),
+              g1: signaturePoint,
               g2: bls.G2.Point.BASE.negate(),
             },
           ])
-        : bls.pairingBatch([
-            {
-              g1: bls.G1.Point.fromBytes(publicKey).negate(),
-              g2: payloadPoint as InstanceType<typeof bls.G2.Point>,
-            },
-            { g1: bls.G1.Point.BASE, g2: bls.G2.Point.fromBytes(signature) },
-          ])
+        }
+        const signaturePoint = bls.G2.Point.fromBytes(signature)
+        const publicKeyPoint = bls.G1.Point.fromBytes(publicKey)
+        const payloadPoint = curve.hashToCurve(
+          payload,
+          dst ? { DST: dst } : undefined,
+        )
+        return bls.pairingBatch([
+          {
+            g1: publicKeyPoint.negate(),
+            g2: payloadPoint as InstanceType<typeof bls.G2.Point>,
+          },
+          { g1: bls.G1.Point.BASE, g2: signaturePoint },
+        ])
+      })()
       return bls.fields.Fp12.eql(pairing, bls.fields.Fp12.ONE)
     },
   },


### PR DESCRIPTION
Adds public `Hash.blake3`, serialized `Bls` fast paths, and a BIP-32 `HdKey` engine boundary, expanding provider coverage and avoiding redundant conversions while preserving audited defaults and validation behavior.