### PR TITLE
fix(evm): report every failure the block and list operations raise

### DIFF
--- a/src/evm/Evm.ts
+++ b/src/evm/Evm.ts
@@ -838,7 +838,12 @@ export function setInspector<asynchronous extends boolean>(
 }
 
 export declare namespace setInspector {
-  type ErrorType = AbiError | BorrowedError | Errors.GlobalErrorType
+  type ErrorType =
+    | AbiError
+    | BorrowedError
+    | EncodeError
+    | ReentrancyError
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -915,7 +920,12 @@ export declare namespace setBal {
     fallback?: boolean | undefined
   }
 
-  type ErrorType = AbiError | BorrowedError | Errors.GlobalErrorType
+  type ErrorType =
+    | AbiError
+    | BorrowedError
+    | EncodeError
+    | ReentrancyError
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -1029,7 +1039,7 @@ export function takeBal<asynchronous extends boolean>(
 }
 
 export declare namespace takeBal {
-  type ErrorType = setBal.ErrorType
+  type ErrorType = setBal.ErrorType | DecodeError
 }
 
 /**
@@ -1091,7 +1101,12 @@ export function startBlockState<asynchronous extends boolean>(
 }
 
 export declare namespace startBlockState {
-  type ErrorType = AbiError | BorrowedError | Errors.GlobalErrorType
+  type ErrorType =
+    | AbiError
+    | BorrowedError
+    | DecodeError
+    | ReentrancyError
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -1122,7 +1137,7 @@ export function takeBlockState<asynchronous extends boolean>(
 }
 
 export declare namespace takeBlockState {
-  type ErrorType = startBlockState.ErrorType | NoBlockStateError
+  type ErrorType = startBlockState.ErrorType | EncodeError | NoBlockStateError
 }
 
 /**
@@ -1148,7 +1163,11 @@ export function warmPrecompiles<asynchronous extends boolean>(
 }
 
 export declare namespace warmPrecompiles {
-  type ErrorType = startBlockState.ErrorType
+  type ErrorType =
+    | AbiError
+    | BorrowedError
+    | ReentrancyError
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -1189,6 +1208,7 @@ export declare namespace commitSource {
     | AbiError
     | BorrowedError
     | EncodeError
+    | ReentrancyError
     | Errors.GlobalErrorType
 }
 

--- a/src/evm/_test/Evm.test-d.ts
+++ b/src/evm/_test/Evm.test-d.ts
@@ -308,3 +308,55 @@ describe('block execution', () => {
     )
   })
 })
+
+describe('error unions', () => {
+  /** The union's member with `name`, or `never` when it has none. */
+  type Named<union, name> = Extract<union, { name: name }>
+
+  test('every operation reaching the engine can report a busy one', () => {
+    // Each goes through the engine, which raises `ReentrancyError` when an
+    // operation is already running, so each union has to carry it. Matched by
+    // name: these error types are otherwise structurally alike, so assignability
+    // alone would pass whatever the union listed.
+    expectTypeOf<
+      Named<Evm.setBlock.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.setInspector.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.setBal.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.takeBal.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.startBlockState.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.takeBlockState.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.warmPrecompiles.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.commitSource.ErrorType, 'Evm.ReentrancyError'>
+    >().not.toBeNever()
+  })
+
+  test('an operation reports the failures its own payload can cause', () => {
+    // Encoding a payload can overflow a field; decoding can meet a shape this
+    // ABI version cannot read.
+    expectTypeOf<
+      Named<Evm.commitSource.ErrorType, 'Evm.EncodeError'>
+    >().not.toBeNever()
+    expectTypeOf<
+      Named<Evm.takeBal.ErrorType, 'Evm.DecodeError'>
+    >().not.toBeNever()
+
+    // `warmPrecompiles` carries no payload, so it cannot fail encoding one.
+    expectTypeOf<
+      Named<Evm.warmPrecompiles.ErrorType, 'Evm.EncodeError'>
+    >().toBeNever()
+  })
+})


### PR DESCRIPTION
Adds the failures the block-state and access-list operations can actually raise to their error unions: every one reaches the engine, so each can report a busy engine, and those carrying a payload or decoding a response can fail at either.
