### PR TITLE
feat(evm): support eip-7702 delegation reads

### DIFF
--- a/.changeset/evm-entrypoint.md
+++ b/.changeset/evm-entrypoint.md
@@ -2,4 +2,4 @@
 "ox": minor
 ---
 
-Added `ox/evm` with nested calls, `CREATE`/`CREATE2`, EIP-7702 delegation reads, and pluggable state sources with synchronized storage metadata.
+Added `ox/evm` with configured ephemeral calls, nested calls, `CREATE`/`CREATE2`, EIP-7702 delegation reads, and pluggable state sources with synchronized storage metadata.

--- a/.changeset/evm-entrypoint.md
+++ b/.changeset/evm-entrypoint.md
@@ -2,4 +2,4 @@
 "ox": minor
 ---
 
-Added `ox/evm` with nested calls, `CREATE`/`CREATE2`, and pluggable state sources whose accounts report `hasStorage` while storage writes keep it synchronized.
+Added `ox/evm` with nested calls, `CREATE`/`CREATE2`, EIP-7702 delegation reads, and pluggable state sources with synchronized storage metadata.

--- a/src/evm/Evm.ts
+++ b/src/evm/Evm.ts
@@ -5,10 +5,17 @@ import type { Compute, ExactPartial } from '../core/internal/types.js'
 import * as State from './State.js'
 import * as Hardfork from './Hardfork.js'
 import { analyzed } from './internal/analysis.js'
+import * as delegation from './internal/delegation.js'
 import { table } from './internal/instructions.js'
 import { execute } from './internal/interpreter.js'
 import * as journal_ from './internal/journal.js'
-import { addressToWord, createFrame, type Machine } from './internal/machine.js'
+import {
+  addressToWord,
+  createFrame,
+  halt,
+  type Frame,
+  type Machine,
+} from './internal/machine.js'
 
 /** Why execution stopped exceptionally. Exceptional halts consume all gas. */
 export type HaltReason =
@@ -16,6 +23,7 @@ export type HaltReason =
   | 'code-size-exceeded'
   | 'create-collision'
   | 'initcode-size-exceeded'
+  | 'insufficient-balance'
   | 'invalid-jump'
   | 'invalid-opcode'
   | 'memory-limit'
@@ -84,6 +92,145 @@ export type Result =
       gasUsed: bigint
     }>
 
