### PR TITLE
feat: add tagged PRF configurations

### DIFF
--- a/.changeset/fresh-tools-tag.md
+++ b/.changeset/fresh-tools-tag.md
@@ -1,0 +1,5 @@
+---
+'ox': minor
+---
+
+Added `Prf.tag` to create credential-bound PRF configurations from stable UTF-8 tags.

--- a/package.json
+++ b/package.json
@@ -463,6 +463,11 @@
       "types": "./dist/core/PersonalMessage.d.ts",
       "default": "./dist/core/PersonalMessage.js"
     },
+    "./Prf": {
+      "src": "./src/core/Prf.ts",
+      "types": "./dist/core/Prf.d.ts",
+      "default": "./dist/core/Prf.js"
+    },
     "./Provider": {
       "src": "./src/core/Provider.ts",
       "types": "./dist/core/Provider.d.ts",

--- a/scripts/docgen/build.ts
+++ b/scripts/docgen/build.ts
@@ -171,6 +171,7 @@ function renderNamespaces(options: {
   for (const namespace of namespaces) {
     const name = namespace.displayName.replace(/_\d+$/, '')
     const docComment = docComments[name]
+    if (docComment?.deprecated) continue
     const basePath = docComment ? getPath(docComment) : '/'
     const baseLink = `${basePath}/${name}`
     const dir = `${pagesDir}${baseLink}`

--- a/src/core/Prf.ts
+++ b/src/core/Prf.ts
@@ -1,0 +1,35 @@
+import * as Bytes from './Bytes.js'
+import type * as Errors from './Errors.js'
+
+/**
+ * Creates a credential-bound PRF configuration from a UTF-8 tag.
+ *
+ * Tags are public, stable identifiers. Use the same tag with the same
+ * credential to reproduce a PRF output.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Prf, WebAuthn } from 'ox'
+ *
+ * const credential = await WebAuthn.getCredential({
+ *   credentialId: 'oZ48...',
+ *   prf: Prf.tag('account.1')
+ * })
+ * ```
+ *
+ * @param value - Tag to encode.
+ * @returns A credential-bound PRF configuration.
+ */
+export function tag(value: string): tag.ReturnType {
+  return { input: Bytes.fromString(value) }
+}
+
+export declare namespace tag {
+  /** Credential-bound PRF configuration. */
+  type ReturnType = {
+    /** UTF-8 encoded PRF input. */
+    input: Bytes.Bytes
+  }
+
+  type ErrorType = Bytes.fromString.ErrorType | Errors.GlobalErrorType
+}

--- a/src/core/_test/Prf.test-d.ts
+++ b/src/core/_test/Prf.test-d.ts
@@ -1,0 +1,9 @@
+import { expectTypeOf, test } from 'vp/test'
+import type * as Bytes from '../Bytes.js'
+import { Prf } from 'ox'
+
+test('tag', () => {
+  expectTypeOf(Prf.tag('account.1')).toEqualTypeOf<{
+    input: Bytes.Bytes
+  }>()
+})

--- a/src/core/_test/Prf.test.ts
+++ b/src/core/_test/Prf.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vp/test'
+import * as Prf from '../Prf.js'
+
+describe('tag', () => {
+  test('default', () => {
+    expect(Prf.tag('account.1')).toMatchInlineSnapshot(`
+      {
+        "input": Uint8Array [
+          97,
+          99,
+          99,
+          111,
+          117,
+          110,
+          116,
+          46,
+          49,
+        ],
+      }
+    `)
+  })
+
+  test('behavior: UTF-8', () => {
+    expect(Prf.tag('account.🔑')).toMatchInlineSnapshot(`
+      {
+        "input": Uint8Array [
+          97,
+          99,
+          99,
+          111,
+          117,
+          110,
+          116,
+          46,
+          240,
+          159,
+          148,
+          145,
+        ],
+      }
+    `)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -2084,6 +2084,22 @@ export * as P256 from './core/P256.js'
  */
 export * as PersonalMessage from './core/PersonalMessage.js'
 /**
+ * Utilities for constructing credential-bound PRF configurations.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Prf, WebAuthn } from 'ox'
+ *
+ * const credential = await WebAuthn.getCredential({
+ *   credentialId: 'oZ48...',
+ *   prf: Prf.tag('account.1')
+ * })
+ * ```
+ *
+ * @category Crypto
+ */
+export * as Prf from './core/Prf.js'
+/**
  * Utilities & types for working with [EIP-1193 Providers](https://eips.ethereum.org/EIPS/eip-1193)
  *
  * @example


### PR DESCRIPTION
Adds `Prf.tag` for stable UTF-8 WebAuthn PRF inputs and omits deprecated modules from generated API documentation, keeping compatibility exports such as `WebAuthnP256` out of navigation.