### PR TITLE
fix: published package missing ox/_types subpath

### DIFF
--- a/.changeset/violet-camels-shout.md
+++ b/.changeset/violet-camels-shout.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed the published package missing the `ox/_types/*` subpath: `zile publish:prepare` rebuilds `exports` and dropped the entry added in v1.3.0, so it now gets re-applied before publishing.

--- a/.changeset/violet-camels-shout.md
+++ b/.changeset/violet-camels-shout.md
@@ -2,4 +2,4 @@
 "ox": patch
 ---
 
-Fixed the published package missing the `ox/_types/*` subpath: `zile publish:prepare` rebuilds `exports` and dropped the entry added in v1.3.0, so it now gets re-applied before publishing.
+Fixed the published package missing the `ox/_types/*` subpath: `postinstall` regenerates `exports` without it, and `zile publish:prepare` strips the `scripts` needed to re-apply it, so publishing now re-applies it directly before `changeset publish`.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Prerelease
         run: |
+          pnpm exports:update
           pnpm exec zile publish:prepare
-          pnpm exports:internal-types
+          node --import tsx ./scripts/exports:internal-types.ts
           pnpx pkg-pr-new publish --pnpm

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,4 +17,5 @@ jobs:
       - name: Prerelease
         run: |
           pnpm exec zile publish:prepare
+          pnpm exports:internal-types
           pnpx pkg-pr-new publish --pnpm

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -30,7 +30,8 @@ jobs:
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           pnpm clean
           pnpm changeset version --no-git-tag --snapshot $snapshot
+          pnpm exports:update
           pnpm exec zile publish:prepare
-          pnpm exports:internal-types
+          node --import tsx ./scripts/exports:internal-types.ts
           pnpm changeset publish --no-git-tag --snapshot $snapshot --tag $snapshot
           pnpm exec zile publish:post

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -31,5 +31,6 @@ jobs:
           pnpm clean
           pnpm changeset version --no-git-tag --snapshot $snapshot
           pnpm exec zile publish:prepare
+          pnpm exports:internal-types
           pnpm changeset publish --no-git-tag --snapshot $snapshot --tag $snapshot
           pnpm exec zile publish:post

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm exports:update && zile && pnpm exports:internal-types",
-    "changeset:publish": "zile publish:prepare && pnpm exports:internal-types && changeset publish && zile publish:post",
+    "changeset:publish": "pnpm exports:update && zile publish:prepare && node --import tsx ./scripts/exports:internal-types.ts && changeset publish && zile publish:post",
     "changeset:version": "changeset version && pnpm version:update && pnpm check",
     "check": "vp check --fix",
     "check:examples": "zile examples:check --fix",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm exports:update && zile && pnpm exports:internal-types",
-    "changeset:publish": "zile publish:prepare && changeset publish && zile publish:post",
+    "changeset:publish": "zile publish:prepare && pnpm exports:internal-types && changeset publish && zile publish:post",
     "changeset:version": "changeset version && pnpm version:update && pnpm check",
     "check": "vp check --fix",
     "check:examples": "zile examples:check --fix",


### PR DESCRIPTION
Re-applies the `ox/_types/*` subpath before `changeset publish` in all three publish paths, invoking the script file directly with `node --import tsx`.

Two interacting causes shipped v1.3.0 without the subpath and broke the first version of this fix: `postinstall` runs `pnpm dev`, whose `exports:update` regenerates `exports` without the entry (so `zile publish:prepare` saw a clean manifest and succeeded), and `publish:prepare` strips `scripts` from the manifest, so a `pnpm exports:internal-types` invocation afterwards fails with "command not found". `pnpm exports:update` now also runs before `publish:prepare`, since `zile`'s build rejects the src-less entry a committed manifest carries.

Unblocks the `ox` bump in https://github.com/wevm/viem/pull/4936, which needs `ox/_types/core/internal/types` resolvable from the published package.