+/** Root type for a configured EVM. */
+export type Evm<state extends State.Sync = State.Sync> = Compute<{
+  /** Hardfork whose rules calls execute under. */
+  hardfork: Hardfork.Hardfork
+  /** State source calls read without mutating. */
+  state: state
+}>
+
+/**
+ * Configures an EVM over a synchronous state source.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Evm, State } from 'ox/evm'
+ *
+ * const evm = Evm.from({
+ *   hardfork: 'osaka',
+ *   state: State.fromMemory()
+ * })
+ * ```
+ *
+ * @param options - Options.
+ * @returns A configured EVM.
+ */
+export function from<const state extends State.Sync>(
+  options: from.Options<state>,
+): Evm<state> {
+  const hardfork = options.hardfork ?? Hardfork.latest
+  Hardfork.atLeast(hardfork, 'cancun')
+  return {
+    hardfork,
+    state: State.from(options.state),
+  }
+}
+
+export declare namespace from {
+  type Options<state extends State.Sync = State.Sync> = {
+    /** Hardfork whose rules calls execute under. @default Hardfork.latest */
+    hardfork?: Hardfork.Hardfork | undefined
+    /** State source calls read without mutating. */
+    state: state
+  }
+
+  type ErrorType =
+    | Hardfork.UnknownHardforkError
+    | State.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Executes an ephemeral call against configured state.
+ *
+ * State changes are visible during execution but are discarded afterward.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Evm, State } from 'ox/evm'
+ *
+ * const to = '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357'
+ * const evm = Evm.from({
+ *   state: State.fromMemory({
+ *     accounts: { [to]: { code: '0x602a5f5260205ff3' } }
+ *   })
+ * })
+ *
+ * const result = Evm.call(evm, { to })
+ * Evm.assertSuccess(result)
+ * result.output
+ * // @log: '0x000000000000000000000000000000000000000000000000000000000000002a'
+ * ```
+ *
+ * @param evm - Configured EVM.
+ * @param options - Call options.
+ * @returns The execution result.
+ */
+export function call(evm: Evm, options: call.Options): Result {
+  const { hardfork, state } = evm
+  const from = (options.from ?? zeroAddress).toLowerCase() as Address.Address
+  const to = options.to.toLowerCase() as Address.Address
+  const code = getCode(state, to)
+  const delegatedTo = Hardfork.atLeast(hardfork, 'prague')
+    ? delegation.getAddress(code)
+    : undefined
+  const bytecode = delegatedTo
+    ? getCode(state, delegatedTo as Address.Address)
+    : code
+
+  const execution = createExecution({
+    address: to,
+    blobHashes: options.blobHashes,
+    block: options.block,
+    bytecode,
+    caller: from,
+    chainId: options.chainId,
+    data: options.data,
+    gas: options.gas,
+    gasPrice: options.gasPrice,
+    hardfork,
+    origin: from,
+    state,
+    value: options.value,
+  })
+
+  if (delegatedTo) chargeAccount(execution, delegatedTo)
+  transferValue(execution, { from, state, to, value: options.value ?? 0n })
+  return executeRun(execution)
+}
+
+export declare namespace call {
+  type Options = {
+    /** Versioned blob hashes for `BLOBHASH`. */
+    blobHashes?: readonly Hex.Hex[] | undefined
+    /** Block environment. Omitted fields default to zero-like values. */
+    block?: ExactPartial<BlockEnv> | undefined
+    /** `CHAINID`. @default 1n */
+    chainId?: bigint | undefined
+    /** Calldata. @default '0x' */
+    data?: Hex.Hex | Uint8Array | undefined
+    /** Sender exposed through `CALLER` and `ORIGIN`. @default zero address */
+    from?: Address.Address | undefined
+    /** Gas available to execution. @default 30_000_000n */
+    gas?: bigint | undefined
+    /** `GASPRICE`. @default 0n */
+    gasPrice?: bigint | undefined
+    /** Account whose code and storage context execute. */
+    to: Address.Address
+    /** `CALLVALUE`. @default 0n */
+    value?: bigint | undefined
+  }
+
+  type ErrorType = run.ErrorType
+}
+
+function getCode(state: State.Sync, address: Address.Address): Uint8Array {
+  const account = state.getAccount(address)
+  if (!account) return new Uint8Array(0)
+  return Hex.toBytes(account.code ?? state.getCode(address))
+}
+
 /**
  * Executes bytecode as a top-level call frame, synchronously.
  *
@@ -137,6 +284,22 @@ export type Result =
  * @returns The execution result.
  */
 export function run(options: run.Options): Result {
+  const execution = createExecution(options)
+  const result = executeRun(execution)
+  if (options.state && result.status === 'success')
+    commit(execution.machine.journal, options.state)
+  return result
+}
+
+type Execution = {
+  frame: Frame
+  gas: bigint
+  hardfork: Hardfork.Hardfork
+  machine: Machine
+  state: State.Sync | undefined
+}
+
+function createExecution(options: run.Options): Execution {
   const {
     address = zeroAddress,
     blobHashes = [],
@@ -199,9 +362,14 @@ export function run(options: run.Options): Result {
   journal_.warmAddress(journal, origin.toLowerCase())
   journal_.warmAddress(journal, caller.toLowerCase())
 
+  return { frame, gas, hardfork, machine, state }
+}
+
+function executeRun(execution: Execution): Result {
+  const { frame, gas, machine, state } = execution
   let request = execute(machine)
   while (request !== undefined) {
-    journal_.seed(journal, resolveSync(state, request))
+    journal_.seed(machine.journal, resolveSync(state, request))
     request = execute(machine)
   }
 
@@ -210,11 +378,10 @@ export function run(options: run.Options): Result {
   const output = frame.output ? Hex.fromBytes(frame.output) : '0x'
   if (machine.reverted) return { gasUsed, output, status: 'reverted' }
 
-  if (state) commit(journal, state)
   return {
-    gasRefund: journal.refund,
+    gasRefund: machine.journal.refund,
     gasUsed,
-    logs: journal.logs.map((log) => ({
+    logs: machine.journal.logs.map((log) => ({
       address: Address.checksum(log.address),
       data: Hex.fromBytes(log.data),
       topics: log.topics.map((topic) => Hex.fromNumber(topic, { size: 32 })),
@@ -222,6 +389,58 @@ export function run(options: run.Options): Result {
     output,
     status: 'success',
   }
+}
+
+function chargeAccount(execution: Execution, address: string): void {
+  const { frame, hardfork, machine } = execution
+  const warm = journal_.isWarmAddress(machine.journal, address)
+  const gas = Hardfork.gas(hardfork)
+  const cost = warm ? gas.warmReadGas : gas.coldAccountAccessGas
+  if (cost > frame.gas) {
+    halt(machine, frame, 'out-of-gas')
+    return
+  }
+  frame.gas -= cost
+  if (!warm) journal_.warmAddress(machine.journal, address)
+}
+
+function transferValue(
+  execution: Execution,
+  options: {
+    from: Address.Address
+    state: State.Sync
+    to: Address.Address
+    value: bigint
+  },
+): void {
+  if (options.value === 0n || execution.machine.halt) return
+  const journal = execution.machine.journal
+  seedAccount(journal, options.state, options.from)
+  seedAccount(journal, options.state, options.to)
+
+  const account = journal_.getAccount(journal, options.from)
+  const balance = account?.balance ?? 0n
+  if (balance < options.value) {
+    halt(execution.machine, execution.frame, 'insufficient-balance')
+    return
+  }
+
+  journal_.setBalance(journal, options.from, balance - options.value)
+  const recipient = journal_.getAccount(journal, options.to)
+  journal_.setBalance(
+    journal,
+    options.to,
+    (recipient?.balance ?? 0n) + options.value,
+  )
+}
+
+function seedAccount(
+  journal: journal_.Journal,
+  state: State.Sync,
+  address: Address.Address,
+): void {
+  if (journal_.getAccount(journal, address) !== undefined) return
+  journal_.seed(journal, resolveSync(state, { address, kind: 'account' }))
 }
 
 const zeroAddress = '0x0000000000000000000000000000000000000000' as const

--- a/src/evm/_test/Evm.calls.test.ts
+++ b/src/evm/_test/Evm.calls.test.ts
@@ -13,6 +13,7 @@ const nobody = '0x00000000000000000000000000000000000000dd' as const
 const ret = '5f5260205ff3'
 // PUSH20 <address>.
 const push = (address: string) => `73${address.slice(2)}`
+const designate = (address: string) => `0xef0100${address.slice(2)}` as const
 // The five zero operands shared by every plain call: out and in windows plus
 // value. STATICCALL/DELEGATECALL variants use four (no value).
 const zeros = (n: number) => '5f'.repeat(n)
@@ -398,6 +399,143 @@ describe('STATICCALL', () => {
       state,
     })
     expect(returned(result)).toBe(word(1))
+  })
+})
+
+describe('EIP-7702 delegation', () => {
+  test.each([
+    {
+      expected: bob,
+      name: 'CALL',
+      opcode: 'f1',
+      operands: `6020${zeros(4)}`,
+    },
+    {
+      expected: self,
+      name: 'CALLCODE',
+      opcode: 'f2',
+      operands: `6020${zeros(4)}`,
+    },
+    {
+      expected: self,
+      name: 'DELEGATECALL',
+      opcode: 'f4',
+      operands: `6020${zeros(3)}`,
+    },
+    {
+      expected: bob,
+      name: 'STATICCALL',
+      opcode: 'fa',
+      operands: `6020${zeros(3)}`,
+    },
+  ])('$name executes delegated code in its normal context', (options) => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: { code: designate(carol) },
+        [carol]: { code: `0x30${ret}` },
+      },
+    })
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${options.operands}${push(bob)}61ffff${options.opcode}60205ff3`,
+      state,
+    })
+    expect(returned(result)).toBe(word(options.expected))
+  })
+
+  test('charges and warms the delegation target separately', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: { code: designate(carol) },
+        [carol]: { code: '0x00' },
+      },
+    })
+    const call = `${zeros(5)}${push(bob)}5ff1`
+    const result = Evm.run({
+      address: self,
+      bytecode: `0x${call}${call}${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(1))
+    // First call: 15 + two cold reads. Second: 15 + two warm reads. Tail: 13.
+    expect(result.gasUsed).toBe(5443n)
+  })
+
+  test('charges a warm read when an account delegates to itself', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: designate(bob) } },
+    })
+    const result = Evm.run({
+      bytecode: `0x${zeros(5)}${push(bob)}5ff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+    // Operands 15 + cold authority 2600 + warm self-delegate 100 + tail 13.
+    expect(result.gasUsed).toBe(2728n)
+  })
+
+  test('activates at Prague', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: { code: designate(carol) },
+        [carol]: { code: '0x00' },
+      },
+    })
+    const bytecode = `0x${zeros(5)}${push(bob)}61fffff1${ret}` as const
+    expect(returned(Evm.run({ bytecode, hardfork: 'cancun', state }))).toBe(
+      word(0),
+    )
+    expect(returned(Evm.run({ bytecode, hardfork: 'prague', state }))).toBe(
+      word(1),
+    )
+  })
+
+  test('requires a complete designator', () => {
+    const state = State.fromMemory({
+      accounts: { [bob]: { code: '0xef0100' } },
+    })
+    const result = Evm.run({
+      bytecode: `0x${zeros(5)}${push(bob)}5ff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+    expect(result.gasUsed).toBe(2628n)
+  })
+
+  test('follows only one delegation', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: { code: designate(carol) },
+        [carol]: { code: designate(nobody) },
+        [nobody]: { code: '0x00' },
+      },
+    })
+    const result = Evm.run({
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff1${ret}`,
+      state,
+    })
+    expect(returned(result)).toBe(word(0))
+  })
+
+  test('code-reading opcodes keep their specified views', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [bob]: { code: designate(carol) },
+        // CODESIZE, then return it.
+        [carol]: { code: `0x38${ret}` },
+      },
+    })
+    const delegated = Evm.run({
+      bytecode: `0x60205f5f5f5f${push(bob)}61fffff160205ff3`,
+      state,
+    })
+    expect(returned(delegated)).toBe(word(7))
+
+    const external = Evm.run({
+      bytecode: `0x${push(bob)}3b${ret}`,
+      state,
+    })
+    expect(returned(external)).toBe(word(23))
   })
 })
 

