### PR TITLE
test: update root export snapshot

### DIFF
--- a/src/core/_test/index.test.ts
+++ b/src/core/_test/index.test.ts
@@ -51,6 +51,7 @@ test('exports', () => {
       "Mnemonic",
       "P256",
       "PersonalMessage",
+      "Prf",
       "Provider",
       "PublicKey",
       "Rlp",


### PR DESCRIPTION
Adds `Prf` to the root export snapshot, matching the namespace introduced by https://github.com/wevm/ox/pull/345 and restoring the core runtime test on `main`.
