### PR TITLE
feat(tempo): add WithdrawalSenderTag

### DIFF
--- a/.changeset/clean-zones-withdraw.md
+++ b/.changeset/clean-zones-withdraw.md
@@ -1,0 +1,5 @@
+---
+'ox': minor
+---
+
+Added `WithdrawalSenderTag` utilities for deriving Tempo Zone withdrawal sender tags.

--- a/package.json
+++ b/package.json
@@ -823,6 +823,11 @@
       "types": "./dist/tempo/VirtualMaster.d.ts",
       "default": "./dist/tempo/VirtualMaster.js"
     },
+    "./tempo/WithdrawalSenderTag": {
+      "src": "./src/tempo/WithdrawalSenderTag.ts",
+      "types": "./dist/tempo/WithdrawalSenderTag.d.ts",
+      "default": "./dist/tempo/WithdrawalSenderTag.js"
+    },
     "./tempo/ZoneId": {
       "src": "./src/tempo/ZoneId.ts",
       "types": "./dist/tempo/ZoneId.d.ts",

--- a/src/tempo/WithdrawalSenderTag.test-d.ts
+++ b/src/tempo/WithdrawalSenderTag.test-d.ts
@@ -1,0 +1,13 @@
+import type { Hex } from 'ox'
+import { WithdrawalSenderTag } from 'ox/tempo'
+import { expectTypeOf, test } from 'vp/test'
+
+test('from', () => {
+  expectTypeOf(
+    WithdrawalSenderTag.from({
+      sender: '0x1234567890abcdef1234567890abcdef12345678',
+      transactionHash:
+        '0xabababababababababababababababababababababababababababababababab',
+    }),
+  ).toEqualTypeOf<Hex.Hex>()
+})

--- a/src/tempo/WithdrawalSenderTag.test.ts
+++ b/src/tempo/WithdrawalSenderTag.test.ts
@@ -1,0 +1,22 @@
+import { WithdrawalSenderTag } from 'ox/tempo'
+import { expect, test } from 'vp/test'
+
+test('from', () => {
+  const senderTag = WithdrawalSenderTag.from({
+    sender: '0x1234567890abcdef1234567890abcdef12345678',
+    transactionHash:
+      '0xabababababababababababababababababababababababababababababababab',
+  })
+  expect(senderTag).toMatchInlineSnapshot(
+    `"0x3362fade7333b56b9f3582089ec5915b8a6f6ac13e73a7f90c169e3eb81d8a5e"`,
+  )
+})
+
+test('deterministic', () => {
+  const value = {
+    sender: '0x1234567890abcdef1234567890abcdef12345678',
+    transactionHash:
+      '0xabababababababababababababababababababababababababababababababab',
+  } as const
+  expect(WithdrawalSenderTag.from(value)).toBe(WithdrawalSenderTag.from(value))
+})

--- a/src/tempo/WithdrawalSenderTag.ts
+++ b/src/tempo/WithdrawalSenderTag.ts
@@ -1,0 +1,47 @@
+import * as AbiParameters from '../core/AbiParameters.js'
+import * as Address from '../core/Address.js'
+import * as Hash from '../core/Hash.js'
+import * as Hex from '../core/Hex.js'
+
+/**
+ * Derives the sender tag that identifies the indexed parent-chain
+ * `WithdrawalProcessed` event for a Zone withdrawal.
+ *
+ * The `transactionHash` is the Zone transaction containing the
+ * `ZoneOutbox.requestWithdrawal` call. The protocol defines the sender tag as
+ * `keccak256(abi.encodePacked(sender, transactionHash))`.
+ *
+ * [Authenticated Withdrawals Specification](https://github.com/tempoxyz/zones/blob/main/specs/spec.md#authenticated-withdrawals)
+ *
+ * @example
+ * ```ts twoslash
+ * import { WithdrawalSenderTag } from 'ox/tempo'
+ *
+ * const senderTag = WithdrawalSenderTag.from({
+ *   sender: '0x1234567890abcdef1234567890abcdef12345678',
+ *   transactionHash:
+ *     '0xabababababababababababababababababababababababababababababababab'
+ * })
+ * ```
+ *
+ * @param value - Withdrawal sender and Zone transaction hash.
+ * @returns The sender tag.
+ */
+export function from(value: from.Value): Hex.Hex {
+  const { sender, transactionHash } = value
+  return Hash.keccak256(
+    AbiParameters.encodePacked(
+      ['address', 'bytes32'],
+      [sender, transactionHash],
+    ),
+  )
+}
+
+export declare namespace from {
+  export type Value = {
+    /** Address that requested the withdrawal. */
+    sender: Address.Address
+    /** Hash of the Zone transaction containing `ZoneOutbox.requestWithdrawal`. */
+    transactionHash: Hex.Hex
+  }
+}

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -530,6 +530,30 @@ export * as VirtualAddress from './VirtualAddress.js'
 export * as VirtualMaster from './VirtualMaster.js'
 
 /**
+ * Utilities for deriving the sender tag that correlates a Zone withdrawal with
+ * its indexed parent-chain `WithdrawalProcessed` event.
+ *
+ * The sender tag commits to the withdrawal sender and the Zone transaction hash
+ * containing the `ZoneOutbox.requestWithdrawal` call.
+ *
+ * [Authenticated Withdrawals Specification](https://github.com/tempoxyz/zones/blob/main/specs/spec.md#authenticated-withdrawals)
+ *
+ * @example
+ * ```ts twoslash
+ * import { WithdrawalSenderTag } from 'ox/tempo'
+ *
+ * const senderTag = WithdrawalSenderTag.from({
+ *   sender: '0x1234567890abcdef1234567890abcdef12345678',
+ *   transactionHash:
+ *     '0xabababababababababababababababababababababababababababababababab'
+ * })
+ * ```
+ *
+ * @category Reference
+ */
+export * as WithdrawalSenderTag from './WithdrawalSenderTag.js'
+
+/**
  * Zone ID utilities for converting between zone IDs and zone chain IDs.
  *
  * Zone chain IDs use the base and range assigned to their Tempo source chain.


### PR DESCRIPTION
## Summary

Adds a public `WithdrawalSenderTag` Tempo utility for deriving the sender tag that correlates Zone withdrawals with parent-chain `WithdrawalProcessed` events.

## Motivation

Consumers need to derive this protocol value without depending on Viem’s synchronous withdrawal submission action.

## Changes

- Added `WithdrawalSenderTag.from` using Ox ABI packing and Keccak primitives.
- Exported both `ox/tempo` and `ox/tempo/WithdrawalSenderTag` entrypoints.
- Added runtime and type coverage for the protocol vector and determinism.
- Added a minor changeset for the new public API.

## Testing

- `pnpm exports:update`
- `pnpm test --project tempo-unit --bail=1 src/tempo/WithdrawalSenderTag.test.ts`
- `pnpm check`
- `pnpm check:types`
- `pnpm build`
- `pnpm docs:gen`

## Compatibility

This preview targets Ox 1.x. Viem 2.55.x currently depends on Ox 0.14.x, so downstream testing requires an intentional Ox upgrade.