### PR TITLE
fix: Json.stringify with replacer no longer drops bigint support

### DIFF
--- a/.changeset/json-stringify-replacer-bigint.md
+++ b/.changeset/json-stringify-replacer-bigint.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Fixed `Json.stringify` throwing `TypeError` when a replacer returned a `bigint` unchanged.

--- a/src/core/Json.ts
+++ b/src/core/Json.ts
@@ -147,7 +147,7 @@ export function stringify(
   return JSON.stringify(
     value,
     (key, value) => {
-      if (typeof replacer === 'function') return replacer(key, value)
+      if (typeof replacer === 'function') value = replacer(key, value)
       if (typeof value === 'bigint') return value.toString() + bigIntSuffix
       return value
     },

--- a/src/core/_test/Json.test.ts
+++ b/src/core/_test/Json.test.ts
@@ -177,6 +177,12 @@ describe('Json.stringify', () => {
     ).toEqual('{"foo":"bar","baz":{"value":"69!"}}')
   })
 
+  test('args: replacer with bigint returned unchanged', () => {
+    expect(
+      Json.stringify({ a: 5n }, (_key, value) => value),
+    ).toMatchInlineSnapshot(`"{"a":"5#__bigint"}"`)
+  })
+
   test('args: space', () => {
     expect(
       Json.stringify(


### PR DESCRIPTION
`Json.stringify` with a replacer currently returns the replacer's result directly, bypassing the `#__bigint` suffix encoding.

This means that a replacer that returns a `bigint` unchanged (like a key-filtering replacer) causes `JSON.stringify` to throw `TypeError: Do not know how to serialize a BigInt`, while the same call without a replacer works fine.

This PR fixes this by not returning early to apply the `#__bigint` suffix afterwards if the value is still a `bigint`.