### PR TITLE
feat(evm): add call API

### DIFF
--- a/.changeset/evm-entrypoint.md
+++ b/.changeset/evm-entrypoint.md
@@ -2,4 +2,4 @@
 "ox": minor
 ---
 
-Added `ox/evm` with nested calls, `CREATE`/`CREATE2`, EIP-7702 delegation reads, and pluggable state sources with synchronized storage metadata.
+Added `ox/evm` with configured ephemeral calls, nested calls, `CREATE`/`CREATE2`, EIP-7702 delegation reads, and pluggable state sources with synchronized storage metadata.

--- a/src/evm/Evm.ts
+++ b/src/evm/Evm.ts
@@ -9,7 +9,13 @@ import * as delegation from './internal/delegation.js'
 import { table } from './internal/instructions.js'
 import { execute } from './internal/interpreter.js'
 import * as journal_ from './internal/journal.js'
-import { addressToWord, createFrame, type Machine } from './internal/machine.js'
+import {
+  addressToWord,
+  createFrame,
+  halt,
+  type Frame,
+  type Machine,
+} from './internal/machine.js'
 
 /** Why execution stopped exceptionally. Exceptional halts consume all gas. */
 export type HaltReason =
@@ -17,6 +23,7 @@ export type HaltReason =
   | 'code-size-exceeded'
   | 'create-collision'
   | 'initcode-size-exceeded'
+  | 'insufficient-balance'
   | 'invalid-jump'
   | 'invalid-opcode'
   | 'memory-limit'
