### PR TITLE
fix: TS2742 when consumers export inferred values

### DIFF
--- a/.changeset/lucky-otters-remember.md
+++ b/.changeset/lucky-otters-remember.md
@@ -1,0 +1,12 @@
+---
+"ox": patch
+---
+
+Added an `ox/_types/*` subpath so consumers can emit declarations for inferred values whose types reach internal modules, fixing `TS2742`.
+
+```ts
+// previously failed to emit a `.d.ts` without an explicit type annotation:
+// `UserOperation` is a `OneOf<...>` instantiation, and `OneOf` had no
+// addressable module.
+export const userOperation = UserOperation.from({ ... })
+```

--- a/.changeset/lucky-otters-remember.md
+++ b/.changeset/lucky-otters-remember.md
@@ -2,11 +2,4 @@
 "ox": patch
 ---
 
-Added an `ox/_types/*` subpath so consumers can emit declarations for inferred values whose types reach internal modules, fixing `TS2742`.
-
-```ts
-// previously failed to emit a `.d.ts` without an explicit type annotation:
-// `UserOperation` is a `OneOf<...>` instantiation, and `OneOf` had no
-// addressable module.
-export const userOperation = UserOperation.from({ ... })
-```
+Added an `ox/_types/*` subpath.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "pnpm exports:update && zile",
+    "build": "pnpm exports:update && zile && pnpm exports:internal-types",
     "changeset:publish": "zile publish:prepare && changeset publish && zile publish:post",
     "changeset:version": "changeset version && pnpm version:update && pnpm check",
     "check": "vp check --fix",
@@ -17,6 +17,7 @@
     "docs:gen": "pnpm build && pnpm docs:extract",
     "docs:build": "pnpm docs:gen && pnpm --filter site build",
     "exports:update": "node --import tsx ./scripts/exports:update.ts",
+    "exports:internal-types": "node --import tsx ./scripts/exports:internal-types.ts",
     "knip": "knip --production",
     "postinstall": "git submodule update --init --recursive && pnpm contracts:build && pnpm dev",
     "preinstall": "pnpx only-allow pnpm",
@@ -1169,12 +1170,19 @@
       "src": "./src/zod/tempo/z.ts",
       "types": "./dist/zod/tempo/z.d.ts",
       "default": "./dist/zod/tempo/z.js"
+    },
+    "./_types/*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     }
   },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
+      "_types/*": [
+        "./dist/*.d.ts"
+      ],
       "*": [
         "./dist/*",
         "./dist/*/index.d.ts",

--- a/scripts/exports:internal-types.ts
+++ b/scripts/exports:internal-types.ts
@@ -1,0 +1,43 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+
+// Adds the `./_types/*` subpath to `package.json#exports` (+ `typesVersions`).
+//
+// This makes every built module addressable so TypeScript can name internal types while
+// a consumer emits its own declarations. Without a public specifier for these files,
+// exporting an inferred value whose type reaches a module-internal symbol fails with
+// `TS2742` (`TS2883` on TypeScript 7). The concrete case: `erc4337/UserOperation` is a
+// `OneOf<...>` instantiation, and the emitter preserves the alias reference, so it must
+// name `OneOf` from `core/internal/types` — which no public specifier reaches.
+//
+// `./_types/*` is not public API and is excluded from semver. Import from the documented
+// entrypoints; this exists only so the compiler has a name to write down.
+//
+// Runs after `zile` rather than inside `exports:update`, because zile requires a `src`
+// field on every export entry and expands it as a glob to decide what to build; a
+// `./src/*.ts` glob would pull test files into the package build.
+
+const packageJsonPath = join(import.meta.dirname, '../package.json')
+
+const key = './_types/*'
+const types = './dist/*.d.ts'
+
+const packageJson = fs.readJsonSync(packageJsonPath)
+
+packageJson.exports = {
+  ...Object.fromEntries(
+    Object.entries(packageJson.exports).filter(([k]) => k !== key),
+  ),
+  [key]: { types, default: './dist/*.js' },
+}
+
+packageJson.typesVersions = {
+  '*': {
+    [key.replace(/^\.\//, '')]: [types],
+    ...packageJson.typesVersions?.['*'],
+  },
+}
+
+fs.writeJsonSync(packageJsonPath, packageJson, { spaces: 2 })
+
+console.log(`Added ${key} export.`)


### PR DESCRIPTION
Adds an `ox/_types/*` subpath (post-`zile` step, since `zile` requires and globs a `src` field per export entry), so TypeScript can name internal modules during a consumer's declaration emit.

Public types such as `erc4337/UserOperation` are `OneOf<...>` instantiations; the emitter preserves the alias reference and must name `OneOf` from `core/internal/types`, which no public specifier reaches, failing consumer declaration emit with `TS2742`/`TS2883`. Unblocks the remaining baselined failures in https://github.com/wevm/viem/pull/4936.
