### PR TITLE
docs(tempo): fix withdrawal sender tag example

### DIFF
--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -533,8 +533,8 @@ export * as VirtualMaster from './VirtualMaster.js'
  * Utilities for deriving the sender tag that correlates a Zone withdrawal with
  * its indexed parent-chain `WithdrawalProcessed` event.
  *
- * The sender tag commits to the withdrawal sender and the Zone transaction hash
- * containing the `ZoneOutbox.requestWithdrawal` call.
+ * The sender tag commits to the withdrawal sender, the Zone transaction hash
+ * containing the `ZoneOutbox.requestWithdrawal` call, and the fallback nonce.
  *
  * [Authenticated Withdrawals Specification](https://github.com/tempoxyz/zones/blob/main/specs/spec.md#authenticated-withdrawals)
  *
@@ -543,6 +543,7 @@ export * as VirtualMaster from './VirtualMaster.js'
  * import { WithdrawalSenderTag } from 'ox/tempo'
  *
  * const senderTag = WithdrawalSenderTag.from({
+ *   fallbackNonce: 19n,
  *   sender: '0x1234567890abcdef1234567890abcdef12345678',
  *   transactionHash:
  *     '0xabababababababababababababababababababababababababababababababab'


### PR DESCRIPTION
## Summary

Updated the public `WithdrawalSenderTag` example to include the required fallback nonce.

## Motivation

PR #385 made `fallbackNonce` required, but the barrel-export JSDoc example retained the previous two-field call and caused the main-branch example check to fail.

## Changes

- Added `fallbackNonce` to the `WithdrawalSenderTag.from` example.
- Updated the accompanying description to include the fallback nonce commitment.

## Testing

- `pnpm zile examples:check`
- `pnpm docs:gen`
- `pnpm check` (passed with two unrelated existing warnings)