### PR TITLE
feat(wasm): install secp256k1 and mldsa by default

### DIFF
--- a/.changeset/mldsa44-support.md
+++ b/.changeset/mldsa44-support.md
@@ -2,4 +2,4 @@
 'ox': minor
 ---
 
-Added `MlDsa44` module for ML-DSA-44 (FIPS 204) post-quantum signatures, backed by `@noble/post-quantum` by default, plus an opt-in `ox/wasm/MlDsa44` engine compiled from [mldsa-native](https://github.com/pq-code-package/mldsa-native).
+Added `MlDsa44` for ML-DSA-44 signatures and included its WASM provider with `Secp256k1` in `ox/wasm`'s aggregate engine.

--- a/scripts/bench:engines.ts
+++ b/scripts/bench:engines.ts
@@ -31,8 +31,6 @@ import * as x25519 from '../src/core/internal/x25519.js'
 import { engine as nodeEngine } from '../src/node/Engine.js'
 import { engine as wasmEngine } from '../src/wasm/Engine.js'
 import { engine as wasmKeystoreEngine } from '../src/wasm/Keystore.js'
-import { engine as wasmMlDsa44Engine } from '../src/wasm/MlDsa44.js'
-import { engine as wasmSecp256k1Engine } from '../src/wasm/Secp256k1.js'
 import { type Target, targets as wasmTargets } from '../wasm/targets.js'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -649,18 +647,13 @@ for (const [slot, primitives] of Object.entries(engineContract.primitives))
       throw new Error(`Missing benchmark for ${slot}.${primitive}`)
 
 const node = await nodeEngine()
-const [wasmAggregate, wasmKeystore, wasmMlDsa44, wasmSecp256k1] =
-  await Promise.all([
-    wasmEngine(),
-    wasmKeystoreEngine(),
-    wasmMlDsa44Engine(),
-    wasmSecp256k1Engine(),
-  ])
+const [wasmAggregate, wasmKeystore] = await Promise.all([
+  wasmEngine(),
+  wasmKeystoreEngine(),
+])
 const wasm = {
   ...wasmAggregate,
   Keystore: wasmKeystore,
-  MlDsa44: wasmMlDsa44,
-  Secp256k1: wasmSecp256k1,
 }
 const cRows = c()
 for (const benchmark of benchmarks) {

--- a/site/src/pages/guides/engine.md
+++ b/site/src/pages/guides/engine.md
@@ -74,7 +74,10 @@ It supplies the following partial slots:
 
 - `Hash`: BLAKE3, HMAC-SHA256, Keccak256, RIPEMD-160, and SHA-256.
 - `Keystore`: synchronous PBKDF2-HMAC-SHA256.
+- `MlDsa44`: public-key derivation, signing, and verification.
 - `Mnemonic`: BIP-39 seed derivation.
+- `Secp256k1`: public-key derivation, shared-secret calculation, recovery,
+  signing, and verification.
 - `Ed25519`: public-key derivation, signing, verification, and private-key
   conversion to X25519.
 - `X25519`: public-key derivation and shared-secret calculation.
@@ -83,18 +86,7 @@ Other operations keep their current implementation, or use Ox's default when
 no earlier override exists. In particular, asynchronous KDFs remain on the
 default because wrapping synchronous WASM in a promise would not make it yield.
 
-An opt-in `Secp256k1` provider supplies public-key derivation, shared-secret
-calculation, recovery, signing, and verification. Random key generation remains
-host-backed. Its 44.7 kB gzip artifact is excluded from the aggregate engine:
-
-```ts twoslash
-import { Engine } from 'ox'
-import { Secp256k1 } from 'ox/wasm'
-
-await Engine.install({
-  Secp256k1: Secp256k1.engine(),
-})
-```
+Random key generation for `MlDsa44` and `Secp256k1` remains host-backed.
 
 The dedicated `ox/wasm/Keystore` provider also supplies synchronous scrypt.
 Install that provider explicitly. The aggregate engine excludes scrypt because
@@ -125,8 +117,8 @@ resolved modules atomically. `Hash.engine()` returns the raw `Hash` slot;
 **Benefits**
 
 - Runs in browsers, Node.js, and other runtimes with WebAssembly.
-- Accelerates hashes, key derivation, Ed25519, X25519, and opt-in Secp256k1 on
-  common runtimes.
+- Accelerates hashes, key derivation, Ed25519, ML-DSA-44, Secp256k1, and X25519
+  on common runtimes.
 - Keeps cryptographic calls synchronous after one asynchronous startup step.
 - Embeds the compiled module, with no separate WASM asset to host.
 - Clears copied secret inputs, staged outputs, and explicit workspaces after
@@ -317,18 +309,19 @@ engine. The columns count the primitives each provider or reference supplies:
 | `Ed25519`   | 6          | 6      | 3         | 4         | 4      |
 | `Hash`      | 5          | 5      | 3         | 5         | 5      |
 | `Keystore`  | 6          | 6      | 4         | 2         | 2      |
+| `MlDsa44`   | 4          | 4      | n/a       | 3         | 3      |
 | `Mnemonic`  | 1          | 1      | 1         | 1         | 1      |
 | `P256`      | 6          | 6      | 1         | n/a       | n/a    |
 | `Secp256k1` | 6          | 6      | n/a       | 5         | 5      |
 | `X25519`    | 3          | 3      | 2         | 2         | 2      |
-| **Total**   | **38**     | **38** | **14**    | **19**    | **19** |
+| **Total**   | **42**     | **42** | **14**    | **22**    | **22** |
 
 `n/a` means the provider does not implement a primitive in that slot. The
 harness never times Ox's fallback under another engine's name.
 The C reference compiles the same primitive wrappers, vendored sources, and
 target configuration as `ox/wasm` for the host. C covers every primitive
 supplied by WASM, but is not an Ox engine. The `ox/wasm` count includes the
-opt-in Keystore and Secp256k1 providers.
+opt-in Keystore scrypt provider.
 
 Local runs on an Apple M4 Max with Node.js 25.9.0 and Apple Clang 21.0.0 used
 50 ms warmups, 200 ms measurement budgets, and three repeats. The following

--- a/src/wasm/Engine.ts
+++ b/src/wasm/Engine.ts
@@ -3,7 +3,9 @@ import type * as Errors from '../core/Errors.js'
 import * as Ed25519 from './Ed25519.js'
 import * as Hash from './Hash.js'
 import * as keystore from './internal/keystore.js'
+import * as MlDsa44 from './MlDsa44.js'
 import * as Mnemonic from './Mnemonic.js'
+import * as Secp256k1 from './Secp256k1.js'
 import * as X25519 from './X25519.js'
 import type * as internal from './internal/instantiate.js'
 
@@ -57,7 +59,9 @@ export async function install(): Promise<install.ReturnType> {
     Ed25519: Ed25519.engine(),
     Hash: Hash.engine(),
     Keystore: keystore.engine(),
+    MlDsa44: MlDsa44.engine(),
     Mnemonic: Mnemonic.engine(),
+    Secp256k1: Secp256k1.engine(),
     X25519: X25519.engine(),
   })
 }
