### PR TITLE
docs(engine): note the CSP requirement for the WASM engine

### DIFF
--- a/site/src/pages/guides/runtime/engines.mdx
+++ b/site/src/pages/guides/runtime/engines.mdx
@@ -119,6 +119,19 @@ independently owned factory described in the
   bundle.
 - Uses pinned portable C implementations that Ox must keep reviewed and
   updated.
+- Requires a Content Security Policy that permits WebAssembly compilation; WASM
+  is disabled by default in browser extensions.
+
+:::info
+**Content Security Policy.** Compiling WebAssembly requires a CSP that allows
+it: add `'wasm-unsafe-eval'` to your `script-src` directive. Browser extensions
+disable WASM under the default Manifest V3 CSP, and pages that ship a strict CSP
+must opt in explicitly, otherwise `Engine.install()` throws and Ox's default
+JavaScript engine should be used instead. See the
+[MDN extension CSP](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy)
+and [Chrome extension CSP](https://developer.chrome.com/docs/extensions/reference/manifest/content-security-policy)
+references.
+:::
 
 ### Install the Node Engine
 


### PR DESCRIPTION
closes #330

## what

The [WASM & Engines guide](https://oxlib.sh/guides/runtime/engines) didn't mention that the WASM engine needs a permissive Content Security Policy. Compiling WebAssembly requires `'wasm-unsafe-eval'` in `script-src`; browser extensions disable WASM by default under the Manifest V3 CSP, and strict-CSP pages must opt in, otherwise `Engine.install()` throws.

Adds a trade-off bullet + an `:::info` callout (matching the guide's existing callout style) with the MDN and Chrome CSP references from the issue.

## receipt

Docs-only change to `site/src/pages/guides/runtime/engines.mdx` (one bullet + one `:::info` block). No code or tests affected.
