### PR TITLE
fix(siwe): reject unparseable expirationTime and notBefore

### DIFF
--- a/.changeset/siwe-invalid-date-fail-closed.md
+++ b/.changeset/siwe-invalid-date-fail-closed.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+**SIWE:** Reject unparseable `expirationTime` / `notBefore` (and invalid caller `time`) so Invalid Date comparisons cannot skip lifetime checks.

--- a/src/core/Siwe.ts
+++ b/src/core/Siwe.ts
@@ -23,6 +23,19 @@ export const prefixRegex =
 export const suffixRegex =
   /(?:URI: (?<uri>.+))\n(?:Version: (?<version>.+))\n(?:Chain ID: (?<chainId>\d+))\n(?:Nonce: (?<nonce>[a-zA-Z0-9]+))\n(?:Issued At: (?<issuedAt>.+))(?:\nExpiration Time: (?<expirationTime>.+))?(?:\nNot Before: (?<notBefore>.+))?(?:\nRequest ID: (?<requestId>.+))?/
 
+const siweDateTimeRegex =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/
+
+function isValidSiweDateTime(value: string): boolean {
+  if (!siweDateTimeRegex.test(value)) return false
+  return !Number.isNaN(new Date(value).getTime())
+}
+
+function parseSiweDateTime(value: string): Date {
+  if (!isValidSiweDateTime(value)) return new Date(Number.NaN)
+  return new Date(value)
+}
+
 /** [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) message fields. */
 export type Message = {
   /**
@@ -388,9 +401,11 @@ export function parseMessage(message: string): ExactPartial<Message> {
     ...prefix,
     ...suffix,
     ...(chainId ? { chainId: Number(chainId) } : {}),
-    ...(expirationTime ? { expirationTime: new Date(expirationTime) } : {}),
-    ...(issuedAt ? { issuedAt: new Date(issuedAt) } : {}),
-    ...(notBefore ? { notBefore: new Date(notBefore) } : {}),
+    ...(expirationTime
+      ? { expirationTime: parseSiweDateTime(expirationTime) }
+      : {}),
+    ...(issuedAt ? { issuedAt: parseSiweDateTime(issuedAt) } : {}),
+    ...(notBefore ? { notBefore: parseSiweDateTime(notBefore) } : {}),
     ...(requestId ? { requestId } : {}),
     ...(resources ? { resources } : {}),
     ...(scheme ? { scheme } : {}),
@@ -431,8 +446,16 @@ export function validateMessage(value: validateMessage.Value): boolean {
   if (nonce && message.nonce !== nonce) return false
   if (scheme && message.scheme !== scheme) return false
 
-  if (message.expirationTime && time >= message.expirationTime) return false
-  if (message.notBefore && time < message.notBefore) return false
+  if (Number.isNaN(time.getTime())) return false
+
+  if (message.expirationTime) {
+    if (Number.isNaN(message.expirationTime.getTime())) return false
+    if (time >= message.expirationTime) return false
+  }
+  if (message.notBefore) {
+    if (Number.isNaN(message.notBefore.getTime())) return false
+    if (time < message.notBefore) return false
+  }
 
   try {
     if (!message.address) return false

--- a/src/core/_test/Siwe.test.ts
+++ b/src/core/_test/Siwe.test.ts
@@ -546,6 +546,20 @@ Expiration Time: 2022-02-04T00:00:00.000Z`
     )
   })
 
+  test('behavior: non-RFC3339 expirationTime yields Invalid Date', () => {
+    const message = `https://example.com wants you to sign in with your Ethereum account:
+0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
+
+URI: https://example.com/path
+Version: 1
+Chain ID: 1
+Nonce: foobarbaz
+Issued At: 2023-02-01T00:00:00.000Z
+Expiration Time: never`
+    const parsed = Siwe.parseMessage(message)
+    expect(Number.isNaN(parsed.expirationTime?.getTime())).toBeTruthy()
+  })
+
   test('behavior: with notBefore', () => {
     const message = `https://example.com wants you to sign in with your Ethereum account:
 0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
@@ -726,6 +740,42 @@ describe('validateMessage', () => {
           expirationTime: new Date(Date.UTC(2024, 1, 1)),
         },
         time: new Date(Date.UTC(2025, 1, 1)),
+      }),
+    ).toBeFalsy()
+  })
+
+  test('behavior: unparseable expirationTime', () => {
+    expect(
+      Siwe.validateMessage({
+        message: {
+          ...message,
+          expirationTime: new Date('never'),
+        },
+        time: new Date(Date.UTC(2024, 1, 1)),
+      }),
+    ).toBeFalsy()
+  })
+
+  test('behavior: unparseable notBefore', () => {
+    expect(
+      Siwe.validateMessage({
+        message: {
+          ...message,
+          notBefore: new Date('not-a-date'),
+        },
+        time: new Date(Date.UTC(2024, 1, 1)),
+      }),
+    ).toBeFalsy()
+  })
+
+  test('behavior: invalid time', () => {
+    expect(
+      Siwe.validateMessage({
+        message: {
+          ...message,
+          expirationTime: new Date(Date.UTC(2030, 1, 1)),
+        },
+        time: new Date('never'),
       }),
     ).toBeFalsy()
   })


### PR DESCRIPTION
`Siwe.validateMessage` treated a present but unparseable `expirationTime` / `notBefore` (and an invalid caller `time`) as a skipped check.

`new Date("never")` is a truthy Invalid Date. Comparisons against it are always false, so a signed SIWE message with `Expiration Time: never` still validated.

This is the same class as wevm/viem#4990. The signer already controls the message text. The remaining server guard is the lifetime window. Unparseable timestamps turn that guard into a no-op.

## Change

- Parse SIWE date-times as RFC 3339 / EIP-4361 before `Date` coercion (`parseMessage`).
- Fail closed in `validateMessage` when `time`, `expirationTime`, or `notBefore` is Invalid Date.
- Keep rejecting a real past expiration.

## Test

`pnpm test --project core src/core/_test/Siwe.test.ts` (68/68). Revert-tested: the three new assertions fail when the guards are removed.


Made with [Cursor](https://cursor.com)