### PR TITLE
feat: add blake3 hash

### DIFF
--- a/.changeset/public-blake3-hash.md
+++ b/.changeset/public-blake3-hash.md
@@ -1,0 +1,11 @@
+---
+'ox': patch
+---
+
+Added `Hash.blake3` for BLAKE3 hashing through Ox's default or an installed engine implementation.
+
+```ts
+import { Hash } from 'ox'
+
+const digest = Hash.blake3('0xdeadbeef')
+```

--- a/site/src/snippets/hash.mdx
+++ b/site/src/snippets/hash.mdx
@@ -4,6 +4,9 @@ import { Bytes, Hash, Hex } from 'ox'
 
 const message = Hex.fromString('hello world')
 
+Hash.blake3(message)
+// @log: '0xd74981efa70a0c880b8d8c1985d075dbcbf679b99a5f9914e5aaf96b831a9e24'
+
 Hash.keccak256(message)
 // @log: '0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad'
 

--- a/src/core/Hash.ts
+++ b/src/core/Hash.ts
@@ -4,6 +4,65 @@ import * as Hex from './Hex.js'
 import * as engine from './internal/hash.js'
 
 /**
+ * Calculates the [BLAKE3](https://github.com/BLAKE3-team/BLAKE3) hash of a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
+ *
+ * Backed by `blake3` from [`@noble/hashes`](https://github.com/paulmillr/noble-hashes), an audited & minimal JS hashing library, unless another implementation is installed with {@link ox#Engine.set}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Hash } from 'ox'
+ *
+ * Hash.blake3('0xdeadbeef')
+ * // @log: '0x53147f3ce49ed4f60dfa5b9654c36ba6103c11f5737df3dabd4cbd296c4161bd'
+ * ```
+ *
+ * @example
+ * ### Configure Return Type
+ *
+ * ```ts twoslash
+ * import { Hash } from 'ox'
+ *
+ * Hash.blake3('0xdeadbeef', { as: 'Bytes' })
+ * // @log: Uint8Array [...]
+ * ```
+ *
+ * @param value - {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
+ * @param options - Options.
+ * @returns BLAKE3 hash.
+ */
+export function blake3<
+  value extends Hex.Hex | Bytes.Bytes,
+  as extends 'Hex' | 'Bytes' =
+    | (value extends Hex.Hex ? 'Hex' : never)
+    | (value extends Bytes.Bytes ? 'Bytes' : never),
+>(
+  value: value | Hex.Hex | Bytes.Bytes,
+  options: blake3.Options<as> = {},
+): blake3.ReturnType<as> {
+  const isBytes = value instanceof Uint8Array
+  const { as = isBytes ? 'Bytes' : 'Hex' } = options
+  const bytes = engine.blake3(isBytes ? value : Bytes.from(value))
+  if (as === 'Bytes') return bytes as never
+  return Hex.fromBytes(bytes) as never
+}
+
+export declare namespace blake3 {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> = {
+    /** The return type. Defaults to the input format. */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes' = 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Calculates the [Keccak256](https://en.wikipedia.org/wiki/SHA-3) hash of a {@link ox#Bytes.Bytes} or {@link ox#Hex.Hex} value.
  *
  * Backed by `keccak_256` from [`@noble/hashes`](https://github.com/paulmillr/noble-hashes), an audited & minimal JS hashing library, unless another implementation is installed with {@link ox#Engine.set}.

--- a/src/core/_test/Hash.test-d.ts
+++ b/src/core/_test/Hash.test-d.ts
@@ -1,0 +1,18 @@
+import { type Bytes, Hash, type Hex } from 'ox'
+import { describe, expectTypeOf, test } from 'vp/test'
+
+describe('blake3', () => {
+  test('default', () => {
+    expectTypeOf(Hash.blake3('0x')).toEqualTypeOf<Hex.Hex>()
+    expectTypeOf(Hash.blake3(new Uint8Array())).toEqualTypeOf<Bytes.Bytes>()
+  })
+
+  test('as', () => {
+    expectTypeOf(
+      Hash.blake3('0x', { as: 'Bytes' }),
+    ).toEqualTypeOf<Bytes.Bytes>()
+    expectTypeOf(
+      Hash.blake3(new Uint8Array(), { as: 'Hex' }),
+    ).toEqualTypeOf<Hex.Hex>()
+  })
+})

--- a/src/core/_test/Hash.test.ts
+++ b/src/core/_test/Hash.test.ts
@@ -1,5 +1,103 @@
-import { Hash } from 'ox'
+import { Engine, Hash } from 'ox'
 import { describe, expect, test } from 'vp/test'
+
+describe('blake3', () => {
+  test('default', () => {
+    expect(Hash.blake3('0x')).toMatchInlineSnapshot(
+      `"0xaf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"`,
+    )
+
+    expect(Hash.blake3(new Uint8Array())).toMatchInlineSnapshot(`
+      Uint8Array [
+        175,
+        19,
+        73,
+        185,
+        245,
+        249,
+        161,
+        166,
+        160,
+        64,
+        77,
+        234,
+        54,
+        220,
+        201,
+        73,
+        155,
+        203,
+        37,
+        201,
+        173,
+        193,
+        18,
+        183,
+        204,
+        154,
+        147,
+        202,
+        228,
+        31,
+        50,
+        98,
+      ]
+    `)
+  })
+
+  test('as: Hex', () => {
+    expect(Hash.blake3(new Uint8Array(), { as: 'Hex' })).toMatchInlineSnapshot(
+      `"0xaf1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"`,
+    )
+  })
+
+  test('as: Bytes', () => {
+    expect(Hash.blake3('0x', { as: 'Bytes' })).toMatchInlineSnapshot(`
+      Uint8Array [
+        175,
+        19,
+        73,
+        185,
+        245,
+        249,
+        161,
+        166,
+        160,
+        64,
+        77,
+        234,
+        54,
+        220,
+        201,
+        73,
+        155,
+        203,
+        37,
+        201,
+        173,
+        193,
+        18,
+        183,
+        204,
+        154,
+        147,
+        202,
+        228,
+        31,
+        50,
+        98,
+      ]
+    `)
+  })
+
+  test('behavior: routes through the installed engine', () => {
+    Engine.set({ Hash: { blake3: () => new Uint8Array(32).fill(1) } })
+
+    expect(Hash.blake3('0x')).toMatchInlineSnapshot(
+      `"0x0101010101010101010101010101010101010101010101010101010101010101"`,
+    )
+  })
+})
 
 describe('hmac256', () => {
   test('default', () => {
@@ -530,6 +628,7 @@ describe('validate', () => {
 test('exports', () => {
   expect(Object.keys(Hash)).toMatchInlineSnapshot(`
     [
+      "blake3",
       "keccak256",
       "hmac256",
       "ripemd160",

--- a/src/core/_test/Hash.vectors.test.ts
+++ b/src/core/_test/Hash.vectors.test.ts
@@ -1,7 +1,6 @@
 import { Hash } from 'ox'
 import { describe, expect, test } from 'vp/test'
 import * as vectors from '../../../test/vectors/hashes/index.js'
-import * as hash from '../internal/hash.js'
 
 /**
  * Published vectors against ox's default (`@noble/hashes`) implementations.
@@ -15,7 +14,7 @@ import * as hash from '../internal/hash.js'
 describe('blake3', () => {
   test(`matches ${vectors.blake3.length} official BLAKE3 vectors`, () => {
     for (const { digest, message } of vectors.blake3)
-      expect(hash.blake3(message)).toEqual(digest)
+      expect(Hash.blake3(message, { as: 'Bytes' })).toEqual(digest)
   })
 })
 

--- a/src/node/Hash.ts
+++ b/src/node/Hash.ts
@@ -12,9 +12,9 @@ export * from '../core/Hash.js'
  * which installs every implementation this entrypoint provides. Reach for this
  * to install or hold the `Hash` slot on its own.
  *
- * Node's `sha3-256` is not Ethereum Keccak256, so this engine deliberately
- * omits `keccak256`. Any earlier override remains installed; otherwise Ox uses
- * its default implementation.
+ * Node does not provide BLAKE3, and its `sha3-256` is not Ethereum Keccak256, so
+ * this engine deliberately omits `blake3` and `keccak256`. Any earlier override
+ * remains installed; otherwise Ox uses its default implementation.
  *
  * @example
  * ```ts twoslash

--- a/src/node/_test/Hash.test-d.ts
+++ b/src/node/_test/Hash.test-d.ts
@@ -27,6 +27,7 @@ test('the result is the raw slot, so `Engine.install` accepts it', () => {
 })
 
 test('the Node namespace exposes the public Hash API', () => {
+  expectTypeOf(NodeHash.blake3).toEqualTypeOf(CoreHash.blake3)
   expectTypeOf(NodeHash.sha256).toEqualTypeOf(CoreHash.sha256)
   expectTypeOf<typeof NodeHash>().not.toHaveProperty('create')
 })

--- a/src/wasm/_test/Hash.browser.test.ts
+++ b/src/wasm/_test/Hash.browser.test.ts
@@ -44,6 +44,9 @@ describe('engine', () => {
   test('behavior: ox uses the WASM implementation once installed', async () => {
     await Engine.install({ Hash: WasmHash.engine() })
     try {
+      expect(Hash.blake3('0xdeadbeef')).toBe(
+        '0x53147f3ce49ed4f60dfa5b9654c36ba6103c11f5737df3dabd4cbd296c4161bd',
+      )
       expect(Hash.keccak256('0xdeadbeef')).toBe(
         '0xd4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1',
       )

--- a/src/wasm/_test/Hash.test-d.ts
+++ b/src/wasm/_test/Hash.test-d.ts
@@ -28,6 +28,7 @@ test('the result is the raw slot, so `Engine.install` accepts it', () => {
 })
 
 test('the WASM namespace exposes the public Hash API', () => {
+  expectTypeOf(WasmHash.blake3).toEqualTypeOf(CoreHash.blake3)
   expectTypeOf(WasmHash.sha256).toEqualTypeOf(CoreHash.sha256)
   expectTypeOf<typeof WasmHash>().not.toHaveProperty('create')
 })

--- a/src/wasm/_test/Hash.test.ts
+++ b/src/wasm/_test/Hash.test.ts
@@ -292,8 +292,8 @@ describe('Engine.install', () => {
   test('behavior: ox uses the WASM implementation once installed', async () => {
     await Engine.install({ Hash: engine })
     try {
-      expect(Engine.get().Hash?.blake3?.(Bytes.from('0xdeadbeef'))).toEqual(
-        blake3(Bytes.from('0xdeadbeef')),
+      expect(Hash.blake3('0xdeadbeef')).toBe(
+        '0x53147f3ce49ed4f60dfa5b9654c36ba6103c11f5737df3dabd4cbd296c4161bd',
       )
       expect(Hash.keccak256('0xdeadbeef')).toBe(
         '0xd4fd4e189132273036449fc9e11198c739161b4c0116a9a2dccdfa1c492006f1',


### PR DESCRIPTION
Adds public `Hash.blake3` support with input-format inference, Engine routing, documentation, and coverage. This exposes the BLAKE3 implementation already available through core and WASM Engine providers.