@@ -93,18 +97,23 @@ export declare namespace install {
  * @returns An engine, ready to install.
  */
 export async function engine(): Promise<engine.ReturnType> {
-  const [ed25519, hash, keystoreEngine, mnemonic, x25519] = await Promise.all([
-    Ed25519.engine(),
-    Hash.engine(),
-    keystore.engine(),
-    Mnemonic.engine(),
-    X25519.engine(),
-  ])
+  const [ed25519, hash, keystoreEngine, mlDsa44, mnemonic, secp256k1, x25519] =
+    await Promise.all([
+      Ed25519.engine(),
+      Hash.engine(),
+      keystore.engine(),
+      MlDsa44.engine(),
+      Mnemonic.engine(),
+      Secp256k1.engine(),
+      X25519.engine(),
+    ])
   return {
     Ed25519: ed25519,
     Hash: hash,
     Keystore: keystoreEngine,
+    MlDsa44: mlDsa44,
     Mnemonic: mnemonic,
+    Secp256k1: secp256k1,
     X25519: x25519,
   }
 }
@@ -117,7 +126,9 @@ export declare namespace engine {
     Keystore: {
       pbkdf2Sha256: NonNullable<CoreEngine.Keystore['pbkdf2Sha256']>
     }
+    MlDsa44: MlDsa44.engine.ReturnType
     Mnemonic: Mnemonic.engine.ReturnType
+    Secp256k1: Secp256k1.engine.ReturnType
     X25519: X25519.engine.ReturnType
   }
 

--- a/src/wasm/_test/Engine.test-d.ts
+++ b/src/wasm/_test/Engine.test-d.ts
@@ -11,6 +11,8 @@ test('install and engine expose the same precise engine', () => {
     (input: Uint8Array) => Uint8Array
   >()
   expectTypeOf<Installed['Keystore']>().not.toHaveProperty('scrypt')
+  expectTypeOf<Installed['MlDsa44']>().not.toHaveProperty('randomSecretKey')
+  expectTypeOf<Installed['Secp256k1']>().not.toHaveProperty('randomSecretKey')
 })
 
 test('the WASM Engine namespace exposes synchronous core operations', () => {

--- a/src/wasm/_test/Engine.test.ts
+++ b/src/wasm/_test/Engine.test.ts
@@ -10,7 +10,9 @@ describe('engine', () => {
         "Ed25519",
         "Hash",
         "Keystore",
+        "MlDsa44",
         "Mnemonic",
+        "Secp256k1",
         "X25519",
       ]
     `)
@@ -39,7 +41,9 @@ describe('install', () => {
         "Ed25519",
         "Hash",
         "Keystore",
+        "MlDsa44",
         "Mnemonic",
+        "Secp256k1",
         "X25519",
       ]
     `)
@@ -88,8 +92,20 @@ describe('install', () => {
           "Keystore": [
             "pbkdf2Sha256",
           ],
+          "MlDsa44": [
+            "getPublicKey",
+            "sign",
+            "verify",
+          ],
           "Mnemonic": [
             "toSeed",
+          ],
+          "Secp256k1": [
+            "getPublicKey",
+            "getSharedSecret",
+            "recoverPublicKey",
+            "sign",
+            "verify",
           ],
           "X25519": [
             "getPublicKey",

--- a/src/wasm/index.ts
+++ b/src/wasm/index.ts
@@ -109,8 +109,8 @@ export * as Kzg from './Kzg.js'
  * WASM implementations of Ox's supported ML-DSA-44 primitives, backed by
  * [mldsa-native](https://github.com/pq-code-package/mldsa-native).
  *
- * This provider is opt-in because its embedded artifact is larger than the
- * modules installed by [`Engine.install`](/api/Engine/install).
+ * This provider is installed by [`Engine.install`](/api/Engine/install), or
+ * can be installed individually.
  *
  * @example
  * ```ts twoslash
@@ -150,8 +150,8 @@ export * as Mnemonic from './Mnemonic.js'
 /**
  * WASM implementations of deterministic Secp256k1 primitives.
  *
- * This provider is opt-in because its embedded libsecp256k1 artifact is larger
- * than the modules installed by [`Engine.install`](/api/Engine/install).
+ * This provider is installed by [`Engine.install`](/api/Engine/install), or
+ * can be installed individually.
  *
  * @example
  * ```ts twoslash


### PR DESCRIPTION
Adds the `Secp256k1` and `MlDsa44` providers to the aggregate `ox/wasm` engine so `Engine.install()` initializes both without explicit provider selection.