@@ -162,6 +169,7 @@ export declare namespace from {
  */
 export function call(evm: Evm, options: call.Options): Result {
   const { hardfork, state } = evm
+  const from = (options.from ?? zeroAddress).toLowerCase() as Address.Address
   const to = options.to.toLowerCase() as Address.Address
   const code = getCode(state, to)
   const delegatedTo = Hardfork.atLeast(hardfork, 'prague')
@@ -171,27 +179,25 @@ export function call(evm: Evm, options: call.Options): Result {
     ? getCode(state, delegatedTo as Address.Address)
     : code
 
-  return executeRun(
-    {
-      address: to,
-      blobHashes: options.blobHashes,
-      block: options.block,
-      bytecode,
-      caller: options.from,
-      chainId: options.chainId,
-      data: options.data,
-      gas: options.gas,
-      gasPrice: options.gasPrice,
-      hardfork,
-      origin: options.from,
-      state,
-      value: options.value,
-    },
-    {
-      persist: false,
-      warmAddresses: delegatedTo ? [delegatedTo] : [],
-    },
-  )
+  const execution = createExecution({
+    address: to,
+    blobHashes: options.blobHashes,
+    block: options.block,
+    bytecode,
+    caller: from,
+    chainId: options.chainId,
+    data: options.data,
+    gas: options.gas,
+    gasPrice: options.gasPrice,
+    hardfork,
+    origin: from,
+    state,
+    value: options.value,
+  })
+
+  if (delegatedTo) chargeAccount(execution, delegatedTo)
+  transferValue(execution, { from, state, to, value: options.value ?? 0n })
+  return executeRun(execution)
 }
 
 export declare namespace call {
@@ -278,16 +284,22 @@ function getCode(state: State.Sync, address: Address.Address): Uint8Array {
  * @returns The execution result.
  */
 export function run(options: run.Options): Result {
-  return executeRun(options, { persist: true, warmAddresses: [] })
+  const execution = createExecution(options)
+  const result = executeRun(execution)
+  if (options.state && result.status === 'success')
+    commit(execution.machine.journal, options.state)
+  return result
 }
 
-function executeRun(
-  options: run.Options,
-  behavior: {
-    persist: boolean
-    warmAddresses: readonly string[]
-  },
-): Result {
+type Execution = {
+  frame: Frame
+  gas: bigint
+  hardfork: Hardfork.Hardfork
+  machine: Machine
+  state: State.Sync | undefined
+}
+
+function createExecution(options: run.Options): Execution {
   const {
     address = zeroAddress,
     blobHashes = [],
@@ -349,12 +361,15 @@ function executeRun(
   journal_.warmAddress(journal, frame.address)
   journal_.warmAddress(journal, origin.toLowerCase())
   journal_.warmAddress(journal, caller.toLowerCase())
-  for (const address of behavior.warmAddresses)
-    journal_.warmAddress(journal, address)
 
+  return { frame, gas, hardfork, machine, state }
+}
+
+function executeRun(execution: Execution): Result {
+  const { frame, gas, machine, state } = execution
   let request = execute(machine)
   while (request !== undefined) {
-    journal_.seed(journal, resolveSync(state, request))
+    journal_.seed(machine.journal, resolveSync(state, request))
     request = execute(machine)
   }
 
@@ -363,11 +378,10 @@ function executeRun(
   const output = frame.output ? Hex.fromBytes(frame.output) : '0x'
   if (machine.reverted) return { gasUsed, output, status: 'reverted' }
 
-  if (state && behavior.persist) commit(journal, state)
   return {
-    gasRefund: journal.refund,
+    gasRefund: machine.journal.refund,
     gasUsed,
-    logs: journal.logs.map((log) => ({
+    logs: machine.journal.logs.map((log) => ({
       address: Address.checksum(log.address),
       data: Hex.fromBytes(log.data),
       topics: log.topics.map((topic) => Hex.fromNumber(topic, { size: 32 })),
@@ -375,6 +389,58 @@ function executeRun(
     output,
     status: 'success',
   }
+}
+
+function chargeAccount(execution: Execution, address: string): void {
+  const { frame, hardfork, machine } = execution
+  const warm = journal_.isWarmAddress(machine.journal, address)
+  const gas = Hardfork.gas(hardfork)
+  const cost = warm ? gas.warmReadGas : gas.coldAccountAccessGas
+  if (cost > frame.gas) {
+    halt(machine, frame, 'out-of-gas')
+    return
+  }
+  frame.gas -= cost
+  if (!warm) journal_.warmAddress(machine.journal, address)
+}
+
+function transferValue(
+  execution: Execution,
+  options: {
+    from: Address.Address
+    state: State.Sync
+    to: Address.Address
+    value: bigint
+  },
+): void {
+  if (options.value === 0n || execution.machine.halt) return
+  const journal = execution.machine.journal
+  seedAccount(journal, options.state, options.from)
+  seedAccount(journal, options.state, options.to)
+
+  const account = journal_.getAccount(journal, options.from)
+  const balance = account?.balance ?? 0n
+  if (balance < options.value) {
+    halt(execution.machine, execution.frame, 'insufficient-balance')
+    return
+  }
+
+  journal_.setBalance(journal, options.from, balance - options.value)
+  const recipient = journal_.getAccount(journal, options.to)
+  journal_.setBalance(
+    journal,
+    options.to,
+    (recipient?.balance ?? 0n) + options.value,
+  )
+}
+
+function seedAccount(
+  journal: journal_.Journal,
+  state: State.Sync,
+  address: Address.Address,
+): void {
+  if (journal_.getAccount(journal, address) !== undefined) return
+  journal_.seed(journal, resolveSync(state, { address, kind: 'account' }))
 }
 
 const zeroAddress = '0x0000000000000000000000000000000000000000' as const

--- a/src/evm/Evm.ts
+++ b/src/evm/Evm.ts
@@ -5,6 +5,7 @@ import type { Compute, ExactPartial } from '../core/internal/types.js'
 import * as State from './State.js'
 import * as Hardfork from './Hardfork.js'
 import { analyzed } from './internal/analysis.js'
+import * as delegation from './internal/delegation.js'
 import { table } from './internal/instructions.js'
 import { execute } from './internal/interpreter.js'
 import * as journal_ from './internal/journal.js'
@@ -84,6 +85,146 @@ export type Result =
       gasUsed: bigint
     }>
 
+/** Root type for a configured EVM. */
+export type Evm<state extends State.Sync = State.Sync> = Compute<{
+  /** Hardfork whose rules calls execute under. */
+  hardfork: Hardfork.Hardfork
+  /** State source calls read without mutating. */
+  state: state
+}>
+
+/**
+ * Configures an EVM over a synchronous state source.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Evm, State } from 'ox/evm'
+ *
+ * const evm = Evm.from({
+ *   hardfork: 'osaka',
+ *   state: State.fromMemory(),
+ * })
+ * ```
+ *
+ * @param options - Options.
+ * @returns A configured EVM.
+ */
+export function from<const state extends State.Sync>(
+  options: from.Options<state>,
+): Evm<state> {
+  const hardfork = options.hardfork ?? Hardfork.latest
+  Hardfork.atLeast(hardfork, 'cancun')
+  return {
+    hardfork,
+    state: State.from(options.state),
+  }
+}
+
+export declare namespace from {
+  type Options<state extends State.Sync = State.Sync> = {
+    /** Hardfork whose rules calls execute under. @default Hardfork.latest */
+    hardfork?: Hardfork.Hardfork | undefined
+    /** State source calls read without mutating. */
+    state: state
+  }
+
+  type ErrorType =
+    | Hardfork.UnknownHardforkError
+    | State.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Executes an ephemeral call against configured state.
+ *
+ * State changes are visible during execution but are discarded afterward.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Evm, State } from 'ox/evm'
+ *
+ * const to = '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357'
+ * const evm = Evm.from({
+ *   state: State.fromMemory({
+ *     accounts: { [to]: { code: '0x602a5f5260205ff3' } },
+ *   }),
+ * })
+ *
+ * const result = Evm.call(evm, { to })
+ * Evm.assertSuccess(result)
+ * result.output
+ * // @log: '0x000000000000000000000000000000000000000000000000000000000000002a'
+ * ```
+ *
+ * @param evm - Configured EVM.
+ * @param options - Call options.
+ * @returns The execution result.
+ */
+export function call(evm: Evm, options: call.Options): Result {
+  const { hardfork, state } = evm
+  const to = options.to.toLowerCase() as Address.Address
+  const code = getCode(state, to)
+  const delegatedTo = Hardfork.atLeast(hardfork, 'prague')
+    ? delegation.getAddress(code)
+    : undefined
+  const bytecode = delegatedTo
+    ? getCode(state, delegatedTo as Address.Address)
+    : code
+
+  return executeRun(
+    {
+      address: to,
+      blobHashes: options.blobHashes,
+      block: options.block,
+      bytecode,
+      caller: options.from,
+      chainId: options.chainId,
+      data: options.data,
+      gas: options.gas,
+      gasPrice: options.gasPrice,
+      hardfork,
+      origin: options.from,
+      state,
+      value: options.value,
+    },
+    {
+      persist: false,
+      warmAddresses: delegatedTo ? [delegatedTo] : [],
+    },
+  )
+}
+
+export declare namespace call {
+  type Options = {
+    /** Versioned blob hashes for `BLOBHASH`. */
+    blobHashes?: readonly Hex.Hex[] | undefined
+    /** Block environment. Omitted fields default to zero-like values. */
+    block?: ExactPartial<BlockEnv> | undefined
+    /** `CHAINID`. @default 1n */
+    chainId?: bigint | undefined
+    /** Calldata. @default '0x' */
+    data?: Hex.Hex | Uint8Array | undefined
+    /** Sender exposed through `CALLER` and `ORIGIN`. @default zero address */
+    from?: Address.Address | undefined
+    /** Gas available to execution. @default 30_000_000n */
+    gas?: bigint | undefined
+    /** `GASPRICE`. @default 0n */
+    gasPrice?: bigint | undefined
+    /** Account whose code and storage context execute. */
+    to: Address.Address
+    /** `CALLVALUE`. @default 0n */
+    value?: bigint | undefined
+  }
+
+  type ErrorType = run.ErrorType
+}
+
+function getCode(state: State.Sync, address: Address.Address): Uint8Array {
+  const account = state.getAccount(address)
+  if (!account) return new Uint8Array(0)
+  return Hex.toBytes(account.code ?? state.getCode(address))
+}
+
 /**
  * Executes bytecode as a top-level call frame, synchronously.
  *
@@ -137,6 +278,16 @@ export type Result =
  * @returns The execution result.
  */
 export function run(options: run.Options): Result {
+  return executeRun(options, { persist: true, warmAddresses: [] })
+}
+
+function executeRun(
+  options: run.Options,
+  behavior: {
+    persist: boolean
+    warmAddresses: readonly string[]
+  },
+): Result {
   const {
     address = zeroAddress,
     blobHashes = [],
@@ -198,6 +349,8 @@ export function run(options: run.Options): Result {
   journal_.warmAddress(journal, frame.address)
   journal_.warmAddress(journal, origin.toLowerCase())
   journal_.warmAddress(journal, caller.toLowerCase())
+  for (const address of behavior.warmAddresses)
+    journal_.warmAddress(journal, address)
 
   let request = execute(machine)
   while (request !== undefined) {
@@ -210,7 +363,7 @@ export function run(options: run.Options): Result {
   const output = frame.output ? Hex.fromBytes(frame.output) : '0x'
   if (machine.reverted) return { gasUsed, output, status: 'reverted' }
 
-  if (state) commit(journal, state)
+  if (state && behavior.persist) commit(journal, state)
   return {
     gasRefund: journal.refund,
     gasUsed,

--- a/src/evm/Evm.ts
+++ b/src/evm/Evm.ts
@@ -102,7 +102,7 @@ export type Evm<state extends State.Sync = State.Sync> = Compute<{
  *
  * const evm = Evm.from({
  *   hardfork: 'osaka',
- *   state: State.fromMemory(),
+ *   state: State.fromMemory()
  * })
  * ```
  *
@@ -146,8 +146,8 @@ export declare namespace from {
  * const to = '0x9f1fdab6458c5fc642fa0f4c5af7473c46837357'
  * const evm = Evm.from({
  *   state: State.fromMemory({
- *     accounts: { [to]: { code: '0x602a5f5260205ff3' } },
- *   }),
+ *     accounts: { [to]: { code: '0x602a5f5260205ff3' } }
+ *   })
  * })
  *
  * const result = Evm.call(evm, { to })

--- a/src/evm/_test/Evm.test-d.ts
+++ b/src/evm/_test/Evm.test-d.ts
@@ -1,4 +1,15 @@
-import { Evm } from 'ox/evm'
+import { Evm, State } from 'ox/evm'
+import { expectTypeOf } from 'vp/test'
+
+const state = State.fromMemory()
+const evm = Evm.from({ state })
+
+expectTypeOf(evm).toEqualTypeOf<Evm.Evm<State.Memory>>()
+expectTypeOf(
+  Evm.call(evm, {
+    to: '0x0000000000000000000000000000000000000000',
+  }),
+).toEqualTypeOf<Evm.Result>()
 
 const number: bigint | undefined = undefined
 

--- a/src/evm/_test/Evm.test.ts
+++ b/src/evm/_test/Evm.test.ts
@@ -1,15 +1,146 @@
-import { Evm } from 'ox/evm'
+import { Evm, State } from 'ox/evm'
 import { describe, expect, test } from 'vp/test'
 
 test('exports', () => {
   expect(Object.keys(Evm)).toMatchInlineSnapshot(`
     [
+      "from",
+      "call",
       "run",
       "assertSuccess",
       "RevertedError",
       "HaltedError",
     ]
   `)
+})
+
+describe('from', () => {
+  test('default', () => {
+    const state = State.fromMemory()
+    const evm = Evm.from({ state })
+
+    expect(evm.hardfork).toBe('osaka')
+    expect(evm.state).toBe(state)
+  })
+
+  test('error: unknown hardfork', () => {
+    expect(() =>
+      Evm.from({
+        // @ts-expect-error
+        hardfork: 'verkle',
+        state: State.fromMemory(),
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Hardfork.UnknownHardforkError: Unknown hardfork \`verkle\`.
+
+      Known hardforks: cancun, prague, osaka.]
+    `)
+  })
+})
+
+describe('call', () => {
+  const from = '0x00000000000000000000000000000000000000f0'
+  const to = '0x00000000000000000000000000000000000000c0'
+
+  test('default', () => {
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: {
+          // CALLER, ORIGIN, CALLVALUE, and CALLDATALOAD(0), returned as words.
+          [to]: { code: '0x335f5232602052346040525f3560605260805ff3' },
+        },
+      }),
+    })
+    const result = Evm.call(evm, {
+      data: '0xdeadbeef',
+      from,
+      to,
+      value: 42n,
+    })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toMatchInlineSnapshot(
+      `"0x00000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000000f0000000000000000000000000000000000000000000000000000000000000002adeadbeef00000000000000000000000000000000000000000000000000000000"`,
+    )
+  })
+
+  test('discards state changes', () => {
+    const state = State.fromMemory({
+      accounts: {
+        // SSTORE(1, 42), then return SLOAD(1).
+        [to]: { code: '0x602a6001556001545f5260205ff3' },
+      },
+    })
+    const result = Evm.call(Evm.from({ state }), { to })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toBe(
+      '0x000000000000000000000000000000000000000000000000000000000000002a',
+    )
+    expect(state.getStorage(to, 1n)).toBe(0n)
+  })
+
+  test('executes delegated code in the authority context', () => {
+    const delegate = '0x00000000000000000000000000000000000000d0'
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: {
+          [delegate]: { code: '0x305f5260205ff3' },
+          [to]: { code: `0xef0100${delegate.slice(2)}` },
+        },
+      }),
+    })
+    const result = Evm.call(evm, { to })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toBe(
+      '0x00000000000000000000000000000000000000000000000000000000000000c0',
+    )
+  })
+
+  test('warms the delegation target', () => {
+    const delegate = '0x00000000000000000000000000000000000000d0'
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: {
+          // PUSH20 delegate, BALANCE, POP, STOP.
+          [delegate]: { code: `0x73${delegate.slice(2)}315000` },
+          [to]: { code: `0xef0100${delegate.slice(2)}` },
+        },
+      }),
+    })
+
+    expect(Evm.call(evm, { to })).toMatchInlineSnapshot(`
+      {
+        "gasRefund": 0n,
+        "gasUsed": 105n,
+        "logs": [],
+        "output": "0x",
+        "status": "success",
+      }
+    `)
+  })
+
+  test('does not follow delegations before Prague', () => {
+    const delegate = '0x00000000000000000000000000000000000000d0'
+    const evm = Evm.from({
+      hardfork: 'cancun',
+      state: State.fromMemory({
+        accounts: {
+          [delegate]: { code: '0x00' },
+          [to]: { code: `0xef0100${delegate.slice(2)}` },
+        },
+      }),
+    })
+
+    expect(Evm.call(evm, { gas: 100n, to })).toMatchInlineSnapshot(`
+      {
+        "gasUsed": 100n,
+        "reason": "invalid-opcode",
+        "status": "halted",
+      }
+    `)
+  })
 })
 
 describe('run', () => {

--- a/src/evm/_test/Evm.test.ts
+++ b/src/evm/_test/Evm.test.ts
@@ -47,6 +47,7 @@ describe('call', () => {
       state: State.fromMemory({
         accounts: {
           // CALLER, ORIGIN, CALLVALUE, and CALLDATALOAD(0), returned as words.
+          [from]: { balance: 100n },
           [to]: { code: '0x335f5232602052346040525f3560605260805ff3' },
         },
       }),
@@ -78,6 +79,41 @@ describe('call', () => {
       '0x000000000000000000000000000000000000000000000000000000000000002a',
     )
     expect(state.getStorage(to, 1n)).toBe(0n)
+  })
+
+  test('applies value ephemerally', () => {
+    const state = State.fromMemory({
+      accounts: {
+        [from]: { balance: 100n },
+        // SELFBALANCE, return the word.
+        [to]: { balance: 5n, code: '0x475f5260205ff3' },
+      },
+    })
+    const result = Evm.call(Evm.from({ state }), { from, to, value: 42n })
+
+    Evm.assertSuccess(result)
+    expect(result.output).toBe(
+      '0x000000000000000000000000000000000000000000000000000000000000002f',
+    )
+    expect(state.getAccount(from)?.balance).toBe(100n)
+    expect(state.getAccount(to)?.balance).toBe(5n)
+  })
+
+  test('halts when value exceeds the sender balance', () => {
+    const evm = Evm.from({
+      state: State.fromMemory({
+        accounts: { [from]: { balance: 41n }, [to]: {} },
+      }),
+    })
+
+    expect(Evm.call(evm, { from, gas: 100n, to, value: 42n }))
+      .toMatchInlineSnapshot(`
+        {
+          "gasUsed": 100n,
+          "reason": "insufficient-balance",
+          "status": "halted",
+        }
+      `)
   })
 
   test('executes delegated code in the authority context', () => {
@@ -113,7 +149,7 @@ describe('call', () => {
     expect(Evm.call(evm, { to })).toMatchInlineSnapshot(`
       {
         "gasRefund": 0n,
-        "gasUsed": 105n,
+        "gasUsed": 2705n,
         "logs": [],
         "output": "0x",
         "status": "success",

--- a/test/evm/eest.ts
+++ b/test/evm/eest.ts
@@ -231,6 +231,7 @@ export type Status =
   | 'create-collision'
   | 'initcode-size-exceeded'
   | 'input-too-large'
+  | 'insufficient-balance'
   | 'invalid-code'
   | 'invalid-jump'
   | 'invalid-opcode'


### PR DESCRIPTION
Adds configured `Evm.from` instances and ephemeral `Evm.call` execution against synchronous state, including EIP-7702 delegation resolution, so callers can execute state-aware calls without persisting journal changes.