### PR TITLE
fix(tempo): align native multisig on v0

### DIFF
--- a/.changeset/calm-pens-approve.md
+++ b/.changeset/calm-pens-approve.md
@@ -1,0 +1,11 @@
+---
+'ox': patch
+---
+
+Updated native multisig signing for configuration versions, access-key authorization, current protocol limits, and the `initialConfig` naming.
+
+```ts
+import { MultisigConfig } from 'ox/tempo'
+
+const digest = MultisigConfig.getSignPayload({ initialConfig, payload })
+```

--- a/src/tempo/KeyAuthorization.test-d.ts
+++ b/src/tempo/KeyAuthorization.test-d.ts
@@ -23,6 +23,12 @@ const multisig = {
   type: 'multisig',
 } as const satisfies SignatureEnvelope.Multisig
 
+const keychain = {
+  inner: signature,
+  type: 'keychain',
+  userAddress: authorization.address,
+} as const satisfies SignatureEnvelope.Keychain
+
 test('accepts primitive signatures', () => {
   const signed = KeyAuthorization.from(authorization, { signature })
 
@@ -31,11 +37,12 @@ test('accepts primitive signatures', () => {
   >()
 })
 
-test('rejects multisig signatures', () => {
-  KeyAuthorization.from(authorization, {
-    // @ts-expect-error Key authorizations accept only primitive signatures.
-    signature: multisig,
-  })
+test('accepts multisig signatures', () => {
+  const signed = KeyAuthorization.from(authorization, { signature: multisig })
+
+  expectTypeOf(signed.signature).toMatchTypeOf<
+    KeyAuthorization.Signed['signature']
+  >()
 
   const multisigRpc = {
     account: multisig.account,
@@ -54,8 +61,36 @@ test('rejects multisig signatures', () => {
     expiry: null,
     keyId: authorization.address,
     keyType: authorization.type,
-    // @ts-expect-error Key authorizations accept only primitive RPC signatures.
     signature: multisigRpc,
+  }
+
+  expectTypeOf(rpc).toEqualTypeOf<KeyAuthorization.Rpc>()
+})
+
+test('rejects keychain signatures', () => {
+  KeyAuthorization.from(authorization, {
+    // @ts-expect-error Key authorizations do not accept keychain signatures.
+    signature: keychain,
+  })
+
+  const keychainRpc = {
+    signature: {
+      r: '0x01',
+      s: '0x02',
+      type: 'secp256k1',
+      yParity: '0x0',
+    },
+    type: 'keychain',
+    userAddress: authorization.address,
+  } as const satisfies SignatureEnvelope.KeychainRpc
+
+  const rpc: KeyAuthorization.Rpc = {
+    chainId: '0x1',
+    expiry: null,
+    keyId: authorization.address,
+    keyType: authorization.type,
+    // @ts-expect-error Key authorizations do not accept keychain RPC signatures.
+    signature: keychainRpc,
   }
 
   expectTypeOf(rpc).toEqualTypeOf<KeyAuthorization.Rpc>()

--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -53,11 +53,17 @@ const signature_webauthn = SignatureEnvelope.from({
   },
 })
 
-const signature_multisig = SignatureEnvelope.from({
+const signature_multisig = {
   account: address,
   signatures: [SignatureEnvelope.from(signature_secp256k1)],
   type: 'multisig',
-})
+} as const satisfies SignatureEnvelope.Multisig
+
+const signature_keychain = {
+  inner: SignatureEnvelope.from(signature_secp256k1),
+  type: 'keychain',
+  userAddress: address,
+} as const satisfies SignatureEnvelope.Keychain
 
 describe('from', () => {
   test('default', () => {
@@ -448,7 +454,34 @@ describe('from', () => {
     `)
   })
 
-  test('rejects a multisig signature', () => {
+  test('with signature (multisig)', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      chainId: 1n,
+      type: 'secp256k1',
+    })
+
+    const signed = KeyAuthorization.from(authorization, {
+      signature: signature_multisig,
+    })
+    expect(signed.signature).toEqual(signature_multisig)
+    expect(
+      KeyAuthorization.from(authorization, {
+        signature: SignatureEnvelope.serialize(signature_multisig),
+      }).signature,
+    ).toEqual(signature_multisig)
+    expect(
+      KeyAuthorization.from({
+        ...authorization,
+        signature: signature_multisig,
+      }).signature,
+    ).toEqual(signature_multisig)
+    expect(
+      KeyAuthorization.deserialize(KeyAuthorization.serialize(signed)),
+    ).toEqual(signed)
+  })
+
+  test('rejects a keychain signature', () => {
     const authorization = KeyAuthorization.from({
       address,
       chainId: 1n,
@@ -457,50 +490,55 @@ describe('from', () => {
 
     expect(() =>
       KeyAuthorization.from(authorization, {
-        signature: signature_multisig as never,
+        signature: signature_keychain as never,
       }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
+      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`keychain\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, \`webAuthn\`, or \`multisig\`.]`,
     )
 
     expect(() =>
       KeyAuthorization.from(authorization, {
-        signature: SignatureEnvelope.serialize(signature_multisig),
+        signature: SignatureEnvelope.serialize(signature_keychain),
       }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
+      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`keychain\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, \`webAuthn\`, or \`multisig\`.]`,
     )
 
     expect(() =>
       KeyAuthorization.from({
         ...authorization,
-        signature: signature_multisig,
+        signature: signature_keychain,
       } as never),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
+      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`keychain\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, \`webAuthn\`, or \`multisig\`.]`,
     )
   })
 })
 
 describe('fromRpc', () => {
-  test('rejects a multisig signature', () => {
+  test('multisig', () => {
+    const authorization = KeyAuthorization.fromRpc({
+      chainId: '0x1',
+      expiry: null,
+      keyId: address,
+      keyType: 'secp256k1',
+      signature: SignatureEnvelope.toRpc(signature_multisig),
+    })
+
+    expect(authorization.signature).toEqual(signature_multisig)
+  })
+
+  test('rejects a keychain signature', () => {
     expect(() =>
       KeyAuthorization.fromRpc({
         chainId: '0x1',
         expiry: null,
         keyId: address,
         keyType: 'secp256k1',
-        signature: {
-          account: address,
-          signatures: [
-            SignatureEnvelope.toRpc(
-              SignatureEnvelope.from(signature_secp256k1),
-            ),
-          ],
-        },
+        signature: SignatureEnvelope.toRpc(signature_keychain),
       } as never),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
+      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`keychain\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, \`webAuthn\`, or \`multisig\`.]`,
     )
   })
 
@@ -721,15 +759,13 @@ describe('fromRpc', () => {
 })
 
 describe('fromTuple', () => {
-  test('rejects a multisig signature', () => {
-    expect(() =>
-      KeyAuthorization.fromTuple([
-        ['0x1', '0x', address],
-        SignatureEnvelope.serialize(signature_multisig),
-      ]),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
-    )
+  test('multisig', () => {
+    const authorization = KeyAuthorization.fromTuple([
+      ['0x1', '0x', address],
+      SignatureEnvelope.serialize(signature_multisig),
+    ])
+
+    expect(authorization.signature).toEqual(signature_multisig)
   })
 
   test('default', () => {
@@ -1069,16 +1105,14 @@ describe('getSignPayload', () => {
 })
 
 describe('deserialize', () => {
-  test('rejects a multisig signature', () => {
+  test('multisig', () => {
     const serialized = Rlp.fromHex([
       ['0x1', '0x', address],
       SignatureEnvelope.serialize(signature_multisig),
     ])
 
-    expect(() =>
-      KeyAuthorization.deserialize(serialized),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
+    expect(KeyAuthorization.deserialize(serialized).signature).toEqual(
+      signature_multisig,
     )
   })
 
@@ -1252,16 +1286,16 @@ describe('serialize', () => {
 })
 
 describe('toRpc', () => {
-  test('rejects a multisig signature', () => {
-    expect(() =>
-      KeyAuthorization.toRpc({
-        address,
-        chainId: 1n,
-        signature: signature_multisig,
-        type: 'secp256k1',
-      } as never),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
+  test('multisig', () => {
+    const authorization = KeyAuthorization.toRpc({
+      address,
+      chainId: 1n,
+      signature: signature_multisig,
+      type: 'secp256k1',
+    })
+
+    expect(authorization.signature).toEqual(
+      SignatureEnvelope.toRpc(signature_multisig),
     )
   })
 
@@ -1522,17 +1556,15 @@ describe('toRpc', () => {
 })
 
 describe('toTuple', () => {
-  test('rejects a multisig signature', () => {
-    expect(() =>
-      KeyAuthorization.toTuple({
-        address,
-        chainId: 1n,
-        signature: signature_multisig,
-        type: 'secp256k1',
-      } as never),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `[KeyAuthorization.InvalidSignatureTypeError: Signature type \`multisig\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.]`,
-    )
+  test('multisig', () => {
+    const tuple = KeyAuthorization.toTuple({
+      address,
+      chainId: 1n,
+      signature: signature_multisig,
+      type: 'secp256k1',
+    })
+
+    expect(tuple[1]).toBe(SignatureEnvelope.serialize(signature_multisig))
   })
 
   test('default', () => {
@@ -2483,12 +2515,12 @@ describe('admin keys (TIP-1049)', () => {
     expect(restored.account).toBeUndefined()
   })
 
-  test('fromTuple: drops orphan account without isAdmin', () => {
+  test('fromTuple: preserves a non-admin account binding', () => {
     const restored = KeyAuthorization.fromTuple([
       ['0x01', '0x', address, '0x', [], [], '0x', '0x', account],
     ])
-    expect(restored.isAdmin).toBeUndefined()
-    expect(restored.account).toBeUndefined()
+    expect(restored.isAdmin).toBe(false)
+    expect(restored.account).toBe(account)
   })
 
   test('fromTuple: extracts isAdmin + account together', () => {
@@ -2523,6 +2555,20 @@ describe('admin keys (TIP-1049)', () => {
     expect(restored.account).toBe(account)
   })
 
+  test('serialize/deserialize: roundtrip with non-admin account binding', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: false,
+      type: 'secp256k1',
+    })
+    const serialized = KeyAuthorization.serialize(authorization)
+    const restored = KeyAuthorization.deserialize(serialized)
+    expect(restored.isAdmin).toBe(false)
+    expect(restored.account).toBe(account)
+  })
+
   test('toRpc/fromRpc: roundtrip with isAdmin + account', () => {
     const authorization = KeyAuthorization.from(
       {
@@ -2553,15 +2599,15 @@ describe('admin keys (TIP-1049)', () => {
     expect(restored.account).toBeUndefined()
   })
 
-  test('fromRpc: drops orphan account without isAdmin', () => {
+  test('fromRpc: preserves a non-admin account binding', () => {
     const authorization = KeyAuthorization.from(
       { address, chainId: 1n, type: 'secp256k1' },
       { signature: SignatureEnvelope.from(signature_secp256k1) },
     )
     const rpc = KeyAuthorization.toRpc(authorization)
     const restored = KeyAuthorization.fromRpc({ ...rpc, account })
-    expect(restored.isAdmin).toBeUndefined()
-    expect(restored.account).toBeUndefined()
+    expect(restored.isAdmin).toBe(false)
+    expect(restored.account).toBe(account)
   })
 
   test('hash: changes when admin pair is added', () => {

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -81,12 +81,21 @@ export type KeyAuthorization<
   | {}
 > &
   (signed extends true
-    ? { signature: SignatureEnvelope.Primitive<bigintType, numberType> }
+    ? { signature: Signature<bigintType, numberType> }
     : {
-        signature?:
-          | SignatureEnvelope.Primitive<bigintType, numberType>
-          | undefined
+        signature?: Signature<bigintType, numberType> | undefined
       })
+
+/** Signature that can authorize an access key. */
+export type Signature<bigintType = bigint, numberType = number> = OneOf<
+  | SignatureEnvelope.Primitive<bigintType, numberType>
+  | SignatureEnvelope.Multisig<bigintType, numberType>
+>
+
+/** RPC-formatted signature that can authorize an access key. */
+export type SignatureRpc = OneOf<
+  SignatureEnvelope.PrimitiveRpc | SignatureEnvelope.MultisigRpc
+>
 
 /** Input type for a Key Authorization. */
 export type Input = KeyAuthorization<
@@ -114,8 +123,8 @@ export type Rpc = {
   keyType: SignatureEnvelope.Type
   /** Token spending limits. */
   limits?: readonly RpcTokenLimit[] | undefined
-  /** Primitive signature authorizing this key. */
-  signature: SignatureEnvelope.PrimitiveRpc
+  /** Signature authorizing this key. */
+  signature: SignatureRpc
   /** Optional 32-byte witness (hex). */
   witness?: Hex.Hex | null | undefined
 }
@@ -146,10 +155,11 @@ export type Signed<
   addressType = Address.Address,
 > = KeyAuthorization<true, bigintType, numberType, addressType>
 
-type PrimitiveSignatureValue =
-  | UnionPartialBy<SignatureEnvelope.Primitive, 'prehash' | 'type'>
+type SignatureValue =
+  | UnionPartialBy<Signature, 'prehash' | 'type'>
   | SignatureEnvelope.Secp256k1Flat
   | SignatureEnvelope.Serialized
+  | SignatureEnvelope.from.MultisigFromInitialConfig
 
 type BaseTuple = readonly [
   chainId: Hex.Hex,
@@ -408,7 +418,7 @@ export type TokenLimit<
  */
 export function from<
   const authorization extends Input | Rpc,
-  const signature extends PrimitiveSignatureValue | undefined = undefined,
+  const signature extends SignatureValue | undefined = undefined,
 >(
   authorization: authorization | KeyAuthorization,
   options: from.Options<signature> = {},
@@ -467,29 +477,25 @@ export function from<
 
 export declare namespace from {
   type Options<
-    signature extends PrimitiveSignatureValue | undefined =
-      | PrimitiveSignatureValue
-      | undefined,
+    signature extends SignatureValue | undefined = SignatureValue | undefined,
   > = {
-    /** The primitive signature to attach to the Key Authorization. */
-    signature?: signature | SignatureEnvelope.Primitive | undefined
+    /** The signature to attach to the Key Authorization. */
+    signature?: signature | Signature | undefined
   }
 
   type ReturnType<
     authorization extends KeyAuthorization | Input | Rpc = KeyAuthorization,
-    signature extends PrimitiveSignatureValue | undefined =
-      | PrimitiveSignatureValue
-      | undefined,
+    signature extends SignatureValue | undefined = SignatureValue | undefined,
   > = Compute<
     authorization extends Rpc
       ? Signed
       : TempoAddress.ResolveAddresses<
           authorization &
-            (signature extends PrimitiveSignatureValue
+            (signature extends SignatureValue
               ? {
                   signature: Extract<
                     SignatureEnvelope.from.ReturnValue<signature>,
-                    SignatureEnvelope.Primitive
+                    Signature
                   >
                 }
               : {})
@@ -551,11 +557,8 @@ export function fromRpc(authorization: Rpc): Signed {
       })
     : undefined
 
-  // TIP-1049 admin fields are paired: emit both or neither; orphan wire
-  // fields are dropped. Separate conditional spreads break `Signed`
-  // assignability without `exactOptionalPropertyTypes` (#290).
-  const adminPair =
-    account !== undefined && isAdmin ? { account, isAdmin: true as const } : {}
+  const accountBinding =
+    account !== undefined ? { account, isAdmin: isAdmin ?? false } : {}
 
   return {
     address: keyId,
@@ -572,7 +575,7 @@ export function fromRpc(authorization: Rpc): Signed {
     signature,
     type: keyType,
     ...(witness !== undefined ? { witness } : {}),
-    ...adminPair,
+    ...accountBinding,
   }
 }
 
@@ -694,11 +697,8 @@ export function fromTuple<const tuple extends Tuple>(
   const account = isAbsent(rawAccount)
     ? undefined
     : (rawAccount as Address.Address)
-  // TIP-1049 admin fields are paired: only emit both when both are present on
-  // the wire. Wire shapes carrying only one are tolerated for forward-compat
-  // but the orphan field is dropped (since the public API requires both).
-  const adminPair =
-    account !== undefined && isAdmin ? { account, isAdmin: true as const } : {}
+  const accountBinding =
+    account !== undefined ? { account, isAdmin: isAdmin ?? false } : {}
   const args: KeyAuthorization = {
     address: keyId,
     chainId: chainId === '0x' ? 0n : Hex.toBigInt(chainId),
@@ -707,7 +707,7 @@ export function fromTuple<const tuple extends Tuple>(
     ...(limits !== undefined ? { limits } : {}),
     ...(scopes !== undefined ? { scopes } : {}),
     ...(witness !== undefined ? { witness } : {}),
-    ...adminPair,
+    ...accountBinding,
   }
   if (signatureSerialized) {
     const signature = SignatureEnvelope.deserialize(signatureSerialized)
@@ -963,9 +963,7 @@ export function toRpc(authorization: Signed): Rpc {
       limit: Hex.fromNumber(limit),
       ...(period ? { period: numberToHex(period) } : {}),
     })),
-    signature: SignatureEnvelope.toRpc(
-      signature,
-    ) as SignatureEnvelope.PrimitiveRpc,
+    signature: SignatureEnvelope.toRpc(signature) as SignatureRpc,
     ...(allowedCalls ? { allowedCalls } : {}),
     ...(witness !== undefined ? { witness } : {}),
     ...(isAdmin ? { isAdmin: true } : {}),
@@ -1162,8 +1160,8 @@ function assertWitness(witness: Hex.Hex): void {
 
 function assertSignature<bigintType, numberType>(
   signature: SignatureEnvelope.SignatureEnvelope<bigintType, numberType>,
-): asserts signature is SignatureEnvelope.Primitive<bigintType, numberType> {
-  if (signature.type === 'keychain' || signature.type === 'multisig')
+): asserts signature is Signature<bigintType, numberType> {
+  if (signature.type === 'keychain')
     throw new InvalidSignatureTypeError(signature.type)
 }
 
@@ -1191,12 +1189,12 @@ export class InvalidAdminMarkerError extends Error {
   }
 }
 
-/** Thrown when a key authorization contains a non-primitive signature. */
+/** Thrown when a key authorization contains a keychain signature. */
 export class InvalidSignatureTypeError extends Error {
   override readonly name = 'KeyAuthorization.InvalidSignatureTypeError'
   constructor(type: SignatureEnvelope.SignatureEnvelope['type']) {
     super(
-      `Signature type \`${type}\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, or \`webAuthn\`.`,
+      `Signature type \`${type}\` is invalid for key authorizations; expected \`secp256k1\`, \`p256\`, \`webAuthn\`, or \`multisig\`.`,
     )
   }
 }

--- a/src/tempo/MultisigConfig.test.ts
+++ b/src/tempo/MultisigConfig.test.ts
@@ -86,23 +86,43 @@ describe('getSignPayload', () => {
   test('matches independent ground truth', () => {
     expect(
       MultisigConfig.getSignPayload({
-        payload: `0x${'de'.repeat(32)}`,
-        genesisConfig: singleOwnerConfig,
+        payload: `0x${'42'.repeat(32)}`,
+        initialConfig: singleOwnerConfig,
       }),
     ).toMatchInlineSnapshot(
-      `"0x7df8cb9fef4fc2aeb271b617d1a4c6178b720ae1d7564f48a363069b7d77a079"`,
+      `"0xbf944a7a752b2cfab0418d5fb4591c5a7ff62976488edce11794d7f35fb34f41"`,
     )
   })
 
-  test('behavior: `genesisConfig` and `{ account }` produce identical digests', () => {
+  test('behavior: `initialConfig` and `{ account }` produce identical digests', () => {
     const account = MultisigConfig.getAddress(singleOwnerConfig)
     const payload = `0x${'42'.repeat(32)}` as const
     expect(
       MultisigConfig.getSignPayload({
         payload,
-        genesisConfig: singleOwnerConfig,
+        initialConfig: singleOwnerConfig,
       }),
     ).toBe(MultisigConfig.getSignPayload({ payload, account }))
+  })
+
+  test('differs for a different config version', () => {
+    const value = {
+      payload: `0x${'42'.repeat(32)}` as const,
+      initialConfig: singleOwnerConfig,
+    }
+    expect(MultisigConfig.getSignPayload(value)).not.toBe(
+      MultisigConfig.getSignPayload({ ...value, version: 1n }),
+    )
+  })
+
+  test('defaults the config version to zero', () => {
+    const value = {
+      payload: `0x${'42'.repeat(32)}` as const,
+      initialConfig: singleOwnerConfig,
+    }
+    expect(MultisigConfig.getSignPayload(value)).toBe(
+      MultisigConfig.getSignPayload({ ...value, version: 0n }),
+    )
   })
 })
 
@@ -149,8 +169,8 @@ describe('assert / validate', () => {
     expect(MultisigConfig.validate({ threshold: 1, owners: [] })).toBe(false)
   })
 
-  test('accepts 255 owners', () => {
-    const owners = Array.from({ length: 255 }, (_, i) => ({
+  test('accepts 50 owners', () => {
+    const owners = Array.from({ length: 50 }, (_, i) => ({
       owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
       weight: 1,
     }))
@@ -163,7 +183,7 @@ describe('assert / validate', () => {
   })
 
   test('too many owners', () => {
-    const owners = Array.from({ length: 256 }, (_, i) => ({
+    const owners = Array.from({ length: 51 }, (_, i) => ({
       owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
       weight: 1,
     }))

--- a/src/tempo/MultisigConfig.ts
+++ b/src/tempo/MultisigConfig.ts
@@ -6,7 +6,7 @@ import * as Hex from '../core/Hex.js'
 import type { Compute, OneOf } from '../core/internal/types.js'
 
 /** Maximum number of owners allowed in a native multisig config. */
-export const maxOwners = 255
+export const maxOwners = 50
 
 /** Maximum threshold accepted by a native multisig config. */
 export const maxThreshold = 8
@@ -20,7 +20,7 @@ export const maxSignatures = maxThreshold
  */
 export const maxNestingDepth = 2
 
-/** Maximum encoded byte length for one owner approval. */
+/** Maximum encoded byte length for one primitive owner approval. */
 export const maxOwnerSignatureBytes = 2049
 
 /** Tempo signature type byte for native multisig signatures. */
@@ -224,14 +224,14 @@ export function fromTuple(tuple: Tuple): Config {
  * ```ts twoslash
  * import { MultisigConfig } from 'ox/tempo'
  *
- * const genesisConfig = MultisigConfig.from({
+ * const initialConfig = MultisigConfig.from({
  *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
  * })
  *
- * const address = MultisigConfig.getAddress(genesisConfig)
+ * const address = MultisigConfig.getAddress(initialConfig)
  * ```
  *
  * @param config - The initial (bootstrap) multisig config.
@@ -272,13 +272,13 @@ export declare namespace getAddress {
 /**
  * Computes the digest a native multisig owner approves (signs).
  *
- * `keccak256("tempo:multisig:signature" || inner_digest || account)`,
+ * `keccak256("tempo:multisig:signature" || inner_digest || account || uint64be(version))`,
  * where `inner_digest` is the transaction sign payload
  * ({@link ox#TxEnvelopeTempo.(getSignPayload:function)}).
  *
- * The digest is keyed on the permanent `account` derived from the genesis
- * (bootstrap) config — config updates never change it, so the genesis config
- * is the correct input even for post-update transactions.
+ * The digest is keyed on the permanent `account` derived from the initial
+ * (bootstrap) config and the current config `version`. Bootstrap approvals use
+ * version `0n`, which is also the default; each config update increments it.
  *
  * For a nested multisig owner approval, the parent digest becomes the nested
  * approval's `payload`, with the nested multisig `account`.
@@ -287,7 +287,7 @@ export declare namespace getAddress {
  * ```ts twoslash
  * import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
  *
- * const genesisConfig = MultisigConfig.from({
+ * const initialConfig = MultisigConfig.from({
  *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
@@ -301,7 +301,7 @@ export declare namespace getAddress {
  *
  * const digest = MultisigConfig.getSignPayload({
  *   payload: TxEnvelopeTempo.getSignPayload(envelope),
- *   genesisConfig,
+ *   initialConfig,
  * })
  * ```
  *
@@ -314,19 +314,20 @@ export declare namespace getAddress {
  * ```ts twoslash
  * import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
  *
- * const genesisConfig = MultisigConfig.from({
+ * const initialConfig = MultisigConfig.from({
  *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
  * })
- * const account = MultisigConfig.getAddress(genesisConfig)
+ * const account = MultisigConfig.getAddress(initialConfig)
  *
  * const envelope = TxEnvelopeTempo.from({ chainId: 1, calls: [] })
  *
  * const digest = MultisigConfig.getSignPayload({
  *   payload: TxEnvelopeTempo.getSignPayload(envelope),
- *   account
+ *   account,
+ *   version: 1n
  * })
  * ```
  *
@@ -334,13 +335,18 @@ export declare namespace getAddress {
  * @returns The owner approval digest.
  */
 export function getSignPayload(value: getSignPayload.Value): Hex.Hex {
-  const { payload } = value
+  const { payload, version = 0n } = value
   const account =
     'account' in value && value.account
       ? value.account
-      : getAddress((value as { genesisConfig: Config }).genesisConfig)
+      : getAddress((value as { initialConfig: Config }).initialConfig)
   return Hash.keccak256(
-    Hex.concat(Hex.fromString(signatureDomain), Hex.from(payload), account),
+    Hex.concat(
+      Hex.fromString(signatureDomain),
+      Hex.from(payload),
+      account,
+      Hex.fromNumber(version, { size: 8 }),
+    ),
   )
 }
 
@@ -348,6 +354,8 @@ export declare namespace getSignPayload {
   type Value = {
     /** The inner transaction sign payload (`tx.signature_hash()`). */
     payload: Hex.Hex | Bytes.Bytes
+    /** Current multisig config version. Defaults to `0n`. */
+    version?: bigint | undefined
   } & OneOf<
     | {
         /** The native multisig account address. */
@@ -357,10 +365,10 @@ export declare namespace getSignPayload {
         /**
          * The initial multisig config (the bootstrap config that derived the
          * permanent `account`). Used to derive the account automatically.
-         * Config updates never change `account`, so the genesis config is
-         * also the correct input for post-update transactions.
+         * Config updates never change `account`, so the initial config can
+         * continue deriving the account for post-update transactions.
          */
-        genesisConfig: Config
+        initialConfig: Config
       }
   >
 
@@ -369,6 +377,7 @@ export declare namespace getSignPayload {
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
     | Hex.from.ErrorType
+    | Hex.fromNumber.ErrorType
     | Errors.GlobalErrorType
 }
 

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -1100,7 +1100,7 @@ describe('from', () => {
   })
 
   describe('multisig', () => {
-    const genesisConfig = MultisigConfig.from({
+    const initialConfig = MultisigConfig.from({
       threshold: 1,
       owners: [
         {
@@ -1110,29 +1110,29 @@ describe('from', () => {
       ],
     })
 
-    test('behavior: derives `account` from `genesisConfig`', () => {
+    test('behavior: derives `account` from `initialConfig`', () => {
       const envelope = SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
       })
 
       expect(envelope).toMatchObject({
         type: 'multisig',
-        account: MultisigConfig.getAddress(genesisConfig),
+        account: MultisigConfig.getAddress(initialConfig),
       })
-      expect('genesisConfig' in envelope).toBe(false)
+      expect('initialConfig' in envelope).toBe(false)
       expect((envelope as SignatureEnvelope.Multisig).init).toBeUndefined()
     })
 
-    test('behavior: `init: true` opts into bootstrap (uses `genesisConfig` as `init`)', () => {
+    test('behavior: `init: true` opts into bootstrap (uses `initialConfig` as `init`)', () => {
       const envelope = SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
         init: true,
       })
 
       expect((envelope as SignatureEnvelope.Multisig).init).toEqual(
-        genesisConfig,
+        initialConfig,
       )
     })
 
@@ -1147,7 +1147,7 @@ describe('from', () => {
         ],
       })
       const envelope = SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
         init: otherConfig,
       })
@@ -1156,7 +1156,7 @@ describe('from', () => {
     })
 
     test('behavior: `{ account }` form still works', () => {
-      const account = MultisigConfig.getAddress(genesisConfig)
+      const account = MultisigConfig.getAddress(initialConfig)
       const envelope = SignatureEnvelope.from({
         account,
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
@@ -1769,7 +1769,7 @@ describe('serialize', () => {
 })
 
 describe('sortMultisigApprovals', () => {
-  // Build owner key pairs first so we can construct a real genesis config
+  // Build owner key pairs first so we can construct a real initial config
   // whose owner set matches the keys that produce the approvals below.
   const ownerKeys = Array.from({ length: 3 }, () => {
     const privateKey = Secp256k1.randomPrivateKey()
@@ -1782,12 +1782,15 @@ describe('sortMultisigApprovals', () => {
     Hex.toBigInt(a.address) < Hex.toBigInt(b.address) ? -1 : 1,
   )
 
-  const genesisConfig = MultisigConfig.from({
+  const initialConfig = MultisigConfig.from({
     threshold: 2,
     owners: ascendingOwners.map((o) => ({ owner: o.address, weight: 1 })),
   })
   const payload = `0x${'42'.repeat(32)}` as const
-  const digest = MultisigConfig.getSignPayload({ payload, genesisConfig })
+  const digest = MultisigConfig.getSignPayload({
+    payload,
+    initialConfig,
+  })
 
   const owners = ownerKeys.map((owner) => ({
     address: owner.address,
@@ -1802,7 +1805,7 @@ describe('sortMultisigApprovals', () => {
 
   test('behavior: orders approvals ascending by recovered owner address', () => {
     const ordered = SignatureEnvelope.sortMultisigApprovals({
-      genesisConfig,
+      initialConfig,
       payload,
       // Provide approvals in reverse of the canonical order.
       signatures: [...ascending].reverse().map((owner) => owner.signature),
@@ -1814,7 +1817,7 @@ describe('sortMultisigApprovals', () => {
     const signatures = ascending.map((owner) => owner.signature)
     expect(
       SignatureEnvelope.sortMultisigApprovals({
-        genesisConfig,
+        initialConfig,
         payload,
         signatures,
       }),
@@ -1823,7 +1826,7 @@ describe('sortMultisigApprovals', () => {
 
   test('behavior: recovered order matches the config owner order', () => {
     const ordered = SignatureEnvelope.sortMultisigApprovals({
-      genesisConfig,
+      initialConfig,
       payload,
       signatures: owners.map((owner) => owner.signature),
     })
@@ -1833,12 +1836,12 @@ describe('sortMultisigApprovals', () => {
     expect(recovered).toEqual(ascending.map((owner) => owner.address))
   })
 
-  test('behavior: `genesisConfig` and `{ account }` produce identical ordering', () => {
-    const account = MultisigConfig.getAddress(genesisConfig)
+  test('behavior: `initialConfig` and `{ account }` produce identical ordering', () => {
+    const account = MultisigConfig.getAddress(initialConfig)
     const signatures = owners.map((owner) => owner.signature)
 
     const fromConfig = SignatureEnvelope.sortMultisigApprovals({
-      genesisConfig,
+      initialConfig,
       payload,
       signatures,
     })
@@ -3013,6 +3016,14 @@ describe('multisig', () => {
     ).toThrowErrorMatchingInlineSnapshot(
       `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig owner signature exceeds 2049 bytes.]`,
     )
+
+    const serialized = Hex.concat(
+      '0x05',
+      Rlp.fromHex([account, [SignatureEnvelope.serialize(oversized)]]),
+    )
+    expect(() => SignatureEnvelope.deserialize(serialized)).toThrowError(
+      SignatureEnvelope.InvalidSerializedError,
+    )
   })
 
   test('assert: rejects keychain owner approvals', () => {
@@ -3052,6 +3063,40 @@ describe('multisig', () => {
         signatures: [nested],
       })
       expect(() => SignatureEnvelope.assert(depth2)).not.toThrowError()
+    })
+
+    test('accepts a nested approval above the primitive byte limit', () => {
+      const primitive = SignatureEnvelope.from({
+        ...signature_webauthn,
+        metadata: {
+          ...signature_webauthn.metadata,
+          clientDataJSON: JSON.stringify({ value: 'x'.repeat(1_050) }),
+        },
+        signature: {
+          r: signature_webauthn.signature.r,
+          s: signature_webauthn.signature.s,
+        },
+      })
+      const largeNested = SignatureEnvelope.from({
+        type: 'multisig',
+        account: nestedAccount,
+        signatures: [primitive, primitive],
+      })
+      expect(Hex.size(SignatureEnvelope.serialize(primitive))).toBeLessThan(
+        MultisigConfig.maxOwnerSignatureBytes,
+      )
+      expect(
+        Hex.size(SignatureEnvelope.serialize(largeNested)),
+      ).toBeGreaterThan(MultisigConfig.maxOwnerSignatureBytes)
+
+      const parent = SignatureEnvelope.from({
+        type: 'multisig',
+        account,
+        signatures: [largeNested],
+      })
+      expect(
+        SignatureEnvelope.deserialize(SignatureEnvelope.serialize(parent)),
+      ).toEqual(parent)
     })
 
     test('assert: rejects nesting deeper than the maximum', () => {

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -424,12 +424,13 @@ function assertMultisig(envelope: Multisig, depth: number): void {
           reason: 'nested multisig owner approvals cannot carry `init`',
         })
       assertMultisig(multisig, depth + 1)
-    } else assert(inner)
-
-    if (Hex.size(serialize(inner)) > MultisigConfig.maxOwnerSignatureBytes)
-      throw new InvalidMultisigApprovalError({
-        reason: `multisig owner signature exceeds ${MultisigConfig.maxOwnerSignatureBytes} bytes`,
-      })
+    } else {
+      assert(inner)
+      if (Hex.size(serialize(inner)) > MultisigConfig.maxOwnerSignatureBytes)
+        throw new InvalidMultisigApprovalError({
+          reason: `multisig owner signature exceeds ${MultisigConfig.maxOwnerSignatureBytes} bytes`,
+        })
+    }
   }
 }
 
@@ -740,7 +741,10 @@ function deserialize_(
       })
     for (const signature of signatures)
       if (
-        Hex.size(signature as Hex.Hex) > MultisigConfig.maxOwnerSignatureBytes
+        Hex.size(signature as Hex.Hex) >
+          MultisigConfig.maxOwnerSignatureBytes &&
+        Hex.slice(signature as Hex.Hex, 0, 1) !==
+          MultisigConfig.signatureTypeByte
       )
         throw new InvalidSerializedError({
           reason: `multisig owner signature exceeds ${MultisigConfig.maxOwnerSignatureBytes} bytes`,
@@ -912,17 +916,17 @@ function deserialize_(
  * ```
  *
  * @example
- * ### Multisig (from genesis config)
+ * ### Multisig (from initial config)
  *
- * Pass `genesisConfig` to derive `account` automatically. Set `init: true` to
- * opt into bootstrap (uses `genesisConfig` as the bootstrap `init`); omit
+ * Pass `initialConfig` to derive `account` automatically. Set `init: true` to
+ * opt into bootstrap (uses `initialConfig` as the bootstrap `init`); omit
  * `init` for subsequent (non-bootstrap) transactions.
  *
  * ```ts twoslash
  * import { Secp256k1 } from 'ox'
  * import { MultisigConfig, SignatureEnvelope } from 'ox/tempo'
  *
- * const genesisConfig = MultisigConfig.from({
+ * const initialConfig = MultisigConfig.from({
  *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
@@ -936,14 +940,14 @@ function deserialize_(
  *
  * // Bootstrap transaction
  * const bootstrap = SignatureEnvelope.from({
- *   genesisConfig,
+ *   initialConfig,
  *   signatures: [signature],
  *   init: true,
  * })
  *
  * // Subsequent (non-bootstrap) transactions
  * const subsequent = SignatureEnvelope.from({
- *   genesisConfig,
+ *   initialConfig,
  *   signatures: [signature],
  * })
  * ```
@@ -970,20 +974,20 @@ export function from<const value extends from.Value>(
 
   if (type === 'multisig') {
     const multisig = value as Multisig & {
-      genesisConfig?: MultisigConfig.Config | undefined
+      initialConfig?: MultisigConfig.Config | undefined
       init?: MultisigConfig.Config | boolean | undefined
     }
-    const { genesisConfig, init, ...rest } = multisig
-    // Derive `account` from `genesisConfig` when not provided explicitly.
+    const { initialConfig, init, ...rest } = multisig
+    // Derive `account` from `initialConfig` when not provided explicitly.
     const account = (() => {
       if (rest.account) return rest.account
-      if (genesisConfig) return MultisigConfig.getAddress(genesisConfig)
+      if (initialConfig) return MultisigConfig.getAddress(initialConfig)
       return rest.account
     })()
-    // `init: true` opts into bootstrap using the supplied `genesisConfig`.
+    // `init: true` opts into bootstrap using the supplied `initialConfig`.
     // Otherwise, `init` is treated as the explicit bootstrap config (or
     // omitted).
-    const initSource = init === true ? genesisConfig : init || undefined
+    const initSource = init === true ? initialConfig : init || undefined
     return {
       ...rest,
       account,
@@ -1039,13 +1043,13 @@ export declare namespace from {
 
   /**
    * Multisig envelope input variant where `account` is derived from the
-   * supplied `genesisConfig`. Pass `init: true` to opt into bootstrap (uses
-   * `genesisConfig` as the bootstrap `init`); omit `init` for subsequent
+   * supplied `initialConfig`. Pass `init: true` to opt into bootstrap (uses
+   * `initialConfig` as the bootstrap `init`); omit `init` for subsequent
    * (non-bootstrap) transactions.
    */
-  type MultisigFromGenesisConfig = {
+  type MultisigFromInitialConfig = {
     type?: 'multisig' | undefined
-    genesisConfig: MultisigConfig.Config
+    initialConfig: MultisigConfig.Config
     signatures: readonly SignatureEnvelope[]
     init?: MultisigConfig.Config | boolean | undefined
   }
@@ -1054,7 +1058,7 @@ export declare namespace from {
     | UnionPartialBy<SignatureEnvelope, 'prehash' | 'type'>
     | Secp256k1Flat
     | Serialized
-    | MultisigFromGenesisConfig
+    | MultisigFromInitialConfig
 
   type ReturnValue<value extends Value> = Compute<
     OneOf<
@@ -1062,7 +1066,7 @@ export declare namespace from {
         ? SignatureEnvelope
         : value extends Secp256k1Flat
           ? Secp256k1
-          : value extends MultisigFromGenesisConfig
+          : value extends MultisigFromInitialConfig
             ? Multisig
             : IsNarrowable<value, SignatureEnvelope> extends true
               ? SignatureEnvelope
@@ -1285,7 +1289,7 @@ export function getType<
   // Detect Multisig signature
   if (
     ('account' in envelope ||
-      'genesisConfig' in envelope ||
+      'initialConfig' in envelope ||
       'init' in envelope) &&
     'signatures' in envelope
   )
@@ -1436,7 +1440,7 @@ export declare namespace serialize {
  * recovered owner address. Works for any owner key type (secp256k1, p256,
  * webAuthn).
  *
- * Config updates never change `account`, so the genesis config is the correct
+ * Config updates never change `account`, so the initial config is the correct
  * input even for post-update transactions.
  *
  * @example
@@ -1444,7 +1448,7 @@ export declare namespace serialize {
  * import { Secp256k1 } from 'ox'
  * import { MultisigConfig, SignatureEnvelope, TxEnvelopeTempo } from 'ox/tempo'
  *
- * const genesisConfig = MultisigConfig.from({
+ * const initialConfig = MultisigConfig.from({
  *   threshold: 2,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
@@ -1455,14 +1459,20 @@ export declare namespace serialize {
  * const tx = TxEnvelopeTempo.from({ chainId: 1, calls: [] })
  * const payload = TxEnvelopeTempo.getSignPayload(tx)
  *
- * const privateKeys = [Secp256k1.randomPrivateKey(), Secp256k1.randomPrivateKey()]
- * const digest = MultisigConfig.getSignPayload({ payload, genesisConfig })
+ * const privateKeys = [
+ *   Secp256k1.randomPrivateKey(),
+ *   Secp256k1.randomPrivateKey(),
+ * ]
+ * const digest = MultisigConfig.getSignPayload({
+ *   payload,
+ *   initialConfig,
+ * })
  * const signatures = privateKeys.map((privateKey) =>
  *   SignatureEnvelope.from(Secp256k1.sign({ payload: digest, privateKey })),
  * )
  *
  * const ordered = SignatureEnvelope.sortMultisigApprovals({ // [!code focus]
- *   genesisConfig, // [!code focus]
+ *   initialConfig, // [!code focus]
  *   payload, // [!code focus]
  *   signatures, // [!code focus]
  * }) // [!code focus]
@@ -1474,11 +1484,15 @@ export declare namespace serialize {
 export function sortMultisigApprovals(
   value: sortMultisigApprovals.Value,
 ): readonly SignatureEnvelope[] {
-  const { payload, signatures } = value
+  const { payload, signatures, version = 0n } = value
   const digest = MultisigConfig.getSignPayload(
-    'genesisConfig' in value && value.genesisConfig
-      ? { payload, genesisConfig: value.genesisConfig }
-      : { payload, account: (value as { account: Address.Address }).account },
+    'initialConfig' in value && value.initialConfig
+      ? { payload, initialConfig: value.initialConfig, version }
+      : {
+          payload,
+          account: (value as { account: Address.Address }).account,
+          version,
+        },
   )
   // Recover each signer once (decorate–sort–undecorate) rather than inside the
   // comparator.
@@ -1497,6 +1511,8 @@ export declare namespace sortMultisigApprovals {
     payload: Hex.Hex | Bytes.Bytes
     /** The owner approvals to order. */
     signatures: readonly SignatureEnvelope[]
+    /** Current multisig config version. Defaults to `0n`. */
+    version?: bigint | undefined
   } & OneOf<
     | {
         /** The native multisig account address. */
@@ -1507,7 +1523,7 @@ export declare namespace sortMultisigApprovals {
          * The initial multisig config (the bootstrap config that derived the
          * permanent `account`). Used to derive the account automatically.
          */
-        genesisConfig: MultisigConfig.Config
+        initialConfig: MultisigConfig.Config
       }
   >
 

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -136,7 +136,7 @@ export * as KeyAuthorization from './KeyAuthorization.js'
  * ```ts twoslash
  * import { MultisigConfig } from 'ox/tempo'
  *
- * const genesisConfig = MultisigConfig.from({
+ * const initialConfig = MultisigConfig.from({
  *   threshold: 2,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
@@ -144,7 +144,7 @@ export * as KeyAuthorization from './KeyAuthorization.js'
  *   ],
  * })
  *
- * const account = MultisigConfig.getAddress(genesisConfig)
+ * const account = MultisigConfig.getAddress(initialConfig)
  * ```
  *
  * @category Reference

--- a/src/tempo/multisig.e2e.test.ts
+++ b/src/tempo/multisig.e2e.test.ts
@@ -8,38 +8,58 @@ import * as TransactionReceipt from './TransactionReceipt.js'
 import * as TxEnvelopeTempo from './TxEnvelopeTempo.js'
 
 const chainId = chain.id
+const updateConfig = AbiFunction.from(
+  'function updateConfig(uint8 threshold, (address owner, uint8 weight)[] owners)',
+)
 
 describe('behavior: multisig (TIP-1061)', () => {
-  function setup(parameters: { count: number; threshold: number }) {
-    const { count, threshold } = parameters
+  function createKey() {
+    const privateKey = Secp256k1.randomPrivateKey()
+    const address = Address.fromPublicKey(
+      Secp256k1.getPublicKey({ privateKey }),
+    )
+    return { address, privateKey } as const
+  }
+
+  function setup(parameters: {
+    count: number
+    threshold: number
+    weights?: readonly number[] | undefined
+  }) {
+    const { count, threshold, weights = Array(count).fill(1) } = parameters
     const ownerKeys = Array.from({ length: count }, () => {
       const privateKey = Secp256k1.randomPrivateKey()
       const address = Address.fromPublicKey(
         Secp256k1.getPublicKey({ privateKey }),
       )
       return { address, privateKey } as const
-    })
+    }).sort((a, b) => a.address.localeCompare(b.address))
 
-    const genesisConfig = MultisigConfig.from({
+    const initialConfig = MultisigConfig.from({
       salt: Hex.random(32),
       threshold,
-      owners: ownerKeys.map((key) => ({
+      owners: ownerKeys.map((key, index) => ({
         owner: key.address,
-        weight: 1,
+        weight: weights[index]!,
       })),
     })
-    const account = MultisigConfig.getAddress(genesisConfig)
+    const account = MultisigConfig.getAddress(initialConfig)
 
-    return { account, genesisConfig, ownerKeys } as const
+    return { account, initialConfig, ownerKeys } as const
   }
 
   function approve(parameters: {
-    genesisConfig: MultisigConfig.Config
+    initialConfig: MultisigConfig.Config
     payload: Hex.Hex
     signers: readonly { privateKey: Hex.Hex }[]
+    version?: bigint | undefined
   }) {
-    const { genesisConfig, payload, signers } = parameters
-    const digest = MultisigConfig.getSignPayload({ payload, genesisConfig })
+    const { initialConfig, payload, signers, version = 0n } = parameters
+    const digest = MultisigConfig.getSignPayload({
+      payload,
+      initialConfig,
+      version,
+    })
     const signatures = signers.map((signer) =>
       SignatureEnvelope.from(
         Secp256k1.sign({ payload: digest, privateKey: signer.privateKey }),
@@ -47,16 +67,91 @@ describe('behavior: multisig (TIP-1061)', () => {
     )
     // The node requires approvals ordered by recovered owner address.
     return SignatureEnvelope.sortMultisigApprovals({
-      genesisConfig,
+      initialConfig,
       payload,
       signatures,
+      version,
     })
   }
 
-  test('behavior: bootstrap + spend (2-of-3 secp256k1)', async () => {
-    const { account, genesisConfig, ownerKeys } = setup({
+  function multisigSignature(parameters: {
+    initialConfig: MultisigConfig.Config
+    payload: Hex.Hex
+    signers: readonly { privateKey: Hex.Hex }[]
+    init?: boolean | undefined
+    version?: bigint | undefined
+  }) {
+    const { init = false, ...approval } = parameters
+    return SignatureEnvelope.from({
+      initialConfig: parameters.initialConfig,
+      ...(init ? { init: true } : {}),
+      signatures: approve(approval),
+    })
+  }
+
+  async function send(serialized: Hex.Hex) {
+    return (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [serialized],
+      })
+      .then((transaction) => TransactionReceipt.fromRpc(transaction as any)))!
+  }
+
+  async function bootstrap(multisig: ReturnType<typeof setup>) {
+    await fundAddress(client, { address: multisig.account })
+    const transaction = TxEnvelopeTempo.from({
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      chainId,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      nonce: 0n,
+      gas: 5_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+    const receipt = await send(
+      TxEnvelopeTempo.serialize(transaction, {
+        signature: multisigSignature({
+          initialConfig: multisig.initialConfig,
+          init: true,
+          payload: TxEnvelopeTempo.getSignPayload(transaction),
+          signers: multisig.ownerKeys,
+        }),
+      }),
+    )
+    expect(receipt.status).toBe('success')
+  }
+
+  function accessKeySignature(parameters: {
+    accessKey: { privateKey: Hex.Hex }
+    account: Address.Address
+    transaction: TxEnvelopeTempo.TxEnvelopeTempo
+  }) {
+    const { accessKey, account, transaction } = parameters
+    return SignatureEnvelope.from({
+      inner: SignatureEnvelope.from(
+        Secp256k1.sign({
+          payload: TxEnvelopeTempo.getSignPayload(transaction, {
+            from: account,
+          }),
+          privateKey: accessKey.privateKey,
+        }),
+      ),
+      type: 'keychain',
+      userAddress: account,
+    })
+  }
+
+  test('examples: bootstrap, initialized, and configuration rotation', async () => {
+    const { account, initialConfig, ownerKeys } = setup({
       count: 3,
       threshold: 2,
+    })
+    const replacement = createKey()
+    const rotatedConfig = MultisigConfig.from({
+      salt: initialConfig.salt,
+      threshold: 1,
+      owners: [{ owner: replacement.address, weight: 1 }],
     })
 
     await fundAddress(client, { address: account })
@@ -73,10 +168,10 @@ describe('behavior: multisig (TIP-1061)', () => {
 
     const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
       signature: SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         init: true,
         signatures: approve({
-          genesisConfig,
+          initialConfig,
           payload: TxEnvelopeTempo.getSignPayload(bootstrap),
           signers: [ownerKeys[0]!, ownerKeys[1]!],
         }),
@@ -105,8 +200,47 @@ describe('behavior: multisig (TIP-1061)', () => {
       expect(response.signature?.type).toBe('multisig')
       expect(
         (response.signature as SignatureEnvelope.Multisig | undefined)?.init,
-      ).toEqual(genesisConfig)
+      ).toEqual(initialConfig)
     }
+
+    const updateNonce = await getTransactionCount(client, {
+      address: account,
+      blockTag: 'pending',
+    })
+    const update = TxEnvelopeTempo.from({
+      calls: [
+        {
+          to: '0xaacc000000000000000000000000000000000000',
+          data: AbiFunction.encodeData(updateConfig, [
+            rotatedConfig.threshold,
+            rotatedConfig.owners,
+          ]),
+        },
+      ],
+      chainId,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      nonce: BigInt(updateNonce),
+      gas: 5_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+    const updateSigned = TxEnvelopeTempo.serialize(update, {
+      signature: SignatureEnvelope.from({
+        initialConfig,
+        signatures: approve({
+          initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(update),
+          signers: [ownerKeys[0]!, ownerKeys[1]!],
+        }),
+      }),
+    })
+    const updateReceipt = (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [updateSigned],
+      })
+      .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+    expect(updateReceipt.status).toBe('success')
 
     const nonce = await getTransactionCount(client, {
       address: account,
@@ -125,11 +259,12 @@ describe('behavior: multisig (TIP-1061)', () => {
 
     const spend_signed = TxEnvelopeTempo.serialize(spend, {
       signature: SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         signatures: approve({
-          genesisConfig,
+          initialConfig,
           payload: TxEnvelopeTempo.getSignPayload(spend),
-          signers: [ownerKeys[1]!, ownerKeys[2]!],
+          signers: [replacement],
+          version: 1n,
         }),
       }),
     })
@@ -145,7 +280,7 @@ describe('behavior: multisig (TIP-1061)', () => {
     expect(spend_receipt.from).toBe(account)
   })
 
-  test('behavior: nested multisig owner', async () => {
+  test('example: nested ownership', async () => {
     const child = setup({ count: 1, threshold: 1 })
     await fundAddress(client, { address: child.account })
 
@@ -160,10 +295,10 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
     const childBootstrapSigned = TxEnvelopeTempo.serialize(childBootstrap, {
       signature: SignatureEnvelope.from({
-        genesisConfig: child.genesisConfig,
+        initialConfig: child.initialConfig,
         init: true,
         signatures: approve({
-          genesisConfig: child.genesisConfig,
+          initialConfig: child.initialConfig,
           payload: TxEnvelopeTempo.getSignPayload(childBootstrap),
           signers: child.ownerKeys,
         }),
@@ -177,12 +312,12 @@ describe('behavior: multisig (TIP-1061)', () => {
       .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
     expect(childReceipt.status).toBe('success')
 
-    const genesisConfig = MultisigConfig.from({
+    const initialConfig = MultisigConfig.from({
       salt: Hex.random(32),
       threshold: 1,
       owners: [{ owner: child.account, weight: 1 }],
     })
-    const account = MultisigConfig.getAddress(genesisConfig)
+    const account = MultisigConfig.getAddress(initialConfig)
     await fundAddress(client, { address: account })
 
     const bootstrap = TxEnvelopeTempo.from({
@@ -195,20 +330,20 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const digest = MultisigConfig.getSignPayload({
-      genesisConfig,
+      initialConfig,
       payload: TxEnvelopeTempo.getSignPayload(bootstrap),
     })
     const nested = SignatureEnvelope.from({
-      genesisConfig: child.genesisConfig,
+      initialConfig: child.initialConfig,
       signatures: approve({
-        genesisConfig: child.genesisConfig,
+        initialConfig: child.initialConfig,
         payload: digest,
         signers: child.ownerKeys,
       }),
     })
     const bootstrapSigned = TxEnvelopeTempo.serialize(bootstrap, {
       signature: SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         init: true,
         signatures: [nested],
       }),
@@ -222,48 +357,191 @@ describe('behavior: multisig (TIP-1061)', () => {
       .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
     expect(receipt.status).toBe('success')
     expect(receipt.from).toBe(account)
-  })
 
-  test('behavior: rejects below-threshold approvals', async () => {
-    const { account, genesisConfig, ownerKeys } = setup({
-      count: 3,
-      threshold: 2,
-    })
-
-    await fundAddress(client, { address: account })
-
-    const bootstrap = TxEnvelopeTempo.from({
+    const transaction = TxEnvelopeTempo.from({
       calls: [{ to: '0x0000000000000000000000000000000000000000' }],
       chainId,
       feeToken: '0x20c0000000000000000000000000000000000001',
-      nonce: 0n,
+      nonce: 1n,
       gas: 5_000_000n,
       maxFeePerGas: Value.fromGwei('20'),
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
-
-    const serialized_signed = TxEnvelopeTempo.serialize(bootstrap, {
+    const parentDigest = MultisigConfig.getSignPayload({
+      initialConfig,
+      payload: TxEnvelopeTempo.getSignPayload(transaction),
+    })
+    const childSignature = multisigSignature({
+      initialConfig: child.initialConfig,
+      payload: parentDigest,
+      signers: child.ownerKeys,
+    })
+    const serialized = TxEnvelopeTempo.serialize(transaction, {
       signature: SignatureEnvelope.from({
-        genesisConfig,
-        init: true,
-        signatures: approve({
-          genesisConfig,
-          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
-          signers: [ownerKeys[0]!],
-        }),
+        initialConfig,
+        signatures: [childSignature],
       }),
     })
+    const nestedReceipt = (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [serialized],
+      })
+      .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+    expect(nestedReceipt.status).toBe('success')
+    expect(nestedReceipt.from).toBe(account)
+  })
+
+  test('example: fee sponsorship (owners sign first)', async () => {
+    const multisig = setup({ count: 2, threshold: 2 })
+    const feePayer = createKey()
+    await Promise.all([
+      bootstrap(multisig),
+      fundAddress(client, { address: feePayer.address }),
+    ])
+
+    const transaction = TxEnvelopeTempo.from({
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      chainId,
+      feePayerSignature: null,
+      nonce: 1n,
+      gas: 5_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+    const signedByOwners = TxEnvelopeTempo.from(transaction, {
+      signature: multisigSignature({
+        initialConfig: multisig.initialConfig,
+        payload: TxEnvelopeTempo.getSignPayload(transaction),
+        signers: multisig.ownerKeys,
+      }),
+    })
+    const sponsored = TxEnvelopeTempo.from({
+      ...signedByOwners,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+    })
+    const feePayerSignature = Secp256k1.sign({
+      payload: TxEnvelopeTempo.getFeePayerSignPayload(sponsored, {
+        sender: multisig.account,
+      }),
+      privateKey: feePayer.privateKey,
+    })
+    const receipt = await send(
+      TxEnvelopeTempo.serialize(sponsored, { feePayerSignature }),
+    )
+    expect(receipt.status).toBe('success')
+    expect(receipt.from).toBe(multisig.account)
+    expect(receipt.feePayer).toBe(feePayer.address)
+  })
+
+  test('example: fee sponsorship (fee payer signs first)', async () => {
+    const multisig = setup({ count: 2, threshold: 2 })
+    const feePayer = createKey()
+    await Promise.all([
+      bootstrap(multisig),
+      fundAddress(client, { address: feePayer.address }),
+    ])
+
+    const transaction = TxEnvelopeTempo.from({
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      chainId,
+      feePayerSignature: null,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      nonce: 1n,
+      gas: 5_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+    const feePayerSignature = Secp256k1.sign({
+      payload: TxEnvelopeTempo.getFeePayerSignPayload(transaction, {
+        sender: multisig.account,
+      }),
+      privateKey: feePayer.privateKey,
+    })
+    const sponsored = TxEnvelopeTempo.from(transaction, { feePayerSignature })
+    const receipt = await send(
+      TxEnvelopeTempo.serialize(sponsored, {
+        signature: multisigSignature({
+          initialConfig: multisig.initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(sponsored),
+          signers: multisig.ownerKeys,
+        }),
+      }),
+    )
+    expect(receipt.status).toBe('success')
+    expect(receipt.from).toBe(multisig.account)
+    expect(receipt.feePayer).toBe(feePayer.address)
+  })
+
+  test('example: weighted quorum', async () => {
+    const { account, initialConfig, ownerKeys } = setup({
+      count: 3,
+      threshold: 3,
+      weights: [2, 1, 1],
+    })
+
+    await fundAddress(client, { address: account })
+
+    const transaction = (nonce: bigint) =>
+      TxEnvelopeTempo.from({
+        calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+        chainId,
+        feeToken: '0x20c0000000000000000000000000000000000001',
+        nonce,
+        gas: 5_000_000n,
+        maxFeePerGas: Value.fromGwei('20'),
+        maxPriorityFeePerGas: Value.fromGwei('10'),
+      })
+    const serialize = (
+      value: ReturnType<typeof transaction>,
+      signers: readonly { privateKey: Hex.Hex }[],
+      init = false,
+    ) =>
+      TxEnvelopeTempo.serialize(value, {
+        signature: multisigSignature({
+          initialConfig,
+          init,
+          payload: TxEnvelopeTempo.getSignPayload(value),
+          signers,
+        }),
+      })
+
+    const bootstrap = transaction(0n)
+    const bootstrapReceipt = (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [serialize(bootstrap, [ownerKeys[0]!, ownerKeys[1]!], true)],
+      })
+      .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+    expect(bootstrapReceipt.status).toBe('success')
+
+    const valid = transaction(1n)
+    const validReceipt = (await client
+      .request({
+        method: 'eth_sendRawTransactionSync',
+        params: [serialize(valid, [ownerKeys[0]!, ownerKeys[2]!])],
+      })
+      .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
+    expect(validReceipt.status).toBe('success')
+
+    const belowThreshold = transaction(2n)
+    await expect(
+      client.request({
+        method: 'eth_sendRawTransactionSync',
+        params: [serialize(belowThreshold, [ownerKeys[1]!, ownerKeys[2]!])],
+      }),
+    ).rejects.toThrow()
 
     await expect(
       client.request({
         method: 'eth_sendRawTransactionSync',
-        params: [serialized_signed],
+        params: [serialize(belowThreshold, ownerKeys)],
       }),
     ).rejects.toThrow()
   })
 
   test('behavior: keychain access key (authorize, spend, reject config update)', async () => {
-    const { account, genesisConfig, ownerKeys } = setup({
+    const { account, initialConfig, ownerKeys } = setup({
       count: 2,
       threshold: 2,
     })
@@ -290,10 +568,10 @@ describe('behavior: multisig (TIP-1061)', () => {
 
     const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
       signature: SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         init: true,
         signatures: approve({
-          genesisConfig,
+          initialConfig,
           payload: TxEnvelopeTempo.getSignPayload(bootstrap),
           signers: ownerKeys,
         }),
@@ -340,9 +618,9 @@ describe('behavior: multisig (TIP-1061)', () => {
 
     const authorize_signed = TxEnvelopeTempo.serialize(authorize, {
       signature: SignatureEnvelope.from({
-        genesisConfig,
+        initialConfig,
         signatures: approve({
-          genesisConfig,
+          initialConfig,
           payload: TxEnvelopeTempo.getSignPayload(authorize),
           signers: ownerKeys,
         }),
@@ -411,9 +689,6 @@ describe('behavior: multisig (TIP-1061)', () => {
       ).toBe(account)
     }
 
-    const updateMultisigConfig = AbiFunction.from(
-      'function updateMultisigConfig(uint8 threshold, (address owner, uint8 weight)[] owners)',
-    )
     const updateNonce = await getTransactionCount(client, {
       address: account,
       blockTag: 'pending',
@@ -422,9 +697,9 @@ describe('behavior: multisig (TIP-1061)', () => {
       calls: [
         {
           to: '0xaacc000000000000000000000000000000000000',
-          data: AbiFunction.encodeData(updateMultisigConfig, [
-            genesisConfig.threshold,
-            genesisConfig.owners,
+          data: AbiFunction.encodeData(updateConfig, [
+            initialConfig.threshold,
+            initialConfig.owners,
           ]),
         },
       ],
@@ -456,127 +731,109 @@ describe('behavior: multisig (TIP-1061)', () => {
     expect(updateReceipt.status).toBe('reverted')
   })
 
-  test('behavior: rejects owner-signed `keyAuthorization` executed by multisig during bootstrap', async () => {
-    const { account, genesisConfig, ownerKeys } = setup({
-      count: 1,
-      threshold: 1,
-    })
+  test('example: bootstrap and immediate access key use', async () => {
+    const multisig = setup({ count: 2, threshold: 2 })
+    const accessKey = createKey()
+    await fundAddress(client, { address: multisig.account })
 
-    await fundAddress(client, { address: account })
-
-    const access = (() => {
-      const privateKey = Secp256k1.randomPrivateKey()
-      const address = Address.fromPublicKey(
-        Secp256k1.getPublicKey({ privateKey }),
-      )
-      return { address, privateKey } as const
-    })()
-
-    const keyAuth = KeyAuthorization.from({
-      address: access.address,
+    const keyAuthorization = KeyAuthorization.from({
+      account: multisig.account,
+      address: accessKey.address,
       chainId: BigInt(chainId),
+      isAdmin: false,
       type: 'secp256k1',
     })
-    const keyAuth_signed = KeyAuthorization.from(keyAuth, {
-      signature: SignatureEnvelope.from(
-        Secp256k1.sign({
-          payload: KeyAuthorization.getSignPayload(keyAuth),
-          privateKey: ownerKeys[0]!.privateKey,
-        }),
-      ),
+    const keyAuthorizationSigned = KeyAuthorization.from(keyAuthorization, {
+      signature: multisigSignature({
+        initialConfig: multisig.initialConfig,
+        init: true,
+        payload: KeyAuthorization.getSignPayload(keyAuthorization),
+        signers: multisig.ownerKeys,
+      }),
     })
-
-    const bootstrap = TxEnvelopeTempo.from({
+    const transaction = TxEnvelopeTempo.from({
       calls: [{ to: '0x0000000000000000000000000000000000000000' }],
       chainId,
       feeToken: '0x20c0000000000000000000000000000000000001',
-      keyAuthorization: keyAuth_signed,
+      keyAuthorization: keyAuthorizationSigned,
       nonce: 0n,
       gas: 5_000_000n,
       maxFeePerGas: Value.fromGwei('20'),
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
-
-    const serialized_signed = TxEnvelopeTempo.serialize(bootstrap, {
-      signature: SignatureEnvelope.from({
-        genesisConfig,
-        init: true,
-        signatures: approve({
-          genesisConfig,
-          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
-          signers: ownerKeys,
+    const receipt = await send(
+      TxEnvelopeTempo.serialize(transaction, {
+        signature: accessKeySignature({
+          accessKey,
+          account: multisig.account,
+          transaction,
         }),
       }),
-    })
-
-    await expect(
-      client.request({
-        method: 'eth_sendRawTransactionSync',
-        params: [serialized_signed],
-      }),
-    ).rejects.toThrow(
-      'native multisig transactions cannot carry key_authorization',
     )
+    expect(receipt.status).toBe('success')
+    expect(receipt.from).toBe(multisig.account)
   })
 
-  test('behavior: rejects owner-signed `keyAuthorization` executed by access key before bootstrap', async () => {
-    const { account, ownerKeys } = setup({
-      count: 1,
-      threshold: 1,
-    })
+  test('example: bootstrap and subsequent access key use', async () => {
+    const multisig = setup({ count: 2, threshold: 2 })
+    const accessKey = createKey()
+    await fundAddress(client, { address: multisig.account })
 
-    await fundAddress(client, { address: account })
-
-    const access = (() => {
-      const privateKey = Secp256k1.randomPrivateKey()
-      const address = Address.fromPublicKey(
-        Secp256k1.getPublicKey({ privateKey }),
-      )
-      return { address, privateKey } as const
-    })()
-
-    const keyAuth = KeyAuthorization.from({
-      address: access.address,
+    const keyAuthorization = KeyAuthorization.from({
+      account: multisig.account,
+      address: accessKey.address,
       chainId: BigInt(chainId),
+      isAdmin: false,
       type: 'secp256k1',
     })
-    const keyAuth_signed = KeyAuthorization.from(keyAuth, {
-      signature: SignatureEnvelope.from(
-        Secp256k1.sign({
-          payload: KeyAuthorization.getSignPayload(keyAuth),
-          privateKey: ownerKeys[0]!.privateKey,
-        }),
-      ),
+    const keyAuthorizationSigned = KeyAuthorization.from(keyAuthorization, {
+      signature: multisigSignature({
+        initialConfig: multisig.initialConfig,
+        payload: KeyAuthorization.getSignPayload(keyAuthorization),
+        signers: multisig.ownerKeys,
+      }),
     })
-
-    const bootstrap = TxEnvelopeTempo.from({
+    const bootstrapTransaction = TxEnvelopeTempo.from({
       calls: [{ to: '0x0000000000000000000000000000000000000000' }],
       chainId,
       feeToken: '0x20c0000000000000000000000000000000000001',
-      keyAuthorization: keyAuth_signed,
+      keyAuthorization: keyAuthorizationSigned,
       nonce: 0n,
       gas: 5_000_000n,
       maxFeePerGas: Value.fromGwei('20'),
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
-
-    const signature = Secp256k1.sign({
-      payload: TxEnvelopeTempo.getSignPayload(bootstrap, { from: account }),
-      privateKey: access.privateKey,
-    })
-    const serialized_signed = TxEnvelopeTempo.serialize(bootstrap, {
-      signature: SignatureEnvelope.from({
-        userAddress: account,
-        inner: SignatureEnvelope.from(signature),
-        type: 'keychain',
+    const bootstrapReceipt = await send(
+      TxEnvelopeTempo.serialize(bootstrapTransaction, {
+        signature: multisigSignature({
+          initialConfig: multisig.initialConfig,
+          init: true,
+          payload: TxEnvelopeTempo.getSignPayload(bootstrapTransaction),
+          signers: multisig.ownerKeys,
+        }),
       }),
-    })
+    )
+    expect(bootstrapReceipt.status).toBe('success')
 
-    await expect(
-      client.request({
-        method: 'eth_sendRawTransactionSync',
-        params: [serialized_signed],
+    const transaction = TxEnvelopeTempo.from({
+      calls: [{ to: '0x0000000000000000000000000000000000000000' }],
+      chainId,
+      feeToken: '0x20c0000000000000000000000000000000000001',
+      nonce: 1n,
+      gas: 5_000_000n,
+      maxFeePerGas: Value.fromGwei('20'),
+      maxPriorityFeePerGas: Value.fromGwei('10'),
+    })
+    const receipt = await send(
+      TxEnvelopeTempo.serialize(transaction, {
+        signature: accessKeySignature({
+          accessKey,
+          account: multisig.account,
+          transaction,
+        }),
       }),
-    ).rejects.toThrow('admin-signed key authorization account mismatch')
+    )
+    expect(receipt.status).toBe('success')
+    expect(receipt.from).toBe(multisig.account)
   })
 })

--- a/test/tempo/multisig.ts
+++ b/test/tempo/multisig.ts
@@ -1,3 +1,3 @@
 export const port = 3001
 
-export const tag = 'sha-6d831c2'
+export const tag = 'sha-4e74a2c'


### PR DESCRIPTION
Aligns Ox v0 native multisig with https://github.com/tempoxyz/tempo/pull/4069 by adding config-version signing, multisig key authorization, current protocol limits, `initialConfig` naming, and the TIP example coverage.