--- a/src/evm/_test/Evm.calls.test.ts
+++ b/src/evm/_test/Evm.calls.test.ts
@@ -474,6 +474,47 @@ describe('EIP-7702 delegation', () => {
     expect(result.gasUsed).toBe(2728n)
   })
 
+  test('fetches the delegated account before its code', () => {
+    const reads: string[] = []
+    const source = State.from({
+      async: false,
+      getAccount(address) {
+        reads.push(`account:${address}`)
+        if (address === bob)
+          return {
+            balance: 0n,
+            code: designate(carol),
+            hasStorage: false,
+            nonce: 0n,
+          }
+        if (address === carol)
+          return { balance: 0n, hasStorage: false, nonce: 0n }
+        return undefined
+      },
+      getBlockHash: () => `0x${'00'.repeat(32)}` as `0x${string}`,
+      getCode(address) {
+        reads.push(`code:${address}`)
+        return address === carol ? '0x00' : '0x'
+      },
+      getStorage: () => 0n,
+      putAccount() {},
+      putStorage() {},
+    })
+    const result = Evm.run({
+      bytecode: `0x${zeros(5)}${push(bob)}61fffff1${ret}`,
+      state: source,
+    })
+
+    expect(returned(result)).toBe(word(1))
+    expect(reads).toMatchInlineSnapshot(`
+      [
+        "account:0x00000000000000000000000000000000000000b0",
+        "account:0x00000000000000000000000000000000000000c1",
+        "code:0x00000000000000000000000000000000000000c1",
+      ]
+    `)
+  })
+
   test('activates at Prague', () => {
     const state = State.fromMemory({
       accounts: {

--- a/src/evm/_test/Evm.test-d.ts
+++ b/src/evm/_test/Evm.test-d.ts
@@ -1,4 +1,15 @@
-import { Evm } from 'ox/evm'
+import { Evm, State } from 'ox/evm'
+import { expectTypeOf } from 'vp/test'
+
+const state = State.fromMemory()
+const evm = Evm.from({ state })
+
+expectTypeOf(evm).toEqualTypeOf<Evm.Evm<State.Memory>>()
+expectTypeOf(
+  Evm.call(evm, {
+    to: '0x0000000000000000000000000000000000000000',
+  }),
+).toEqualTypeOf<Evm.Result>()
 
 const number: bigint | undefined = undefined
 

--- a/src/evm/_test/Evm.test.ts
+++ b/src/evm/_test/Evm.test.ts
@@ -1,15 +1,182 @@
-import { Evm } from 'ox/evm'
+import { Evm, State } from 'ox/evm'
 import { describe, expect, test } from 'vp/test'
 
 test('exports', () => {
   expect(Object.keys(Evm)).toMatchInlineSnapshot(`
     [
+      "from",
+      "call",
       "run",
       "assertSuccess",
       "RevertedError",
       "HaltedError",
     ]
   `)
+})
+
+describe('from', () => {
+  test('default', () => {
+    const state = State.fromMemory()
+    const evm = Evm.from({ state })
+
+    expect(evm.hardfork).toBe('osaka')
+    expect(evm.state).toBe(state)
+  })
+
+  test('error: unknown hardfork', () => {
+    expect(() =>
+      Evm.from({
+        // @ts-expect-error
+        hardfork: 'verkle',
+        state: State.fromMemory(),
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Hardfork.UnknownHardforkError: Unknown hardfork \`verkle\`.
+
+      Known hardforks: cancun, prague, osaka.]
+    `)
+  })
+})
+
+describe('call', () => {
+  const from = '0x00000000000000000000000000000000000000f0'
+  const to = '0x00000000000000000000000000000000000000c0'
+
+  test('default', () => {
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: {
+          // CALLER, ORIGIN, CALLVALUE, and CALLDATALOAD(0), returned as words.
+          [from]: { balance: 100n },
+          [to]: { code: '0x335f5232602052346040525f3560605260805ff3' },
+        },
+      }),
+    })
+    const result = Evm.call(evm, {
+      data: '0xdeadbeef',
+      from,
+      to,
+      value: 42n,
+    })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toMatchInlineSnapshot(
+      `"0x00000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000000f0000000000000000000000000000000000000000000000000000000000000002adeadbeef00000000000000000000000000000000000000000000000000000000"`,
+    )
+  })
+
+  test('discards state changes', () => {
+    const state = State.fromMemory({
+      accounts: {
+        // SSTORE(1, 42), then return SLOAD(1).
+        [to]: { code: '0x602a6001556001545f5260205ff3' },
+      },
+    })
+    const result = Evm.call(Evm.from({ state }), { to })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toBe(
+      '0x000000000000000000000000000000000000000000000000000000000000002a',
+    )
+    expect(state.getStorage(to, 1n)).toBe(0n)
+  })
+
+  test('applies value ephemerally', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [from]: { balance: 100n },
+        // SELFBALANCE, return the word.
+        [to]: { balance: 5n, code: '0x475f5260205ff3' },
+      },
+    })
+    const result = Evm.call(Evm.from({ state }), { from, to, value: 42n })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toBe(
+      '0x000000000000000000000000000000000000000000000000000000000000002f',
+    )
+    expect(state.getAccount(from)?.balance).toBe(100n)
+    expect(state.getAccount(to)?.balance).toBe(5n)
+  })
+
+  test('halts when value exceeds the sender balance', () => {
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: { [from]: { balance: 41n }, [to]: {} },
+      }),
+    })
+
+    expect(Evm.call(evm, { from, gas: 100n, to, value: 42n }))
+      .toMatchInlineSnapshot(`
+        {
+          "gasUsed": 100n,
+          "reason": "insufficient-balance",
+          "status": "halted",
+        }
+      `)
+  })
+
+  test('executes delegated code in the authority context', () => {
+    const delegate = '0x00000000000000000000000000000000000000d0'
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: {
+          [delegate]: { code: '0x305f5260205ff3' },
+          [to]: { code: `0xef0100${delegate.slice(2)}` },
+        },
+      }),
+    })
+    const result = Evm.call(evm, { to })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toBe(
+      '0x00000000000000000000000000000000000000000000000000000000000000c0',
+    )
+  })
+
+  test('warms the delegation target', () => {
+    const delegate = '0x00000000000000000000000000000000000000d0'
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: {
+          // PUSH20 delegate, BALANCE, POP, STOP.
+          [delegate]: { code: `0x73${delegate.slice(2)}315000` },
+          [to]: { code: `0xef0100${delegate.slice(2)}` },
+        },
+      }),
+    })
+
+    expect(Evm.call(evm, { to })).toMatchInlineSnapshot(`
+      {
+        "gasRefund": 0n,
+        "gasUsed": 2705n,
+        "logs": [],
+        "output": "0x",
+        "status": "success",
+      }
+    `)
+  })
+
+  test('does not follow delegations before Prague', () => {
+    const delegate = '0x00000000000000000000000000000000000000d0'
+    const evm = Evm.from({
+      hardfork: 'cancun',
+      state: State.fromMemory({
+        accounts: {
+          [delegate]: { code: '0x00' },
+          [to]: { code: `0xef0100${delegate.slice(2)}` },
+        },
+      }),
+    })
+
+    expect(Evm.call(evm, { gas: 100n, to })).toMatchInlineSnapshot(`
+      {
+        "gasUsed": 100n,
+        "reason": "invalid-opcode",
+        "status": "halted",
+      }
+    `)
+  })
 })
 
 describe('run', () => {

--- a/src/evm/_test/eest.test.ts
+++ b/src/evm/_test/eest.test.ts
@@ -172,6 +172,7 @@ describe('EEST adapter', () => {
         value: 0n,
       }),
     ).toBe('success')
+    expect(adapter.gasLeft()).toBe(75_294n)
     expect(adapter.readStorage().get(authority)).toMatchInlineSnapshot(`
       Map {
         1n => 42n,

--- a/src/evm/_test/eest.test.ts
+++ b/src/evm/_test/eest.test.ts
@@ -130,7 +130,7 @@ describe('transaction validity', () => {
   })
 })
 
-describe('ts', () => {
+describe('EEST adapter', () => {
   test('executes a top-level delegation in the authority context', () => {
     const authority = '0x00000000000000000000000000000000000000a0'
     const delegate = '0x00000000000000000000000000000000000000d0'

--- a/src/evm/_test/eest.test.ts
+++ b/src/evm/_test/eest.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative } from 'node:path'
+import { Hex } from 'ox'
 import { describe, expect, test } from 'vp/test'
 
 import * as eest from '../../../test/evm/eest.js'
@@ -20,7 +21,7 @@ import * as eest from '../../../test/evm/eest.js'
 // precompile-dependent cases, stEIP150*, stMemExpandingEIP150Calls,
 // stLogTests, vmLogTest, most vmIOandFlowOperations and
 // vmBitwiseLogicOperation, the reentrant transient-storage and MCOPY slices,
-// and prague/eip7702_set_code_tx (delegation reads land with PR 4).
+// and most prague/eip7702_set_code_tx transaction cases.
 //
 // Runs offline: `SKIP_GLOBAL_SETUP=1 pnpm test src/evm --project core`.
 
@@ -126,5 +127,55 @@ describe('transaction validity', () => {
     }
     const result = eest.runCase(eest.ts(), case_, 'Prague', post)
     expect(result.rejected).toBe(true)
+  })
+})
+
+describe('ts', () => {
+  test('executes a top-level delegation in the authority context', () => {
+    const authority = '0x00000000000000000000000000000000000000a0'
+    const delegate = '0x00000000000000000000000000000000000000d0'
+    const adapter = eest.ts()
+    adapter.reset()
+    adapter.putAccount(authority, {
+      balance: 0n,
+      code: Hex.toBytes(`0xef0100${delegate.slice(2)}`),
+      nonce: 0n,
+    })
+    adapter.putAccount(delegate, {
+      balance: 0n,
+      code: Hex.toBytes('0x602a600155'),
+      nonce: 0n,
+    })
+    adapter.setContext({
+      baseFee: 0n,
+      blobBaseFee: 1n,
+      blobHashes: [],
+      chainHashes: [],
+      chainId: 1n,
+      coinbase: '0x0000000000000000000000000000000000000000',
+      fork: 'Prague',
+      gasLimit: 30_000_000n,
+      gasPrice: 0n,
+      number: 1n,
+      origin: authority,
+      prevRandao: 0n,
+      timestamp: 1n,
+    })
+    adapter.warmAccount(authority)
+
+    expect(
+      adapter.execute({
+        address: authority,
+        caller: authority,
+        data: new Uint8Array(0),
+        gas: 100_000n,
+        value: 0n,
+      }),
+    ).toBe('success')
+    expect(adapter.readStorage().get(authority)).toMatchInlineSnapshot(`
+      Map {
+        1n => 42n,
+      }
+    `)
   })
 })

--- a/src/evm/internal/delegation.ts
+++ b/src/evm/internal/delegation.ts
@@ -1,0 +1,13 @@
+import * as Hex from '../../core/Hex.js'
+
+/** Returns the address in a complete EIP-7702 delegation designator. */
+export function getAddress(code: Uint8Array): string | undefined {
+  if (
+    code.length !== 23 ||
+    code[0] !== 0xef ||
+    code[1] !== 0x01 ||
+    code[2] !== 0x00
+  )
+    return undefined
+  return Hex.fromBytes(code.subarray(3))
+}

--- a/src/evm/internal/instructions.ts
+++ b/src/evm/internal/instructions.ts
@@ -4,6 +4,7 @@ import * as ContractAddress from '../../core/ContractAddress.js'
 import * as Hex from '../../core/Hex.js'
 import * as Hardfork from '../Hardfork.js'
 import { analyzed } from './analysis.js'
+import * as delegation from './delegation.js'
 import * as journal from './journal.js'
 import {
   bitLength,
@@ -79,6 +80,7 @@ export function table(hardfork: Hardfork.Hardfork): Table {
 
 function build(hardfork: Hardfork.Hardfork): Table {
   const table = Array.from<Instruction | undefined>({ length: 256 })
+  const delegationEnabled = Hardfork.atLeast(hardfork, 'prague')
 
   // Control
 
@@ -545,11 +547,11 @@ function build(hardfork: Hardfork.Hardfork): Table {
   // Calls
 
   table[0xf0] = createOp(0xf0)
-  table[0xf1] = callOp(0xf1)
-  table[0xf2] = callOp(0xf2)
-  table[0xf4] = callOp(0xf4)
+  table[0xf1] = callOp(0xf1, delegationEnabled)
+  table[0xf2] = callOp(0xf2, delegationEnabled)
+  table[0xf4] = callOp(0xf4, delegationEnabled)
   table[0xf5] = createOp(0xf5)
-  table[0xfa] = callOp(0xfa)
+  table[0xfa] = callOp(0xfa, delegationEnabled)
 
   // Stack, memory & flow
 
@@ -747,7 +749,7 @@ function createOp(opcode: number): Instruction {
 // STATICCALL (0xfa). Only CALL and CALLCODE take a value operand, and only
 // CALL moves it — CALLCODE runs foreign code in the caller's own account, so
 // its value never leaves and is there for the stipend and CALLVALUE.
-function callOp(opcode: number): Instruction {
+function callOp(opcode: number, delegationEnabled: boolean): Instruction {
   const hasValue = opcode === 0xf1 || opcode === 0xf2
   return op(0n, hasValue ? 7 : 6, 1, (f, m) => {
     const gasArg = pop(f)
@@ -773,10 +775,22 @@ function callOp(opcode: number): Instruction {
       need(m, { address: to, kind: 'account' })
       return
     }
-    const code = journal.getCode(m.journal, to)
+    let code = journal.getCode(m.journal, to)
     if (code === undefined) {
       need(m, { address: to, kind: 'code' })
       return
+    }
+    const delegatedTo = delegationEnabled
+      ? delegation.getAddress(code)
+      : undefined
+    if (delegatedTo) {
+      // EIP-7702 follows exactly one designator, so delegated code is never
+      // parsed again even when it is itself a designator.
+      code = journal.getCode(m.journal, delegatedTo)
+      if (code === undefined) {
+        need(m, { address: delegatedTo, kind: 'code' })
+        return
+      }
     }
     const own = value !== 0n ? journal.getAccount(m.journal, f.address) : null
     if (own === undefined) {
@@ -790,6 +804,7 @@ function callOp(opcode: number): Instruction {
     if (!expandMemory(m, f, inOffset, inLength)) return
     if (!expandMemory(m, f, outOffset, outLength)) return
     if (!chargeAccount(f, m, to)) return
+    if (delegatedTo && !chargeAccount(f, m, delegatedTo)) return
     if (value !== 0n) {
       let cost = 9000n
       // A value-bearing CALL to a dead account (EIP-161 empty) pays to

--- a/src/evm/internal/instructions.ts
+++ b/src/evm/internal/instructions.ts
@@ -786,6 +786,11 @@ function callOp(opcode: number, delegationEnabled: boolean): Instruction {
     if (delegatedTo) {
       // EIP-7702 follows exactly one designator, so delegated code is never
       // parsed again even when it is itself a designator.
+      const delegatedAccount = journal.getAccount(m.journal, delegatedTo)
+      if (delegatedAccount === undefined) {
+        need(m, { address: delegatedTo, kind: 'account' })
+        return
+      }
       code = journal.getCode(m.journal, delegatedTo)
       if (code === undefined) {
         need(m, { address: delegatedTo, kind: 'code' })

--- a/test/evm/eest.ts
+++ b/test/evm/eest.ts
@@ -231,6 +231,7 @@ export type Status =
   | 'create-collision'
   | 'initcode-size-exceeded'
   | 'input-too-large'
+  | 'insufficient-balance'
   | 'invalid-code'
   | 'invalid-jump'
   | 'invalid-opcode'

--- a/test/evm/eest.ts
+++ b/test/evm/eest.ts
@@ -34,6 +34,7 @@ import * as Rlp from '../../src/core/Rlp.js'
 import * as Secp256k1 from '../../src/core/Secp256k1.js'
 import type * as Hardfork from '../../src/evm/Hardfork.js'
 import { analyzed } from '../../src/evm/internal/analysis.js'
+import * as delegation from '../../src/evm/internal/delegation.js'
 import { table } from '../../src/evm/internal/instructions.js'
 import { execute as interpret } from '../../src/evm/internal/interpreter.js'
 import * as journal_ from '../../src/evm/internal/journal.js'
@@ -1618,10 +1619,16 @@ export function ts(): Adapter {
       logs = []
       const journal = journal_.create()
       const address = frame.address.toLowerCase()
+      const designation = forkAtLeast((context as Context).fork, 'Prague')
+        ? delegation.getAddress(accounts.get(address)?.code ?? empty)
+        : undefined
+      if (designation) warmAddresses.add(designation)
       const { frame: top, machine } = runFrame(journal, {
         address,
         caller: frame.caller.toLowerCase(),
-        code: accounts.get(address)?.code ?? empty,
+        code: designation
+          ? (accounts.get(designation)?.code ?? empty)
+          : (accounts.get(address)?.code ?? empty),
         data: frame.data,
         gas: frame.gas,
         static: frame.static ?? false,

--- a/test/evm/eest.ts
+++ b/test/evm/eest.ts
@@ -1623,7 +1623,17 @@ export function ts(): Adapter {
       const designation = forkAtLeast((context as Context).fork, 'Prague')
         ? delegation.getAddress(accounts.get(address)?.code ?? empty)
         : undefined
-      if (designation) warmAddresses.add(designation)
+      let gas = frame.gas
+      if (designation) {
+        const cost = warmAddresses.has(designation) ? 100n : 2600n
+        if (cost > gas) {
+          gasLeft = 0n
+          output = empty
+          return 'out-of-gas'
+        }
+        gas -= cost
+        warmAddresses.add(designation)
+      }
       const { frame: top, machine } = runFrame(journal, {
         address,
         caller: frame.caller.toLowerCase(),
@@ -1631,7 +1641,7 @@ export function ts(): Adapter {
           ? (accounts.get(designation)?.code ?? empty)
           : (accounts.get(address)?.code ?? empty),
         data: frame.data,
-        gas: frame.gas,
+        gas,
         static: frame.static ?? false,
         value: frame.value,
       })


### PR DESCRIPTION
Added Prague-gated EIP-7702 code resolution for `CALL`, `CALLCODE`, `DELEGATECALL`, and `STATICCALL`, including one-hop semantics and warm/cold access charges. The conformance adapter now resolves top-level delegations.