### PR TITLE
feat(evm): add the call family

### DIFF
--- a/.changeset/evm-entrypoint.md
+++ b/.changeset/evm-entrypoint.md
@@ -2,7 +2,7 @@
 "ox": minor
 ---
 
-Added the `ox/evm` entrypoint: a pure-TypeScript EVM interpreter (`Evm.run`) with journaled state execution over pluggable sources (`State`), plus `Opcode` and `Hardfork` modules.
+Added the `ox/evm` entrypoint: a pure-TypeScript EVM interpreter (`Evm.run`) with nested message calls and journaled state execution over pluggable sources (`State`), plus `Opcode` and `Hardfork` modules.
 
 ```ts
 import { Evm, State } from 'ox/evm'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,3 +142,4 @@
 - **Type snapshot config** -- `@ark/attest` 0.16 does not follow root project references. Point `ATTEST_CONFIG.tsconfig` at `test/tsconfig.json`.
 - **Node local storage** -- Node 24+ needs a valid `--localstorage-file` for the `@typescript/vfs` dependency used by attest.
 - **`scripts/` is not typechecked** -- `pnpm check:types` (`tsc -b`) covers only the `src` and `test` projects. A type error in `scripts/*.ts` surfaces at runtime; typecheck script changes by exercising them (or with an ad hoc `tsc --noEmit`).
+- **EVM oracle treats precompile addresses specially** -- the WASM differential oracle (`test/evm/oracle.ts`) dispatches calls to `0x01`-`0x11` (and `0x0100` on Osaka) to its built-in precompiles, ignoring staged code. Until the TS core implements precompiles, keep fuzz peer accounts and call targets outside that range.

--- a/src/evm/Evm.ts
+++ b/src/evm/Evm.ts
@@ -21,6 +21,7 @@ export type HaltReason =
   | 'memory-limit'
   | 'nonce-overflow'
   | 'out-of-gas'
+  | 'returndata-out-of-bounds'
   | 'stack-overflow'
   | 'stack-underflow'
   | 'static-violation'
@@ -84,13 +85,14 @@ export type Result =
     }>
 
 /**
- * Executes bytecode in a single frame, synchronously.
+ * Executes bytecode as a top-level call frame, synchronously.
  *
  * The frame reads and writes journaled state when a `state` source is given —
  * successful runs commit their changes to the source; reverts and halts
- * discard them — and reads empty state otherwise. Call frames (`CALL`,
- * `CREATE`, …) are not yet part of the dispatch table and halt with
- * `invalid-opcode`.
+ * discard them — and reads empty state otherwise. Message calls (`CALL`,
+ * `CALLCODE`, `DELEGATECALL`, `STATICCALL`) execute as nested frames;
+ * contract creation (`CREATE`, `CREATE2`) is not yet part of the dispatch
+ * table and halts with `invalid-opcode`.
  *
  * @example
  * ```ts twoslash

--- a/src/evm/_test/Evm.calls.test.ts
+++ b/src/evm/_test/Evm.calls.test.ts
@@ -1,0 +1,545 @@
+import { Evm, State } from 'ox/evm'
+import { describe, expect, test } from 'vp/test'
+
+// Expected gas figures are computed by hand from the fee schedule (annotated
+// per test) — never derived from the implementation.
+
+const self = '0x00000000000000000000000000000000000000aa' as const
+const bob = '0x00000000000000000000000000000000000000b0' as const
+const carol = '0x00000000000000000000000000000000000000c1' as const
+const nobody = '0x00000000000000000000000000000000000000dd' as const
+
+// Program tail: store the stack top at memory 0 and return the word.
+const ret = '5f5260205ff3'
+// PUSH20 <address>.
+const push = (address: string) => `73${address.slice(2)}`
+// The five zero operands shared by every plain call: out and in windows plus
+// value. STATICCALL/DELEGATECALL variants use four (no value).
+const zeros = (n: number) => '5f'.repeat(n)
+
+const word = (value: bigint | number | string) =>
+  `0x${BigInt(value).toString(16).padStart(64, '0')}` as const
+
+function returned(result: Evm.Result): `0x${string}` {
+  Evm.assertSuccess(result)
+  return result.output
+}
+
+describe('CALL', () => {
+  test('zero-value call to a non-existent account: cold 2600, no surcharge, no account', () => {
+    const state = State.fromMemory()
+    // PUSH0 ×5 (10) + PUSH20 (3) + PUSH0 gas (2) + cold 2600 + tail 13.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(nobody)}5ff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+    expect(result.gasUsed).toBe(2628n)
+    expect(state.getAccount(nobody)).toBeUndefined()
+  })
+
+  test('second call to the same target is warm: 100', () => {
+    const call = `${zeros(5)}${push(nobody)}5ff1`
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${call}${call}${ret}`,
+    })
+    expect(returned(result)).toBe(word(1))
+    // 15 + 2600 + 15 + 100 + 13.
+    expect(result.gasUsed).toBe(2743n)
+  })
+
+  test('gas assembly: memory, access, and value charges all precede the 63/64 cap; stipend rides free', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [self]: { balance: 10n },
+        // GAS at the first instruction, returned as a word.
+        [bob]: { balance: 5n, code: `0x5a${ret}` },
+      },
+    })
+    // PUSH1 32 outLen (3), PUSH0 ×3 (6), PUSH1 3 value (3), PUSH20 (3),
+    // PUSH4 gas (3) = 18. CALL charges: out-window expansion 3, cold 2600,
+    // value 9000. Remaining 200000 − 18 − 3 − 2600 − 9000 = 188379; the cap
+    // retains ⌊188379/64⌋ = 2943, forwarding 185436, plus the 2300 stipend.
+    // The child's GAS (static 2) then reads 185436 + 2300 − 2 = 187734.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f6003${push(bob)}63fffffffff160205ff3`,
+      gas: 200_000n,
+      state,
+    })
+    expect(returned(result)).toBe(word(187_734))
+    // Child used 15; parent tail (PUSH1 32, PUSH0, RETURN) 5.
+    // 18 + 3 + 2600 + 9000 + 15 + 5.
+    expect(result.gasUsed).toBe(9341n)
+    expect(state.getAccount(self)?.balance).toBe(7n)
+    expect(state.getAccount(bob)?.balance).toBe(8n)
+  })
+
+  test('value to a dead account: 25000 surcharge, account created on commit', () => {
+    const state = State.fromMemory({
+      accounts: { [self]: { balance: 10n } },
+    })
+    // PUSH0 ×4 (8) + PUSH1 3 (3) + PUSH20 (3) + PUSH0 gas (2) = 16.
+    // CALL: cold 2600 + value 9000 + new account 25000 + tail 13. The child
+    // hands back its untouched 2300 stipend, which the caller never paid —
+    // a net gain (the classic 9000-charged, 6700-effective transfer).
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(4)}6003${push(nobody)}5ff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+    expect(result.gasUsed).toBe(34_329n)
+    expect(state.getAccount(nobody)?.balance).toBe(3n)
+    expect(state.getAccount(nobody)?.nonce).toBe(0n)
+    expect(state.getAccount(self)?.balance).toBe(7n)
+  })
+
+  test('value to an existing-but-empty account still pays 25000 (EIP-161 emptiness)', () => {
+    const state = State.fromMemory({
+      accounts: { [self]: { balance: 10n }, [bob]: {} },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(4)}6003${push(bob)}5ff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+    expect(result.gasUsed).toBe(34_329n)
+    expect(state.getAccount(bob)?.balance).toBe(3n)
+  })
+
+  test('insufficient balance: pushes 0, refunds the stipend, moves nothing', () => {
+    const state = State.fromMemory({
+      accounts: { [self]: { balance: 2n }, [bob]: { balance: 5n } },
+    })
+    // 16 + cold 2600 + value 9000 + tail 13; the failed call refunds its
+    // full allowance — the never-paid 2300 stipend included.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(4)}6005${push(bob)}5ff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+    expect(result.gasUsed).toBe(9329n)
+    expect(state.getAccount(self)?.balance).toBe(2n)
+    expect(state.getAccount(bob)?.balance).toBe(5n)
+  })
+
+  test('self-call with value nets to zero', () => {
+    const state = State.fromMemory({
+      accounts: { [self]: { balance: 10n } },
+    })
+    // 16 + warm self (preamble) 100 + value 9000 + tail 13 − the returned
+    // stipend 2300; no 25000 (self is not empty).
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(4)}6004${push(self)}5ff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+    expect(result.gasUsed).toBe(6829n)
+    expect(state.getAccount(self)?.balance).toBe(10n)
+  })
+
+  test('reverting child: writes and value roll back, revert data surfaces', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [self]: { balance: 10n },
+        // SSTORE slot 1 ← 0x2a, then REVERT with the word 0x2a.
+        [bob]: { balance: 5n, code: '0x602a600155602a5f5260205ffd' },
+      },
+    })
+    // Out window [0, 32) receives the revert data; the success word is 0.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f6003${push(bob)}63fffffffff160205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0x2a))
+    expect(state.getStorage(bob, 1n)).toBe(0n)
+    expect(state.getAccount(self)?.balance).toBe(10n)
+    expect(state.getAccount(bob)?.balance).toBe(5n)
+  })
+
+  test('reverting child pushes 0', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: '0x5f5ffd' } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+  })
+
+  test('halting child consumes its whole allowance and pushes 0', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: '0xfe' } },
+    })
+    // PUSH0 ×5 (10) + PUSH20 (3) + PUSH2 10000 (3) = 16; cold 2600; the
+    // child burns all 10000; RETURNDATASIZE (2) reads 0; tail 13.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}612710f13d${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+    expect(result.gasUsed).toBe(12_631n)
+  })
+
+  test('output copy-back is bounded by what the child returned', () => {
+    const state = State.fromMemory({
+      // Returns 4 bytes: 0xdeadbeef.
+      accounts: { [bob]: { code: '0x63deadbeef5f526004601cf3' } },
+    })
+    // Pre-fill memory[0..32) with ones, call with a 32-byte out window, and
+    // return the word: only the first 4 bytes may be overwritten.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x7f${'ff'.repeat(32)}5f5260205f5f5f5f${push(bob)}61fffff160205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(`0xdeadbeef${'ff'.repeat(28)}`)
+  })
+})
+
+describe('CALLCODE', () => {
+  test('runs foreign code against the caller storage', () => {
+    const state = State.fromMemory({
+      // SSTORE slot 1 ← 0x2a.
+      accounts: { [bob]: { code: '0x602a600155' } },
+    })
+    // 16 + cold 2600 + child (3 + 3 + 2100 + 20000) + tail 13.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff2${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+    expect(result.gasUsed).toBe(24_735n)
+    expect(state.getStorage(self, 1n)).toBe(42n)
+    expect(state.getStorage(bob, 1n)).toBe(0n)
+  })
+
+  test('value sets CALLVALUE and the stipend but never moves', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [self]: { balance: 10n },
+        [bob]: { balance: 5n, code: `0x34${ret}` },
+      },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f6007${push(bob)}61fffff260205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(7))
+    expect(state.getAccount(self)?.balance).toBe(10n)
+    expect(state.getAccount(bob)?.balance).toBe(5n)
+  })
+
+  test('ADDRESS inside the child is the caller', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: `0x30${ret}` } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f5f${push(bob)}61fffff260205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(self))
+  })
+
+  test('insufficient balance fails the call even though nothing would move', () => {
+    const state = State.fromMemory({
+      accounts: { [self]: { balance: 2n }, [bob]: { code: `0x34${ret}` } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(4)}6007${push(bob)}61fffff2${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+  })
+})
+
+describe('DELEGATECALL', () => {
+  test('preserves the caller', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: `0x33${ret}` } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f${push(bob)}61fffff460205ff3`,
+      caller: carol,
+      state,
+    })
+    expect(returned(result)).toBe(word(carol))
+  })
+
+  test('preserves the value', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: `0x34${ret}` } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f${push(bob)}61fffff460205ff3`,
+      state,
+      value: 5n,
+    })
+    expect(returned(result)).toBe(word(5))
+  })
+
+  test('writes storage to the caller; no value charges', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: '0x602a600155' } },
+    })
+    // PUSH0 ×4 (8) + PUSH20 (3) + PUSH2 (3) = 14 + cold 2600 +
+    // child (3 + 3 + 2100 + 20000) + tail 13.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(4)}${push(bob)}61fffff4${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+    expect(result.gasUsed).toBe(24_733n)
+    expect(state.getStorage(self, 1n)).toBe(42n)
+    expect(state.getStorage(bob, 1n)).toBe(0n)
+  })
+})
+
+describe('STATICCALL', () => {
+  test('child SSTORE halts with static-violation, consuming the allowance', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: '0x602a600155' } },
+    })
+    // PUSH0 ×4 (8) + PUSH20 (3) + PUSH2 10000 (3) = 14; cold 2600; the
+    // child burns all 10000; RETURNDATASIZE (2) reads 0; tail 13.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(4)}${push(bob)}612710fa3d${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+    expect(result.gasUsed).toBe(12_629n)
+    expect(state.getStorage(bob, 1n)).toBe(0n)
+  })
+
+  test('the child sees CALLVALUE 0', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: `0x34${ret}` } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f${push(bob)}61fffffa60205ff3`,
+      state,
+      value: 5n,
+    })
+    expect(returned(result)).toBe(word(0))
+  })
+
+  test('staticness propagates through nested zero-value CALL', () => {
+    const state = State.fromMemory({
+      accounts: {
+        // Calls carol and returns the success word.
+        [bob]: { code: `0x${zeros(5)}${push(carol)}6103e8f1${ret}` },
+        // LOG0 — a static violation when the context is static.
+        [carol]: { code: '0x5f5fa0' },
+      },
+    })
+    const viaStatic = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f${push(bob)}61fffffa60205ff3`,
+      state,
+    })
+    expect(returned(viaStatic)).toBe(word(0))
+
+    const viaCall = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f5f${push(bob)}61fffff160205ff3`,
+      state,
+    })
+    expect(returned(viaCall)).toBe(word(1))
+  })
+
+  test('value-bearing CALL inside a static frame halts that frame', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: {
+          balance: 5n,
+          code: `0x${zeros(4)}6001${push(carol)}61fffff1${ret}`,
+        },
+      },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f${push(bob)}61fffffa60205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+  })
+
+  test('value-bearing CALLCODE inside a static frame is allowed', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: {
+          balance: 5n,
+          code: `0x${zeros(4)}6001${push(nobody)}61fffff2${ret}`,
+        },
+      },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x60205f5f5f${push(bob)}61fffffa60205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+  })
+})
+
+describe('returndata', () => {
+  test('RETURNDATASIZE starts at 0', () => {
+    const result = Evm.run({ bytecode: `0x3d${ret}` })
+    expect(returned(result)).toBe(word(0))
+    expect(result.gasUsed).toBe(15n)
+  })
+
+  test('RETURNDATACOPY copies a completed call output', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: `0x602a${ret}` } },
+    })
+    // Call (out window empty), then copy the 32-byte returndata to memory 0
+    // and return it. Copy: 3 static + 3 per word + 3 expansion.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff160205f5f3e60205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0x2a))
+    // 16 + 2600 + child 16 + copy (3+2+2+9) + return 5.
+    expect(result.gasUsed).toBe(2653n)
+  })
+
+  test('RETURNDATACOPY past the end is a hard halt', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: `0x602a${ret}` } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff160215f5f3e`,
+      gas: 100_000n,
+      state,
+    })
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "gasUsed": 100000n,
+        "reason": "returndata-out-of-bounds",
+        "status": "halted",
+      }
+    `)
+  })
+
+  test('a zero-length RETURNDATACOPY still bounds-checks its offset', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: `0x602a${ret}` } },
+    })
+    // offset 33, length 0: 33 > 32 halts.
+    const past = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff15f60215f3e${ret}`,
+      gas: 100_000n,
+      state,
+    })
+    expect(past.status).toBe('halted')
+    // offset 32, length 0: at the boundary, allowed.
+    const at = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff15f60205f3e${ret}`,
+      state,
+    })
+    expect(returned(at)).toBe(word(1))
+  })
+
+  test('a reverting child sets returndata; a halting child clears it', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: { code: '0x602a5f5260205ffd' },
+        [carol]: { code: '0xfe' },
+      },
+    })
+    const reverted = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff13d${ret}`,
+      state,
+    })
+    expect(returned(reverted)).toBe(word(32))
+
+    const halted = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff1${zeros(5)}${push(carol)}6103e8f13d${ret}`,
+      state,
+    })
+    expect(returned(halted)).toBe(word(0))
+  })
+
+  test('a call that never starts still replaces returndata', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [self]: { balance: 2n },
+        [bob]: { code: `0x602a${ret}` },
+      },
+    })
+    // First call fills returndata (32 bytes); the second fails its balance
+    // check before a child exists, clearing it.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff1${zeros(4)}6005${push(bob)}5ff13d${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+  })
+
+  test('a child starts with empty returndata', () => {
+    const state = State.fromMemory({
+      accounts: {
+        // Returns its own RETURNDATASIZE.
+        [bob]: { code: `0x3d${ret}` },
+        [carol]: { code: `0x602a${ret}` },
+      },
+    })
+    // Fill the parent returndata via carol, then call bob with a 32-byte out
+    // window: bob must report 0.
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${zeros(5)}${push(carol)}61fffff160205f5f5f5f${push(bob)}61fffff160205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+  })
+})
+
+describe('depth', () => {
+  test('the 1025th frame is refused without halting its parent', () => {
+    // Each frame bumps slot 0, then re-calls itself with all remaining gas.
+    // Exactly 1024 frames run: the deepest CALL fails fast with 0 and its
+    // frame still succeeds, so every increment commits.
+    const code = `0x60015f54015f55${zeros(5)}305af100` as const
+    const state = State.fromMemory({
+      accounts: { [self]: { code } },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: code,
+      // The 63/64 ladder plus ~324 gas per level needs a deep budget to
+      // still hold ~100k gas at frame 1024.
+      gas: 10n ** 12n,
+      state,
+    })
+    Evm.assertSuccess(result)
+    expect(state.getStorage(self, 0n)).toBe(1024n)
+  })
+})

--- a/src/evm/_test/Evm.calls.test.ts
+++ b/src/evm/_test/Evm.calls.test.ts
@@ -523,10 +523,11 @@ describe('returndata', () => {
 })
 
 describe('depth', () => {
-  test('the 1025th frame is refused without halting its parent', () => {
+  test('calls enter depth 1024; only calls from there are refused', () => {
     // Each frame bumps slot 0, then re-calls itself with all remaining gas.
-    // Exactly 1024 frames run: the deepest CALL fails fast with 0 and its
-    // frame still succeeds, so every increment commits.
+    // Exactly 1025 frames run (semantic depths 0 through 1024): the deepest
+    // frame's CALL fails fast with 0 and the frame itself still succeeds,
+    // so every increment commits.
     const code = `0x60015f54015f55${zeros(5)}305af100` as const
     const state = State.fromMemory({
       accounts: { [self]: { code } },
@@ -535,11 +536,11 @@ describe('depth', () => {
       address: self,
       bytecode: code,
       // The 63/64 ladder plus ~324 gas per level needs a deep budget to
-      // still hold ~100k gas at frame 1024.
+      // still hold ~90k gas at depth 1024.
       gas: 10n ** 12n,
       state,
     })
     Evm.assertSuccess(result)
-    expect(state.getStorage(self, 0n)).toBe(1024n)
+    expect(state.getStorage(self, 0n)).toBe(1025n)
   })
 })

--- a/src/evm/_test/Evm.diff-calls.fuzz.ts
+++ b/src/evm/_test/Evm.diff-calls.fuzz.ts
@@ -1,0 +1,352 @@
+import { fc, test } from '@fast-check/vitest'
+import { Hex } from 'ox'
+import { Evm, State } from 'ox/evm'
+import { describe, expect } from 'vp/test'
+
+import * as oracle from '../../../test/evm/oracle.js'
+
+const numRuns = Number(process.env.FC_NUM_RUNS) || 100
+
+// Differential fuzz over the call family: random programs mixing raw opcodes
+// with well-formed CALL/CALLCODE/DELEGATECALL/STATICCALL templates, executed
+// against runnable peer accounts on both the TS interpreter and the WASM
+// engine. Peers carry generated programs of their own — including call
+// templates back into the pool, so frames nest and recurse — and every
+// address sits outside the precompile range, which the TS core does not
+// implement yet. Status class, gas, refund, output, logs, and post-state
+// must all agree.
+//
+// Programs are assembled from chunks whose PUSH immediates are part of the
+// chunk, so instruction boundaries are exact by construction: a call opcode
+// only ever executes with the operands its own template pushed.
+
+const self = '0x00000000000000000000000000000000000000aa'
+const peers = [
+  '0x00000000000000000000000000000000000000b1',
+  '0x00000000000000000000000000000000000000b2',
+] as const
+const caller = '0x00000000000000000000000000000000000000c0'
+
+// Single-byte opcodes safe to interleave freely (no immediates). Raw
+// RETURNDATACOPY runs with arbitrary stack operands — usually an
+// out-of-bounds hard halt, which both engines must classify identically.
+const rawOps = [
+  ...Array.from({ length: 0x1e }, (_, i) => i + 0x01), // arithmetic – CLZ
+  0x20,
+  0x30,
+  0x31,
+  0x32,
+  0x33,
+  0x34,
+  0x35,
+  0x36,
+  0x37,
+  0x38,
+  0x39,
+  0x3a,
+  0x3b,
+  0x3c,
+  0x3d,
+  0x3e,
+  0x3f,
+  0x40,
+  0x41,
+  0x42,
+  0x43,
+  0x44,
+  0x45,
+  0x46,
+  0x47,
+  0x48,
+  0x49,
+  0x4a,
+  0x50,
+  0x51,
+  0x52,
+  0x53,
+  0x54,
+  0x55,
+  0x56,
+  0x57,
+  0x58,
+  0x59,
+  0x5a,
+  0x5b,
+  0x5c,
+  0x5d,
+  0x5e,
+  0x5f,
+  ...Array.from({ length: 32 }, (_, i) => i + 0x80), // DUP1 – SWAP16
+  0xa0,
+  0xa1,
+  0xa2,
+  0xa3,
+  0xa4,
+  0x00,
+  0xf3,
+  0xfd,
+  0xfe,
+  0xff,
+]
+
+// Call targets, pushed as PUSH1 (addresses left-pad): the executing account,
+// both peers, and a never-staged address for the dead-account paths.
+const targets = [0xaa, 0xb1, 0xb2, 0xdd]
+
+// PUSH snippets for the gas operand: nothing, a trickle, a mid allowance,
+// and far more than the 63/64 cap will grant.
+const gasPushes = [
+  [0x5f],
+  [0x60, 0x40],
+  [0x61, 0x4e, 0x20],
+  [0x63, 0xff, 0xff, 0xff, 0xff],
+]
+
+// PUSH snippets for the value operand: zero, small (usually funded), and
+// beyond any staged balance (the balance-check failure path).
+const valuePushes = [
+  [0x5f],
+  [0x60, 0x01],
+  [0x6c, ...Array.from({ length: 13 }, () => 0xff)],
+]
+
+const arbitraryCallChunk = () =>
+  fc
+    .record({
+      gas: fc.constantFrom(...gasPushes),
+      opcode: fc.constantFrom(0xf1, 0xf2, 0xf4, 0xfa),
+      target: fc.constantFrom(...targets),
+      value: fc.constantFrom(...valuePushes),
+      windows: fc.array(fc.constantFrom(0, 32, 64), {
+        maxLength: 4,
+        minLength: 4,
+      }),
+    })
+    .map(({ gas, opcode, target, value, windows }) => [
+      // outLen, outOff, inLen, inOff — then value, target, gas.
+      ...windows.flatMap((size) => [0x60, size]),
+      ...(opcode === 0xf1 || opcode === 0xf2 ? value : []),
+      0x60,
+      target,
+      ...gas,
+      opcode,
+    ])
+
+const arbitraryChunk = () =>
+  fc.oneof(
+    { weight: 5, arbitrary: fc.constantFrom(...rawOps).map((op) => [op]) },
+    {
+      weight: 2,
+      arbitrary: fc
+        .tuple(fc.constant(0x60), fc.integer({ min: 0, max: 255 }))
+        .map(([push, byte]) => [push, byte]),
+    },
+    { weight: 2, arbitrary: arbitraryCallChunk() },
+    {
+      // RETURNDATACOPY with small controlled operands — in range often
+      // enough to exercise the copy itself, not just the halt.
+      weight: 1,
+      arbitrary: fc
+        .record({
+          length: fc.constantFrom(0, 1, 32, 64),
+          offset: fc.constantFrom(0, 1, 32),
+        })
+        .map(({ length, offset }) => [0x60, length, 0x60, offset, 0x5f, 0x3e]),
+    },
+  )
+
+const arbitraryProgram = (maxChunks: number) =>
+  fc
+    .array(arbitraryChunk(), { maxLength: maxChunks, minLength: 0 })
+    .map((chunks) => new Uint8Array(chunks.flat()))
+
+const arbitraryAccount = () =>
+  fc.record({
+    balance: fc.bigInt({ min: 0n, max: 2n ** 96n }),
+    nonce: fc.bigInt({ min: 0n, max: 100n }),
+  })
+
+const arbitraryStorage = () =>
+  fc.array(
+    fc.record({
+      slot: fc.bigInt({ min: 0n, max: 4n }),
+      value: fc.bigInt({ min: 0n, max: 2n ** 256n - 1n }),
+    }),
+    { maxLength: 6 },
+  )
+
+const block = {
+  baseFee: 7n,
+  blobBaseFee: 3n,
+  chainId: 1n,
+  coinbase: '0x00000000000000000000000000000000000000fe',
+  gasLimit: 30_000_000n,
+  number: 10n,
+  prevRandao: 0xabcdefn,
+  timestamp: 1000n,
+}
+const chainHashes = [0x9999n, 0x8888n, 0x7777n]
+
+function compare(options: {
+  program: Uint8Array
+  peerPrograms: Uint8Array[]
+  data: Uint8Array
+  gas: bigint
+  accounts: { balance: bigint; nonce: bigint }[]
+  storage: { slot: bigint; value: bigint }[]
+  static?: boolean
+}) {
+  const accounts = [
+    {
+      address: self,
+      balance: options.accounts[0]?.balance ?? 0n,
+      code: options.program,
+      nonce: 1n,
+    },
+    ...peers.map((address, i) => ({
+      address,
+      balance: options.accounts[i + 1]?.balance ?? 0n,
+      code: options.peerPrograms[i] ?? new Uint8Array(0),
+      nonce: options.accounts[i + 1]?.nonce ?? 0n,
+    })),
+  ]
+  const storage = options.storage.map((entry) => ({ address: self, ...entry }))
+
+  const expected = oracle.execute({
+    accounts,
+    address: self,
+    block,
+    caller,
+    chainHashes,
+    data: options.data,
+    gas: options.gas,
+    gasPrice: 9n,
+    static: options.static ?? false,
+    storage,
+    value: 5n,
+  })
+
+  const state = State.fromMemory({
+    accounts: Object.fromEntries(
+      accounts.map((account) => [
+        account.address,
+        {
+          balance: account.balance,
+          code: Hex.fromBytes(account.code),
+          nonce: account.nonce,
+        },
+      ]),
+    ),
+    blockHashes: Object.fromEntries(
+      chainHashes.map((hash, i) => [
+        Number(block.number) - 1 - i,
+        Hex.fromNumber(hash, { size: 32 }),
+      ]),
+    ),
+  })
+  for (const entry of storage) state.putStorage(self, entry.slot, entry.value)
+
+  const actual = Evm.run({
+    address: self,
+    block: {
+      baseFeePerGas: block.baseFee,
+      blobBaseFee: block.blobBaseFee,
+      coinbase: block.coinbase as `0x${string}`,
+      gasLimit: block.gasLimit,
+      number: block.number,
+      prevRandao: Hex.fromNumber(block.prevRandao, { size: 32 }),
+      timestamp: block.timestamp,
+    },
+    bytecode: options.program,
+    caller,
+    chainId: block.chainId,
+    data: options.data,
+    gas: options.gas,
+    gasPrice: 9n,
+    state,
+    static: options.static ?? false,
+    value: 5n,
+  })
+
+  const statusClass = actual.status === 'halted' ? 'exceptional' : actual.status
+  expect(statusClass, `status (oracle: ${expected.status})`).toBe(
+    expected.statusClass,
+  )
+  expect(actual.gasUsed, `gasUsed (oracle: ${expected.status})`).toBe(
+    expected.gasUsed,
+  )
+  if (actual.status === 'halted') return
+
+  expect(actual.output).toBe(Hex.fromBytes(expected.output))
+  if (actual.status !== 'success') return
+
+  expect(actual.gasRefund, 'refund').toBe(expected.refund)
+  expect(
+    actual.logs.map((log) => ({
+      address: log.address.toLowerCase(),
+      data: log.data,
+      topics: log.topics,
+    })),
+    'logs',
+  ).toEqual(
+    expected.logs.map((log) => ({
+      address: log.address,
+      data: Hex.fromBytes(log.data),
+      topics: log.topics.map((topic) => Hex.fromNumber(topic, { size: 32 })),
+    })),
+  )
+
+  // Post-state: every account and slot the engine reports must match the
+  // committed TS source.
+  for (const [address, account] of expected.accounts) {
+    const actualAccount = state.getAccount(address as `0x${string}`)
+    expect(actualAccount?.balance ?? 0n, `balance of ${address}`).toBe(
+      account.balance,
+    )
+    expect(actualAccount?.nonce ?? 0n, `nonce of ${address}`).toBe(
+      account.nonce,
+    )
+  }
+  for (const [address, slots] of expected.storage)
+    for (const [slot, value] of slots)
+      expect(
+        state.getStorage(address as `0x${string}`, slot),
+        `storage ${address}[${slot}]`,
+      ).toBe(value)
+}
+
+describe('TS interpreter matches the WASM engine over calls', () => {
+  test.prop(
+    {
+      accounts: fc.array(arbitraryAccount(), { minLength: 3, maxLength: 3 }),
+      data: fc.uint8Array({ maxLength: 32 }),
+      gas: fc.constantFrom(60_000n, 300_000n, 1_000_000n),
+      peerPrograms: fc.array(arbitraryProgram(10), {
+        minLength: 2,
+        maxLength: 2,
+      }),
+      program: arbitraryProgram(24),
+      storage: arbitraryStorage(),
+    },
+    { numRuns },
+  )('call programs over runnable peers agree', (options) => {
+    compare(options)
+  })
+
+  test.prop(
+    {
+      accounts: fc.array(arbitraryAccount(), { minLength: 3, maxLength: 3 }),
+      data: fc.uint8Array({ maxLength: 16 }),
+      gas: fc.constantFrom(300_000n),
+      peerPrograms: fc.array(arbitraryProgram(10), {
+        minLength: 2,
+        maxLength: 2,
+      }),
+      program: arbitraryProgram(24),
+      storage: arbitraryStorage(),
+    },
+    { numRuns },
+  )('static contexts agree', (options) => {
+    compare({ ...options, static: true })
+  })
+})

--- a/src/evm/internal/instructions.ts
+++ b/src/evm/internal/instructions.ts
@@ -707,9 +707,11 @@ function callOp(opcode: number): Instruction {
     f.returndata = emptyBytes
 
     // An unfunded or too-deep call fails without a child frame, refunding
-    // the full allowance — stipend included.
+    // the full allowance — stipend included. The top frame sits at semantic
+    // depth 0 and `frames.length` is the child's would-be depth, which may
+    // reach the limit itself: only calls made from that deepest frame fail.
     const ownBalance = own ? own.balance : 0n
-    if (ownBalance < value || m.frames.length >= callDepthLimit) {
+    if (ownBalance < value || m.frames.length > callDepthLimit) {
       f.gas += childGas
       push(f, 0n)
       return

--- a/src/evm/internal/instructions.ts
+++ b/src/evm/internal/instructions.ts
@@ -1,9 +1,12 @@
 import * as hash from '../../core/internal/hash.js'
 import * as Hardfork from '../Hardfork.js'
+import { analyzed } from './analysis.js'
 import * as journal from './journal.js'
 import {
   bitLength,
   copyPadded,
+  createFrame,
+  emptyBytes,
   expandMemory,
   halt,
   loadWordPadded,
@@ -266,6 +269,30 @@ function build(hardfork: Hardfork.Hardfork): Table {
   table[0x39] = op(3n, 3, 0, (f, m) => copy(f, m, f.code))
   table[0x3a] = op(2n, 0, 1, (f, m) => push(f, m.gasPrice))
 
+  // Returndata (EIP-211)
+
+  table[0x3d] = op(2n, 0, 1, (f) => push(f, BigInt(f.returndata.length)))
+  table[0x3e] = op(3n, 3, 0, (f, m) => {
+    const dest = pop(f)
+    const offset = pop(f)
+    const length = pop(f)
+    if (!chargeDynamic(f, m, 3n * wordCount(length))) return
+    if (!expandMemory(m, f, dest, length)) return
+    // Unlike the other copies, a read past the end of the returndata buffer
+    // is a halt rather than a zero-fill — a zero-length read included.
+    if (offset + length > BigInt(f.returndata.length)) {
+      halt(m, f, 'returndata-out-of-bounds')
+      return
+    }
+    if (length !== 0n) {
+      const start = Number(offset)
+      f.memory.set(
+        f.returndata.subarray(start, start + Number(length)),
+        Number(dest),
+      )
+    }
+  })
+
   // Account state
 
   table[0x31] = op(0n, 1, 1, (f, m) => {
@@ -525,6 +552,13 @@ function build(hardfork: Hardfork.Hardfork): Table {
     m.done = true
   })
 
+  // Calls
+
+  table[0xf1] = callOp(0xf1)
+  table[0xf2] = callOp(0xf2)
+  table[0xf4] = callOp(0xf4)
+  table[0xfa] = callOp(0xfa)
+
   // Stack, memory & flow
 
   table[0x50] = op(2n, 1, 0, (f) => {
@@ -602,6 +636,117 @@ function build(hardfork: Hardfork.Hardfork): Table {
     })
 
   return table
+}
+
+const callDepthLimit = 1024
+
+// One handler for CALL (0xf1), CALLCODE (0xf2), DELEGATECALL (0xf4), and
+// STATICCALL (0xfa). Only CALL and CALLCODE take a value operand, and only
+// CALL moves it — CALLCODE runs foreign code in the caller's own account, so
+// its value never leaves and is there for the stipend and CALLVALUE.
+function callOp(opcode: number): Instruction {
+  const hasValue = opcode === 0xf1 || opcode === 0xf2
+  return op(0n, hasValue ? 7 : 6, 1, (f, m) => {
+    const gasArg = pop(f)
+    const to = wordToAddress(pop(f))
+    const value = hasValue ? pop(f) : 0n
+    const inOffset = pop(f)
+    const inLength = pop(f)
+    const outOffset = pop(f)
+    const outLength = pop(f)
+
+    // A static frame may not move value — but only CALL moves any.
+    if (opcode === 0xf1 && f.static && value !== 0n) {
+      halt(m, f, 'static-violation')
+      return
+    }
+
+    // Resolve every state dimension before any mutation (restart discipline):
+    // the callee's account and code, and the caller's account when value is
+    // at stake. Fetching the code also settles `hasCode`, which the EIP-161
+    // emptiness check below reads.
+    const callee = journal.getAccount(m.journal, to)
+    if (callee === undefined) {
+      need(m, { address: to, kind: 'account' })
+      return
+    }
+    const code = journal.getCode(m.journal, to)
+    if (code === undefined) {
+      need(m, { address: to, kind: 'code' })
+      return
+    }
+    const own = value !== 0n ? journal.getAccount(m.journal, f.address) : null
+    if (own === undefined) {
+      need(m, { address: f.address, kind: 'account' })
+      return
+    }
+
+    // Gas assembly, in consensus order: memory expansion over the input and
+    // output windows, target access (EIP-2929), the value-transfer and
+    // new-account surcharges, then the 63/64 cap (EIP-150) on what remains.
+    if (!expandMemory(m, f, inOffset, inLength)) return
+    if (!expandMemory(m, f, outOffset, outLength)) return
+    if (!chargeAccount(f, m, to)) return
+    if (value !== 0n) {
+      let cost = 9000n
+      // A value-bearing CALL to a dead account (EIP-161 empty) pays to
+      // bring it into existence.
+      if (opcode === 0xf1 && (callee === null || journal.isEmpty(callee)))
+        cost += 25_000n
+      if (!chargeDynamic(f, m, cost)) return
+    }
+    const allowed = f.gas - f.gas / 64n
+    let childGas = gasArg < allowed ? gasArg : allowed
+    f.gas -= childGas
+    // The stipend rides on top of the cap and is not deducted from the
+    // caller.
+    if (value !== 0n) childGas += 2300n
+
+    // Every call replaces the returndata buffer, including one that never
+    // starts (EIP-211).
+    f.returndata = emptyBytes
+
+    // An unfunded or too-deep call fails without a child frame, refunding
+    // the full allowance — stipend included.
+    const ownBalance = own ? own.balance : 0n
+    if (ownBalance < value || m.frames.length >= callDepthLimit) {
+      f.gas += childGas
+      push(f, 0n)
+      return
+    }
+
+    const checkpoint = journal.checkpoint(m.journal)
+    if (opcode === 0xf1 && value !== 0n) {
+      journal.setBalance(m.journal, f.address, ownBalance - value)
+      // Re-read after the debit so a self-call nets to zero.
+      const target = journal.getAccount(m.journal, to)
+      journal.setBalance(m.journal, to, (target ? target.balance : 0n) + value)
+    }
+
+    // DELEGATECALL and CALLCODE run the callee's code against the caller's
+    // own address and storage; DELEGATECALL also inherits caller and value.
+    m.frames.push(
+      createFrame({
+        address: opcode === 0xf1 || opcode === 0xfa ? to : f.address,
+        analysis: analyzed(code).analysis,
+        caller: opcode === 0xf4 ? f.caller : f.addressWord,
+        checkpoint,
+        code,
+        gas: childGas,
+        input:
+          inLength === 0n
+            ? emptyBytes
+            : f.memory.subarray(
+                Number(inOffset),
+                Number(inOffset) + Number(inLength),
+              ),
+        outLength: outLength === 0n ? 0 : Number(outLength),
+        outOffset: outLength === 0n ? 0 : Number(outOffset),
+        static: f.static || opcode === 0xfa,
+        value: opcode === 0xf4 ? f.value : value,
+      }),
+    )
+  })
 }
 
 function copy(f: Frame, m: Machine, source: Uint8Array): void {

--- a/src/evm/internal/interpreter.ts
+++ b/src/evm/internal/interpreter.ts
@@ -1,13 +1,28 @@
+import * as journal from './journal.js'
 import type { StateRequest } from './journal.js'
-import { halt, STACK_LIMIT, type Frame, type Machine } from './machine.js'
+import {
+  emptyBytes,
+  halt,
+  push,
+  STACK_LIMIT,
+  type Frame,
+  type Machine,
+} from './machine.js'
 
 /**
- * Runs the machine's current frame until it halts or hits unfetched state.
+ * Runs the machine's frame stack until the bottom frame halts or execution
+ * hits unfetched state.
  *
  * The loop owns every check the opcode handlers rely on: static gas, stack
  * underflow, and stack overflow are validated here from the instruction's
  * metadata, so handlers pop and push unchecked. Dynamic gas (memory expansion,
  * per-word costs, warm/cold access) is charged inside handlers.
+ *
+ * A call instruction pushes a child frame and returns; the loop notices the
+ * deeper stack and dispatches the child next. When a frame other than the
+ * bottom one completes, {@link resolve} folds its outcome into the parent —
+ * journal revert, returndata, gas refund, output copy-back, success word —
+ * and the parent resumes after its call instruction.
  *
  * Restartability is structural: the loop snapshots `pc`, `sp`, and `gas`
  * before dispatching, and when an instruction reports a state miss it restores
@@ -17,49 +32,82 @@ import { halt, STACK_LIMIT, type Frame, type Machine } from './machine.js'
  * their last possible miss.
  */
 export function execute(machine: Machine): StateRequest | undefined {
-  const frame = machine.frames[machine.frames.length - 1] as Frame
-  const code = frame.code
+  const frames = machine.frames
   const table = machine.table
-  while (!machine.done) {
-    const pc = frame.pc
-    if (pc >= code.length) {
-      // Running off the end of the code is an implicit STOP.
-      machine.done = true
-      break
+  while (true) {
+    const depth = frames.length
+    const frame = frames[depth - 1] as Frame
+    const code = frame.code
+    while (!machine.done) {
+      const pc = frame.pc
+      if (pc >= code.length) {
+        // Running off the end of the code is an implicit STOP.
+        machine.done = true
+        break
+      }
+      const opcode = code[pc] as number
+      const instruction = table[opcode]
+      if (instruction === undefined) {
+        halt(machine, frame, 'invalid-opcode')
+        break
+      }
+      if (instruction.gas > frame.gas) {
+        halt(machine, frame, 'out-of-gas')
+        break
+      }
+      const gas = frame.gas
+      frame.gas = gas - instruction.gas
+      const sp = frame.sp
+      if (sp < instruction.inputs) {
+        halt(machine, frame, 'stack-underflow')
+        break
+      }
+      if (sp - instruction.inputs + instruction.outputs > STACK_LIMIT) {
+        halt(machine, frame, 'stack-overflow')
+        break
+      }
+      frame.pc = pc + 1
+      instruction.handler(frame, machine)
+      if (machine.request) {
+        // State miss: undo this instruction entirely and hand the request to
+        // the driver. Re-entry restarts at the same pc with a seeded cache.
+        frame.pc = pc
+        frame.sp = sp
+        frame.gas = gas
+        const request = machine.request
+        machine.request = undefined
+        return request
+      }
+      if (frames.length !== depth) break
     }
-    const opcode = code[pc] as number
-    const instruction = table[opcode]
-    if (instruction === undefined) {
-      halt(machine, frame, 'invalid-opcode')
-      break
-    }
-    if (instruction.gas > frame.gas) {
-      halt(machine, frame, 'out-of-gas')
-      break
-    }
-    const gas = frame.gas
-    frame.gas = gas - instruction.gas
-    const sp = frame.sp
-    if (sp < instruction.inputs) {
-      halt(machine, frame, 'stack-underflow')
-      break
-    }
-    if (sp - instruction.inputs + instruction.outputs > STACK_LIMIT) {
-      halt(machine, frame, 'stack-overflow')
-      break
-    }
-    frame.pc = pc + 1
-    instruction.handler(frame, machine)
-    if (machine.request) {
-      // State miss: undo this instruction entirely and hand the request to
-      // the driver. Re-entry restarts at the same pc with a seeded cache.
-      frame.pc = pc
-      frame.sp = sp
-      frame.gas = gas
-      const request = machine.request
-      machine.request = undefined
-      return request
-    }
+    if (!machine.done) continue // a call pushed a child frame — run it
+    if (depth === 1) return undefined
+    resolve(machine)
   }
-  return undefined
+}
+
+/**
+ * Folds a completed child frame's outcome into its parent. The parent's
+ * memory was expanded over the output window before the child ran, and the
+ * dispatch loop validated the success word's stack slot when it dispatched
+ * the call instruction, so both writes here are unchecked.
+ */
+function resolve(machine: Machine): void {
+  const child = machine.frames.pop() as Frame
+  const parent = machine.frames[machine.frames.length - 1] as Frame
+  const success = machine.halt === undefined && !machine.reverted
+  // A revert or halt unwinds the child's journal writes, its value transfer
+  // included. REVERT carries output back (EIP-140); an exceptional halt
+  // carries none and has already consumed the child's gas.
+  if (!success) journal.revert(machine.journal, child.checkpoint)
+  const output =
+    machine.halt === undefined ? (child.output ?? emptyBytes) : emptyBytes
+  parent.returndata = output
+  parent.gas += child.gas
+  const length = Math.min(child.outLength, output.length)
+  if (length > 0) parent.memory.set(output.subarray(0, length), child.outOffset)
+  push(parent, success ? 1n : 0n)
+  machine.done = false
+  machine.halt = undefined
+  machine.reverted = false
 }

--- a/src/evm/internal/machine.ts
+++ b/src/evm/internal/machine.ts
@@ -45,14 +45,22 @@ export type Frame = {
   addressWord: bigint
   analysis: Analysis
   caller: bigint
+  /** Journal checkpoint taken when this frame was entered; the dispatch loop
+   * reverts to it when the frame reverts or halts. */
+  checkpoint: number
   code: Uint8Array
   gas: bigint
   input: Uint8Array
   memory: Uint8Array
   /** Logical memory size in 32-byte words (`MSIZE` = this × 32). */
   memoryWords: number
+  /** Parent-memory window this frame's output is copied back into. */
+  outLength: number
+  outOffset: number
   output: Uint8Array | undefined
   pc: number
+  /** Output of the frame's most recent completed sub-call (EIP-211). */
+  returndata: Uint8Array
   sp: number
   stack: bigint[]
   static: boolean
@@ -92,13 +100,18 @@ export function addressToWord(address: string): bigint {
   return BigInt(address)
 }
 
+export const emptyBytes = new Uint8Array(0)
+
 export function createFrame(options: {
   address: string
   analysis: Analysis
   caller: bigint
+  checkpoint?: number | undefined
   code: Uint8Array
   gas: bigint
   input: Uint8Array
+  outLength?: number | undefined
+  outOffset?: number | undefined
   static: boolean
   value: bigint
 }): Frame {
@@ -108,13 +121,17 @@ export function createFrame(options: {
     addressWord: addressToWord(options.address),
     analysis: options.analysis,
     caller: options.caller,
+    checkpoint: options.checkpoint ?? 0,
     code: options.code,
     gas: options.gas,
     input: options.input,
     memory,
     memoryWords: 0,
+    outLength: options.outLength ?? 0,
+    outOffset: options.outOffset ?? 0,
     output: undefined,
     pc: 0,
+    returndata: emptyBytes,
     sp: 0,
     // Packed with zeroes up front: the elements kind stays PACKED, and reads
     // beneath `sp` are always assigned slots.

--- a/test/evm/eest.ts
+++ b/test/evm/eest.ts
@@ -239,6 +239,7 @@ export type Status =
   | 'nonce-overflow'
   | 'out-of-gas'
   | 'out-of-memory'
+  | 'returndata-out-of-bounds'
   | 'stack-overflow'
   | 'stack-underflow'
   | 'static-violation'


### PR DESCRIPTION
Adds the call family to the TS interpreter: `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `RETURNDATASIZE`, and `RETURNDATACOPY` as iterative frames with EIP-150/2929/161/211 gas assembly, validated by differential fuzzing against the WASM oracle.

Stacked on https://github.com/wevm/ox/pull/358.
