### PR TITLE
feat: add seed and mnemonic key derivation

### DIFF
--- a/.changeset/tidy-seeds-derive.md
+++ b/.changeset/tidy-seeds-derive.md
@@ -2,4 +2,4 @@
 'ox': minor
 ---
 
-Added domain-separated seed and BIP-39 mnemonic derivation for P256, Secp256k1, Ed25519, ML-DSA-44, and AES-GCM keys.
+Added seed and BIP-39 mnemonic key derivation for P256, Secp256k1, Ed25519, ML-DSA-44, and AES-GCM, with domain separation for non-HD derivations.

--- a/.changeset/tidy-seeds-derive.md
+++ b/.changeset/tidy-seeds-derive.md
@@ -2,4 +2,4 @@
 'ox': minor
 ---
 
-Added domain-separated seed derivation for P256, Secp256k1, Ed25519, ML-DSA-44, and AES-GCM keys.
+Added domain-separated seed and BIP-39 mnemonic derivation for P256, Secp256k1, Ed25519, ML-DSA-44, and AES-GCM keys.

--- a/.changeset/tidy-seeds-derive.md
+++ b/.changeset/tidy-seeds-derive.md
@@ -1,0 +1,5 @@
+---
+'ox': minor
+---
+
+Added domain-separated seed derivation for P256, Secp256k1, Ed25519, ML-DSA-44, and AES-GCM keys.

--- a/site/src/pages/guides/crypto/index.mdx
+++ b/site/src/pages/guides/crypto/index.mdx
@@ -44,6 +44,12 @@ const signer = Secp256k1.recoverAddress({ payload, signature })
   />
   <Card
     icon="lucide:key-round"
+    title="Derive Keys from a Seed"
+    description="Derive independent signing and encryption keys from one root seed."
+    to="/guides/crypto/seed-key-derivation"
+  />
+  <Card
+    icon="lucide:key-round"
     title="Ed25519 & X25519"
     description="Sign with Ed25519 and derive shared secrets with X25519."
     to="/guides/crypto/ed25519-x25519"

--- a/site/src/pages/guides/crypto/seed-key-derivation.mdx
+++ b/site/src/pages/guides/crypto/seed-key-derivation.mdx
@@ -75,12 +75,15 @@ const mlDsa44PrivateKey = MlDsa44.fromMnemonic(phrase)
 const encryptionKey = await AesGcm.fromMnemonic(phrase)
 ```
 
-Each `fromMnemonic` function is equivalent to
+`Secp256k1.fromMnemonic` is equivalent to `Mnemonic.toPrivateKey` and uses the standard
+`m/44'/60'/0'/0/0` path by default. Pass a `path` option to derive another account.
+
+The other `fromMnemonic` functions are equivalent to
 `fromSeed(Mnemonic.toSeed(phrase, { passphrase }))`.
 
 :::warning
-Mnemonic-derived keys use Ox's `fromSeed` derivation domains. They are not BIP-32 child keys and
-will not match wallet keys derived from paths such as `m/44'/60'/0'/0/0`.
+P256, Ed25519, ML-DSA-44, and AES-GCM mnemonic-derived keys use Ox's `fromSeed` derivation domains.
+They are not BIP-32 child keys. Only `Secp256k1.fromMnemonic` follows a BIP-32 derivation path.
 :::
 
 ## Best Practices
@@ -97,9 +100,9 @@ with the same Ox API and seed instead of implementing the HMAC construction sepa
 
 ### Use HD Paths for Multiple Ethereum Accounts
 
-`Secp256k1.fromSeed` and `Secp256k1.fromMnemonic` each produce one deterministic secp256k1 key.
-Use [`HdKey`](/api/HdKey) or [`Mnemonic`](/api/Mnemonic) when you need multiple interoperable
-Ethereum accounts with BIP-32 derivation paths.
+`Secp256k1.fromMnemonic` derives an interoperable Ethereum account at its default path. Pass a
+different `path`, or use [`HdKey`](/api/HdKey) or [`Mnemonic`](/api/Mnemonic), when you need
+multiple accounts.
 
 ## See More
 

--- a/site/src/pages/guides/crypto/seed-key-derivation.mdx
+++ b/site/src/pages/guides/crypto/seed-key-derivation.mdx
@@ -1,0 +1,120 @@
+---
+description: Derive independent signing and encryption keys from one root seed.
+---
+
+import { Card, Cards } from 'vocs'
+
+# Derive Keys from a Seed
+
+## Overview
+
+Use a cryptographically strong root seed to deterministically derive keys for multiple
+algorithms. [`Secp256k1`](/api/Secp256k1), [`P256`](/api/P256),
+[`Ed25519`](/api/Ed25519), [`MlDsa44`](/api/MlDsa44), and [`AesGcm`](/api/AesGcm) each expose
+a `fromSeed` function that accepts at least 32 bytes of key material.
+
+Each function applies its own fixed, versioned HMAC-SHA256 derivation domain. The same seed
+therefore reproduces the same key for a given module without reusing raw key material across
+algorithms.
+
+```ts twoslash
+import { AesGcm, Ed25519, Hex, MlDsa44, P256, Secp256k1 } from 'ox'
+
+const seed = Hex.random(32)
+
+const secp256k1PrivateKey = Secp256k1.fromSeed(seed)
+const p256PrivateKey = P256.fromSeed(seed)
+const ed25519PrivateKey = Ed25519.fromSeed(seed)
+const mlDsa44PrivateKey = MlDsa44.fromSeed(seed)
+const encryptionKey = await AesGcm.fromSeed(seed)
+```
+
+:::warning
+Do not pass a password or other human-readable text directly to `fromSeed`. Passwords do not
+contain enough entropy, and `fromSeed` does not perform password stretching. Use a password KDF
+first, or generate at least 32 random bytes.
+:::
+
+## Recipes
+
+### Generate a Root Seed
+
+[`Bytes.random`](/api/Bytes/random) uses the platform's cryptographically secure random number
+generator. Store the root seed as the single secret needed to reproduce every derived key.
+
+```ts twoslash
+import { AesGcm, Bytes, Ed25519, MlDsa44, P256, Secp256k1 } from 'ox'
+
+const seed = Bytes.random(32) // [!code hl]
+
+const secp256k1PrivateKey = Secp256k1.fromSeed(seed)
+const p256PrivateKey = P256.fromSeed(seed)
+const ed25519PrivateKey = Ed25519.fromSeed(seed)
+const mlDsa44PrivateKey = MlDsa44.fromSeed(seed)
+const encryptionKey = await AesGcm.fromSeed(seed)
+```
+
+`AesGcm.fromSeed` is async and returns a non-extractable AES-256-GCM `CryptoKey`. The signing
+modules return a hex private key by default; pass `{ as: 'Bytes' }` when mutable bytes are more
+appropriate.
+
+### Restore Keys from a Recovery Phrase
+
+[`Mnemonic.toSeed`](/api/Mnemonic/toSeed) converts a valid BIP-39 recovery phrase into 64 bytes
+of seed material. Passing that seed to the same `fromSeed` functions restores the same keys.
+
+```ts twoslash
+import { Ed25519, MlDsa44, Mnemonic, P256, Secp256k1 } from 'ox'
+
+const phrase = Mnemonic.random(Mnemonic.english)
+const seed = Mnemonic.toSeed(phrase) // [!code hl]
+
+const secp256k1PrivateKey = Secp256k1.fromSeed(seed)
+const p256PrivateKey = P256.fromSeed(seed)
+const ed25519PrivateKey = Ed25519.fromSeed(seed)
+const mlDsa44PrivateKey = MlDsa44.fromSeed(seed)
+```
+
+These keys use Ox's `fromSeed` derivation domains. They are not BIP-32 child keys and will not
+match wallet keys derived from paths such as `m/44'/60'/0'/0/0`.
+
+## Best Practices
+
+### Protect the Root Seed
+
+Anyone with the root seed can reproduce every derived key. Keep it out of logs, analytics, URLs,
+and plaintext storage. Back it up with the same protections as a wallet recovery phrase.
+
+### Keep the Derivation Contract Stable
+
+Each module's versioned domain is part of its deterministic derivation contract. Re-derive keys
+with the same Ox API and seed instead of implementing the HMAC construction separately.
+
+### Use HD Paths for Multiple Ethereum Accounts
+
+`Secp256k1.fromSeed` produces one deterministic secp256k1 key for a seed. Use
+[`HdKey`](/api/HdKey) or [`Mnemonic`](/api/Mnemonic) when you need multiple interoperable
+Ethereum accounts with BIP-32 derivation paths.
+
+## See More
+
+<Cards>
+  <Card
+    icon="lucide:list-tree"
+    title="Mnemonics & HD Wallets"
+    description="Derive interoperable Ethereum accounts with BIP-32 paths."
+    to="/guides/accounts/mnemonics-hd"
+  />
+  <Card
+    icon="lucide:fingerprint"
+    title="Derive Secrets with PRF"
+    description="Derive keys from a WebAuthn passkey instead of a stored seed."
+    to="/guides/webauthn/prf"
+  />
+  <Card
+    icon="lucide:lock"
+    title="Work with AES-GCM"
+    description="Encrypt and decrypt data with the derived encryption key."
+    to="/guides/crypto/encryption"
+  />
+</Cards>

--- a/site/src/pages/guides/crypto/seed-key-derivation.mdx
+++ b/site/src/pages/guides/crypto/seed-key-derivation.mdx
@@ -11,7 +11,7 @@ import { Card, Cards } from 'vocs'
 Use a cryptographically strong root seed to deterministically derive keys for multiple
 algorithms. [`Secp256k1`](/api/Secp256k1), [`P256`](/api/P256),
 [`Ed25519`](/api/Ed25519), [`MlDsa44`](/api/MlDsa44), and [`AesGcm`](/api/AesGcm) each expose
-a `fromSeed` function that accepts at least 32 bytes of key material.
+`fromSeed` and `fromMnemonic` functions.
 
 Each function applies its own fixed, versioned HMAC-SHA256 derivation domain. The same seed
 therefore reproduces the same key for a given module without reusing raw key material across
@@ -60,23 +60,28 @@ appropriate.
 
 ### Restore Keys from a Recovery Phrase
 
-[`Mnemonic.toSeed`](/api/Mnemonic/toSeed) converts a valid BIP-39 recovery phrase into 64 bytes
-of seed material. Passing that seed to the same `fromSeed` functions restores the same keys.
+Pass a BIP-39 recovery phrase directly to each module's `fromMnemonic` function. An optional
+`passphrase` is forwarded to the BIP-39 seed derivation.
 
 ```ts twoslash
-import { Ed25519, MlDsa44, Mnemonic, P256, Secp256k1 } from 'ox'
+import { AesGcm, Ed25519, MlDsa44, Mnemonic, P256, Secp256k1 } from 'ox'
 
 const phrase = Mnemonic.random(Mnemonic.english)
-const seed = Mnemonic.toSeed(phrase) // [!code hl]
 
-const secp256k1PrivateKey = Secp256k1.fromSeed(seed)
-const p256PrivateKey = P256.fromSeed(seed)
-const ed25519PrivateKey = Ed25519.fromSeed(seed)
-const mlDsa44PrivateKey = MlDsa44.fromSeed(seed)
+const secp256k1PrivateKey = Secp256k1.fromMnemonic(phrase)
+const p256PrivateKey = P256.fromMnemonic(phrase)
+const ed25519PrivateKey = Ed25519.fromMnemonic(phrase)
+const mlDsa44PrivateKey = MlDsa44.fromMnemonic(phrase)
+const encryptionKey = await AesGcm.fromMnemonic(phrase)
 ```
 
-These keys use Ox's `fromSeed` derivation domains. They are not BIP-32 child keys and will not
-match wallet keys derived from paths such as `m/44'/60'/0'/0/0`.
+Each `fromMnemonic` function is equivalent to
+`fromSeed(Mnemonic.toSeed(phrase, { passphrase }))`.
+
+:::warning
+Mnemonic-derived keys use Ox's `fromSeed` derivation domains. They are not BIP-32 child keys and
+will not match wallet keys derived from paths such as `m/44'/60'/0'/0/0`.
+:::
 
 ## Best Practices
 
@@ -92,8 +97,8 @@ with the same Ox API and seed instead of implementing the HMAC construction sepa
 
 ### Use HD Paths for Multiple Ethereum Accounts
 
-`Secp256k1.fromSeed` produces one deterministic secp256k1 key for a seed. Use
-[`HdKey`](/api/HdKey) or [`Mnemonic`](/api/Mnemonic) when you need multiple interoperable
+`Secp256k1.fromSeed` and `Secp256k1.fromMnemonic` each produce one deterministic secp256k1 key.
+Use [`HdKey`](/api/HdKey) or [`Mnemonic`](/api/Mnemonic) when you need multiple interoperable
 Ethereum accounts with BIP-32 derivation paths.
 
 ## See More

--- a/site/src/pages/guides/crypto/seed-key-derivation.mdx
+++ b/site/src/pages/guides/crypto/seed-key-derivation.mdx
@@ -13,9 +13,9 @@ algorithms. [`Secp256k1`](/api/Secp256k1), [`P256`](/api/P256),
 [`Ed25519`](/api/Ed25519), [`MlDsa44`](/api/MlDsa44), and [`AesGcm`](/api/AesGcm) each expose
 `fromSeed` and `fromMnemonic` functions.
 
-Each function applies its own fixed, versioned HMAC-SHA256 derivation domain. The same seed
-therefore reproduces the same key for a given module without reusing raw key material across
-algorithms.
+Each `fromSeed` function applies its own fixed, versioned HMAC-SHA256 derivation domain. The same
+seed therefore reproduces the same key for a given module without reusing raw key material
+across algorithms.
 
 ```ts twoslash
 import { AesGcm, Ed25519, Hex, MlDsa44, P256, Secp256k1 } from 'ox'
@@ -57,6 +57,36 @@ const encryptionKey = await AesGcm.fromSeed(seed)
 `AesGcm.fromSeed` is async and returns a non-extractable AES-256-GCM `CryptoKey`. The signing
 modules return a hex private key by default; pass `{ as: 'Bytes' }` when mutable bytes are more
 appropriate.
+
+### Derive a Seed from a Password
+
+Use [`Keystore.scryptAsync`](/api/Keystore/scryptAsync) when the root secret is a strong password
+instead of random bytes. Scrypt derives a 32-byte seed and makes each password guess more
+expensive, but it does not increase the password's entropy.
+
+```ts twoslash
+import { AesGcm, Bytes, Keystore, P256, Secp256k1 } from 'ox'
+
+const salt = Bytes.random(32)
+const [getSeed] = await Keystore.scryptAsync({
+  password: 'your-long-unique-password',
+  salt,
+})
+const seed = getSeed()
+
+const secp256k1PrivateKey = Secp256k1.fromSeed(seed)
+const p256PrivateKey = P256.fromSeed(seed)
+const encryptionKey = await AesGcm.fromSeed(seed)
+```
+
+Store the salt and scrypt parameters with your account metadata or backup. They are not secret,
+but the same values are required to reproduce the seed. `getSeed` returns the already-derived
+key; calling it does not run scrypt again.
+
+:::warning
+Scrypt does not prevent brute-force attacks. Never use short or common text such as `lolcats`.
+Prefer a long, unique password, a recovery phrase, or a randomly generated root seed.
+:::
 
 ### Restore Keys from a Recovery Phrase
 

--- a/site/vocs.config.ts
+++ b/site/vocs.config.ts
@@ -225,6 +225,10 @@ export default defineConfig({
                 link: '/guides/crypto/signatures',
               },
               {
+                text: 'Derive Keys from a Seed',
+                link: '/guides/crypto/seed-key-derivation',
+              },
+              {
                 text: 'Ed25519 & X25519',
                 link: '/guides/crypto/ed25519-x25519',
               },

--- a/src/core/AesGcm.ts
+++ b/src/core/AesGcm.ts
@@ -138,8 +138,8 @@ export declare namespace encrypt {
  * Derives an AES-256-GCM key from a 32-byte WebAuthn PRF output.
  *
  * The permanent derivation contract uses the PRF output as the HMAC-SHA256
- * key. Its message is the UTF-8 bytes of `ox.aesGcm.fromPrf.v1` followed by
- * a 32-bit big-endian counter set to zero.
+ * key. The HMAC message uses the `ox.aesGcm.fromPrf.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
  *
  * @example
  * ```ts twoslash
@@ -158,35 +158,7 @@ export async function fromPrf(
 ): Promise<CryptoKey> {
   const bytes = Bytes.from(value)
   if (bytes.length !== 32) throw new InvalidPrfSizeError({ size: bytes.length })
-
-  const prfKey = await globalThis.crypto.subtle.importKey(
-    'raw',
-    bytes,
-    {
-      name: 'HMAC',
-      hash: 'SHA-256',
-    },
-    false,
-    ['sign'],
-  )
-  const key = new Uint8Array(
-    await globalThis.crypto.subtle.sign(
-      'HMAC',
-      prfKey,
-      Bytes.concat(fromPrfLabel, Bytes.fromNumber(0, { size: 4 })),
-    ),
-  )
-  try {
-    return await globalThis.crypto.subtle.importKey(
-      'raw',
-      key,
-      { name: 'AES-GCM' },
-      false,
-      ['encrypt', 'decrypt'],
-    )
-  } finally {
-    key.fill(0)
-  }
+  return deriveKey(bytes, fromPrfDomain)
 }
 
 export declare namespace fromPrf {
@@ -195,6 +167,45 @@ export declare namespace fromPrf {
     | Bytes.from.ErrorType
     | Bytes.fromNumber.ErrorType
     | InvalidPrfSizeError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an AES-256-GCM key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.aesGcm.fromSeed.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
+ *
+ * @example
+ * ```ts twoslash
+ * import { AesGcm } from 'ox'
+ *
+ * const key = await AesGcm.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @returns A nonextractable AES-256-GCM key for encryption and decryption.
+ */
+export async function fromSeed(
+  seed: Hex.Hex | Bytes.Bytes,
+): Promise<CryptoKey> {
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+  return deriveKey(bytes, fromSeedDomain)
+}
+
+export declare namespace fromSeed {
+  type ErrorType =
+    | Bytes.concat.ErrorType
+    | Bytes.from.ErrorType
+    | Bytes.fromNumber.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -290,4 +301,58 @@ export declare namespace InvalidPrfSizeError {
   }
 }
 
-const fromPrfLabel = Bytes.fromString('ox.aesGcm.fromPrf.v1')
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'AesGcm.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for {@link ox#AesGcm.InvalidSeedSizeError}. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+async function deriveKey(
+  seed: Bytes.Bytes,
+  domain: Bytes.Bytes,
+): Promise<CryptoKey> {
+  const baseKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    seed,
+    {
+      name: 'HMAC',
+      hash: 'SHA-256',
+    },
+    false,
+    ['sign'],
+  )
+  const key = new Uint8Array(
+    await globalThis.crypto.subtle.sign(
+      'HMAC',
+      baseKey,
+      Bytes.concat(domain, Bytes.fromNumber(0, { size: 4 })),
+    ),
+  )
+  try {
+    return await globalThis.crypto.subtle.importKey(
+      'raw',
+      key,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt'],
+    )
+  } finally {
+    key.fill(0)
+  }
+}
+
+const fromPrfDomain = Bytes.fromString('ox.aesGcm.fromPrf.v1')
+const fromSeedDomain = Bytes.fromString('ox.aesGcm.fromSeed.v1')

--- a/src/core/AesGcm.ts
+++ b/src/core/AesGcm.ts
@@ -1,6 +1,7 @@
 import * as Bytes from './Bytes.js'
 import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
+import * as mnemonic_ from './internal/mnemonic.js'
 
 export const ivLength = 16
 
@@ -168,6 +169,47 @@ export declare namespace fromPrf {
     | Bytes.fromNumber.ErrorType
     | InvalidPrfSizeError
     | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an AES-256-GCM key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to {@link ox#AesGcm.fromSeed}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { AesGcm } from 'ox'
+ *
+ * const key = await AesGcm.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns A nonextractable AES-256-GCM key for encryption and decryption.
+ */
+export async function fromMnemonic(
+  mnemonic: string,
+  options: fromMnemonic.Options = {},
+): Promise<CryptoKey> {
+  const { passphrase } = options
+  const seed = mnemonic_.toSeed(mnemonic, passphrase)
+  try {
+    return await fromSeed(seed)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options = {
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ErrorType = fromSeed.ErrorType
 }
 
 /**

--- a/src/core/Ed25519.ts
+++ b/src/core/Ed25519.ts
@@ -5,6 +5,7 @@ import * as Hash from './Hash.js'
 import * as Hex from './Hex.js'
 import * as engine from './internal/ed25519.js'
 import * as keyDerivation from './internal/keyDerivation.js'
+import * as mnemonic_ from './internal/mnemonic.js'
 
 /** Re-export of noble/curves Ed25519 utilities. */
 export const noble = ed25519
@@ -122,6 +123,54 @@ export declare namespace fromPrf {
     | Hex.fromBytes.ErrorType
     | InvalidPrfSizeError
     | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an Ed25519 private key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to {@link ox#Ed25519.fromSeed}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const privateKey = Ed25519.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns An Ed25519 private key.
+ */
+export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  mnemonic: string,
+  options: fromMnemonic.Options<as> = {},
+): fromMnemonic.ReturnType<as> {
+  const { passphrase } = options
+  const seed = mnemonic_.toSeed(mnemonic, passphrase)
+  try {
+    return fromSeed(seed, options)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = fromSeed.ReturnType<as>
+
+  type ErrorType = fromSeed.ErrorType
 }
 
 /**

--- a/src/core/Ed25519.ts
+++ b/src/core/Ed25519.ts
@@ -4,6 +4,7 @@ import * as Errors from './Errors.js'
 import * as Hash from './Hash.js'
 import * as Hex from './Hex.js'
 import * as engine from './internal/ed25519.js'
+import * as keyDerivation from './internal/keyDerivation.js'
 
 /** Re-export of noble/curves Ed25519 utilities. */
 export const noble = ed25519
@@ -63,8 +64,8 @@ export declare namespace createKeyPair {
  * Derives an Ed25519 private key from a 32-byte WebAuthn PRF output.
  *
  * The permanent derivation contract uses the PRF output as the HMAC-SHA256
- * key. Its message is the UTF-8 bytes of `ox.ed25519.fromPrf.v1` followed by
- * a 32-bit big-endian counter set to zero.
+ * key. The HMAC message uses the `ox.ed25519.fromPrf.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
  *
  * @example
  * ```ts twoslash
@@ -89,7 +90,7 @@ export function fromPrf<as extends 'Hex' | 'Bytes' = 'Hex'>(
 
   const privateKey = Hash.hmac256(
     bytes,
-    Bytes.concat(fromPrfLabel, Bytes.fromNumber(0, { size: 4 })),
+    Bytes.concat(fromPrfDomain, Bytes.fromNumber(0, { size: 4 })),
     { as: 'Bytes' },
   )
   if (as === 'Hex') {
@@ -120,6 +121,67 @@ export declare namespace fromPrf {
     | Hash.hmac256.ErrorType
     | Hex.fromBytes.ErrorType
     | InvalidPrfSizeError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an Ed25519 private key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.ed25519.fromSeed.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const privateKey = Ed25519.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @param options - Options.
+ * @returns An Ed25519 private key.
+ */
+export function fromSeed<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  seed: Hex.Hex | Bytes.Bytes,
+  options: fromSeed.Options<as> = {},
+): fromSeed.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+
+  const privateKey = keyDerivation.derive(bytes, fromSeedDomain)
+  if (as === 'Hex') {
+    const value = Hex.fromBytes(privateKey)
+    privateKey.fill(0)
+    return value as never
+  }
+  return privateKey as never
+}
+
+export declare namespace fromSeed {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | keyDerivation.derive.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -430,4 +492,24 @@ export declare namespace InvalidPrfSizeError {
   }
 }
 
-const fromPrfLabel = Bytes.fromString('ox.ed25519.fromPrf.v1')
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'Ed25519.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for {@link ox#Ed25519.InvalidSeedSizeError}. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+const fromPrfDomain = Bytes.fromString('ox.ed25519.fromPrf.v1')
+const fromSeedDomain = Bytes.fromString('ox.ed25519.fromSeed.v1')

--- a/src/core/MlDsa44.ts
+++ b/src/core/MlDsa44.ts
@@ -4,6 +4,7 @@ import * as Errors from './Errors.js'
 import * as Hash from './Hash.js'
 import * as Hex from './Hex.js'
 import * as Entropy from './internal/entropy.js'
+import * as keyDerivation from './internal/keyDerivation.js'
 import * as engine from './internal/mlDsa44.js'
 
 /** Re-export of noble/post-quantum ML-DSA-44 utilities. */
@@ -77,8 +78,8 @@ export declare namespace createKeyPair {
  * Derives an ML-DSA-44 private key from a 32-byte WebAuthn PRF output.
  *
  * The permanent derivation contract uses the PRF output as the HMAC-SHA256
- * key. Its message is the UTF-8 bytes of `ox.mldsa44.fromPrf.v1` followed by
- * a 32-bit big-endian counter set to zero.
+ * key. The HMAC message uses the `ox.mldsa44.fromPrf.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
  *
  * @example
  * ```ts twoslash
@@ -103,7 +104,7 @@ export function fromPrf<as extends 'Hex' | 'Bytes' = 'Hex'>(
 
   const privateKey = Hash.hmac256(
     bytes,
-    Bytes.concat(fromPrfLabel, Bytes.fromNumber(0, { size: 4 })),
+    Bytes.concat(fromPrfDomain, Bytes.fromNumber(0, { size: 4 })),
     { as: 'Bytes' },
   )
   if (as === 'Hex') {
@@ -134,6 +135,67 @@ export declare namespace fromPrf {
     | Hash.hmac256.ErrorType
     | Hex.fromBytes.ErrorType
     | InvalidPrfSizeError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an ML-DSA-44 private key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.mldsa44.fromSeed.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
+ *
+ * @example
+ * ```ts twoslash
+ * import { MlDsa44 } from 'ox'
+ *
+ * const privateKey = MlDsa44.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @param options - Options.
+ * @returns An ML-DSA-44 private key (32-byte seed).
+ */
+export function fromSeed<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  seed: Hex.Hex | Bytes.Bytes,
+  options: fromSeed.Options<as> = {},
+): fromSeed.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+
+  const privateKey = keyDerivation.derive(bytes, fromSeedDomain)
+  if (as === 'Hex') {
+    const value = Hex.fromBytes(privateKey)
+    privateKey.fill(0)
+    return value as never
+  }
+  return privateKey as never
+}
+
+export declare namespace fromSeed {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | keyDerivation.derive.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -402,6 +464,25 @@ export declare namespace InvalidPrfSizeError {
   }
 }
 
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'MlDsa44.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for {@link ox#MlDsa44.InvalidSeedSizeError}. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
 function toContextBytes(
   context: Hex.Hex | Bytes.Bytes | undefined,
 ): Bytes.Bytes | undefined {
@@ -412,4 +493,5 @@ function toContextBytes(
   return bytes
 }
 
-const fromPrfLabel = Bytes.fromString('ox.mldsa44.fromPrf.v1')
+const fromPrfDomain = Bytes.fromString('ox.mldsa44.fromPrf.v1')
+const fromSeedDomain = Bytes.fromString('ox.mldsa44.fromSeed.v1')

--- a/src/core/MlDsa44.ts
+++ b/src/core/MlDsa44.ts
@@ -6,6 +6,7 @@ import * as Hex from './Hex.js'
 import * as Entropy from './internal/entropy.js'
 import * as keyDerivation from './internal/keyDerivation.js'
 import * as engine from './internal/mlDsa44.js'
+import * as mnemonic_ from './internal/mnemonic.js'
 
 /** Re-export of noble/post-quantum ML-DSA-44 utilities. */
 export const noble = ml_dsa44
@@ -136,6 +137,54 @@ export declare namespace fromPrf {
     | Hex.fromBytes.ErrorType
     | InvalidPrfSizeError
     | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an ML-DSA-44 private key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to {@link ox#MlDsa44.fromSeed}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { MlDsa44 } from 'ox'
+ *
+ * const privateKey = MlDsa44.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns An ML-DSA-44 private key (32-byte seed).
+ */
+export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  mnemonic: string,
+  options: fromMnemonic.Options<as> = {},
+): fromMnemonic.ReturnType<as> {
+  const { passphrase } = options
+  const seed = mnemonic_.toSeed(mnemonic, passphrase)
+  try {
+    return fromSeed(seed, options)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = fromSeed.ReturnType<as>
+
+  type ErrorType = fromSeed.ErrorType
 }
 
 /**

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -9,6 +9,7 @@ import {
   normalizeSignature,
 } from './internal/cryptoIo.js'
 import * as keyDerivation from './internal/keyDerivation.js'
+import * as mnemonic_ from './internal/mnemonic.js'
 import * as engine from './internal/p256.js'
 import * as Entropy from './internal/entropy.js'
 import {
@@ -68,6 +69,54 @@ export declare namespace createKeyPair {
     | Hex.fromBytes.ErrorType
     | PublicKey.from.ErrorType
     | Errors.GlobalErrorType
+}
+
+/**
+ * Derives a valid P256 private key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to {@link ox#P256.fromSeed}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { P256 } from 'ox'
+ *
+ * const privateKey = P256.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns A valid P256 private key.
+ */
+export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  mnemonic: string,
+  options: fromMnemonic.Options<as> = {},
+): fromMnemonic.ReturnType<as> {
+  const { passphrase } = options
+  const seed = mnemonic_.toSeed(mnemonic, passphrase)
+  try {
+    return fromSeed(seed, options)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = fromSeed.ReturnType<as>
+
+  type ErrorType = fromSeed.ErrorType
 }
 
 /**

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -1,6 +1,6 @@
 import { p256 as noble_p256 } from '@noble/curves/nist.js'
 import * as Bytes from './Bytes.js'
-import type * as Errors from './Errors.js'
+import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 import {
   formatPublicKey,
@@ -8,6 +8,7 @@ import {
   normalizePublicKey,
   normalizeSignature,
 } from './internal/cryptoIo.js'
+import * as keyDerivation from './internal/keyDerivation.js'
 import * as engine from './internal/p256.js'
 import * as Entropy from './internal/entropy.js'
 import {
@@ -66,6 +67,69 @@ export declare namespace createKeyPair {
   type ErrorType =
     | Hex.fromBytes.ErrorType
     | PublicKey.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives a valid P256 private key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.p256.fromSeed.v1` domain followed by a
+ * 32-bit big-endian counter starting at zero. Invalid scalars are skipped.
+ *
+ * @example
+ * ```ts twoslash
+ * import { P256 } from 'ox'
+ *
+ * const privateKey = P256.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @param options - Options.
+ * @returns A valid P256 private key.
+ */
+export function fromSeed<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  seed: Hex.Hex | Bytes.Bytes,
+  options: fromSeed.Options<as> = {},
+): fromSeed.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+
+  const privateKey = keyDerivation.derive(bytes, fromSeedDomain, {
+    validate: noble.utils.isValidSecretKey,
+  })
+  if (as === 'Hex') {
+    const value = Hex.fromBytes(privateKey)
+    privateKey.fill(0)
+    return value as never
+  }
+  return privateKey as never
+}
+
+export declare namespace fromSeed {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | keyDerivation.derive.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -404,3 +468,24 @@ export declare namespace verify {
 
   type ErrorType = Errors.GlobalErrorType
 }
+
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'P256.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for {@link ox#P256.InvalidSeedSizeError}. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+const fromSeedDomain = Bytes.fromString('ox.p256.fromSeed.v1')

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -11,6 +11,7 @@ import {
   normalizeSignature,
 } from './internal/cryptoIo.js'
 import * as keyDerivation from './internal/keyDerivation.js'
+import * as mnemonic_ from './internal/mnemonic.js'
 import * as engine from './internal/secp256k1.js'
 import * as Entropy from './internal/entropy.js'
 import {
@@ -140,6 +141,54 @@ export declare namespace fromPrf {
     | Hex.fromBytes.ErrorType
     | InvalidPrfSizeError
     | Errors.GlobalErrorType
+}
+
+/**
+ * Derives a valid secp256k1 private key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to {@link ox#Secp256k1.fromSeed}.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Secp256k1 } from 'ox'
+ *
+ * const privateKey = Secp256k1.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns A valid secp256k1 private key.
+ */
+export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  mnemonic: string,
+  options: fromMnemonic.Options<as> = {},
+): fromMnemonic.ReturnType<as> {
+  const { passphrase } = options
+  const seed = mnemonic_.toSeed(mnemonic, passphrase)
+  try {
+    return fromSeed(seed, options)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = fromSeed.ReturnType<as>
+
+  type ErrorType = fromSeed.ErrorType
 }
 
 /**

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -10,6 +10,7 @@ import {
   normalizePublicKey,
   normalizeSignature,
 } from './internal/cryptoIo.js'
+import * as keyDerivation from './internal/keyDerivation.js'
 import * as engine from './internal/secp256k1.js'
 import * as Entropy from './internal/entropy.js'
 import {
@@ -76,7 +77,7 @@ export declare namespace createKeyPair {
  * Derives a valid secp256k1 private key from a 32-byte WebAuthn PRF output.
  *
  * The permanent derivation contract uses the PRF output as the HMAC-SHA256
- * key. Its message is the UTF-8 bytes of `ox.secp256k1.fromPrf.v1` followed by
+ * key. The HMAC message uses the `ox.secp256k1.fromPrf.v1` domain followed by
  * a 32-bit big-endian counter starting at zero. Invalid scalars are skipped.
  *
  * @example
@@ -103,7 +104,7 @@ export function fromPrf<as extends 'Hex' | 'Bytes' = 'Hex'>(
   for (let counter = 0; ; counter++) {
     const candidate = Hash.hmac256(
       bytes,
-      Bytes.concat(fromPrfLabel, Bytes.fromNumber(counter, { size: 4 })),
+      Bytes.concat(fromPrfDomain, Bytes.fromNumber(counter, { size: 4 })),
       { as: 'Bytes' },
     )
     if (noble.utils.isValidSecretKey(candidate)) {
@@ -138,6 +139,69 @@ export declare namespace fromPrf {
     | Hash.hmac256.ErrorType
     | Hex.fromBytes.ErrorType
     | InvalidPrfSizeError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives a valid secp256k1 private key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.secp256k1.fromSeed.v1` domain followed by
+ * a 32-bit big-endian counter starting at zero. Invalid scalars are skipped.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Secp256k1 } from 'ox'
+ *
+ * const privateKey = Secp256k1.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @param options - Options.
+ * @returns A valid secp256k1 private key.
+ */
+export function fromSeed<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  seed: Hex.Hex | Bytes.Bytes,
+  options: fromSeed.Options<as> = {},
+): fromSeed.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+
+  const privateKey = keyDerivation.derive(bytes, fromSeedDomain, {
+    validate: noble.utils.isValidSecretKey,
+  })
+  if (as === 'Hex') {
+    const value = Hex.fromBytes(privateKey)
+    privateKey.fill(0)
+    return value as never
+  }
+  return privateKey as never
+}
+
+export declare namespace fromSeed {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | keyDerivation.derive.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -593,4 +657,24 @@ export declare namespace InvalidPrfSizeError {
   }
 }
 
-const fromPrfLabel = Bytes.fromString('ox.secp256k1.fromPrf.v1')
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'Secp256k1.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for {@link ox#Secp256k1.InvalidSeedSizeError}. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+const fromPrfDomain = Bytes.fromString('ox.secp256k1.fromPrf.v1')
+const fromSeedDomain = Bytes.fromString('ox.secp256k1.fromSeed.v1')

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -11,7 +11,6 @@ import {
   normalizeSignature,
 } from './internal/cryptoIo.js'
 import * as keyDerivation from './internal/keyDerivation.js'
-import * as mnemonic_ from './internal/mnemonic.js'
 import * as engine from './internal/secp256k1.js'
 import * as Entropy from './internal/entropy.js'
 import {
@@ -20,6 +19,7 @@ import {
   toRecoveredBytes,
 } from './internal/signature.js'
 import type { OneOf } from './internal/types.js'
+import * as Mnemonic from './Mnemonic.js'
 import * as PublicKey from './PublicKey.js'
 import type * as Signature from './Signature.js'
 
@@ -146,8 +146,8 @@ export declare namespace fromPrf {
 /**
  * Derives a valid secp256k1 private key from a BIP-39 mnemonic.
  *
- * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
- * to {@link ox#Secp256k1.fromSeed}.
+ * This is equivalent to {@link ox#Mnemonic.toPrivateKey}, and derives the
+ * private key at `m/44'/60'/0'/0/0` by default.
  *
  * @example
  * ```ts twoslash
@@ -166,13 +166,8 @@ export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
   mnemonic: string,
   options: fromMnemonic.Options<as> = {},
 ): fromMnemonic.ReturnType<as> {
-  const { passphrase } = options
-  const seed = mnemonic_.toSeed(mnemonic, passphrase)
-  try {
-    return fromSeed(seed, options)
-  } finally {
-    seed.fill(0)
-  }
+  const { as = 'Hex', passphrase, path } = options
+  return Mnemonic.toPrivateKey(mnemonic, { as, passphrase, path }) as never
 }
 
 export declare namespace fromMnemonic {
@@ -182,13 +177,16 @@ export declare namespace fromMnemonic {
      * @default 'Hex'
      */
     as?: as | 'Hex' | 'Bytes' | undefined
+    /** Derivation path. @default `m/44'/60'/0'/0/0` */
+    path?: string | undefined
     /** Optional BIP-39 passphrase. */
     passphrase?: string | undefined
   }
 
-  type ReturnType<as extends 'Hex' | 'Bytes'> = fromSeed.ReturnType<as>
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    Mnemonic.toPrivateKey.ReturnType<as>
 
-  type ErrorType = fromSeed.ErrorType
+  type ErrorType = Mnemonic.toPrivateKey.ErrorType
 }
 
 /**

--- a/src/core/_test/AesGcm.test-d.ts
+++ b/src/core/_test/AesGcm.test-d.ts
@@ -1,6 +1,17 @@
 import { AesGcm } from 'ox'
 import { expectTypeOf, test } from 'vp/test'
 
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(AesGcm.fromMnemonic(mnemonic)).toEqualTypeOf<
+    Promise<CryptoKey>
+  >()
+  expectTypeOf(
+    AesGcm.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Promise<CryptoKey>>()
+})
+
 test('fromSeed', () => {
   expectTypeOf(AesGcm.fromSeed(new Uint8Array(32))).toEqualTypeOf<
     Promise<CryptoKey>

--- a/src/core/_test/AesGcm.test-d.ts
+++ b/src/core/_test/AesGcm.test-d.ts
@@ -1,0 +1,8 @@
+import { AesGcm } from 'ox'
+import { expectTypeOf, test } from 'vp/test'
+
+test('fromSeed', () => {
+  expectTypeOf(AesGcm.fromSeed(new Uint8Array(32))).toEqualTypeOf<
+    Promise<CryptoKey>
+  >()
+})

--- a/src/core/_test/AesGcm.test.ts
+++ b/src/core/_test/AesGcm.test.ts
@@ -159,6 +159,69 @@ describe('fromPrf', () => {
   })
 })
 
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', async () => {
+    const key = await AesGcm.fromSeed(seed)
+    const expectedKey = await globalThis.crypto.subtle.importKey(
+      'raw',
+      Bytes.fromHex(
+        '0xd42ffe5cb894ce61e9f448e8083f53b2ab90d2acad0929e80b0abb85e915cb3a',
+      ),
+      { name: 'AES-GCM' },
+      false,
+      ['decrypt'],
+    )
+    const value = Bytes.fromString('i am a secret message')
+    const encrypted = await AesGcm.encrypt(value, key)
+
+    await expect(AesGcm.decrypt(encrypted, expectedKey)).resolves.toEqual(value)
+  })
+
+  test('value: Bytes', async () => {
+    const key = await AesGcm.fromSeed(Bytes.fromHex(seed))
+    const value = Bytes.fromString('i am a secret message')
+
+    await expect(
+      AesGcm.decrypt(await AesGcm.encrypt(value, key), key),
+    ).resolves.toEqual(value)
+  })
+
+  test('behavior: accepts seeds longer than 32 bytes', async () => {
+    const key = await AesGcm.fromSeed(new Uint8Array(64))
+
+    expect({
+      algorithm: key.algorithm,
+      extractable: key.extractable,
+      type: key.type,
+      usages: key.usages,
+    }).toMatchInlineSnapshot(`
+      {
+        "algorithm": {
+          "length": 256,
+          "name": "AES-GCM",
+        },
+        "extractable": false,
+        "type": "secret",
+        "usages": [
+          "encrypt",
+          "decrypt",
+        ],
+      }
+    `)
+  })
+
+  test('error: seed is too short', async () => {
+    await expect(
+      AesGcm.fromSeed(new Uint8Array(31)),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AesGcm.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]`,
+    )
+  })
+})
+
 describe('getKey', () => {
   test('default', async () => {
     const key = await AesGcm.getKey({ password: 'qwerty' })
@@ -180,9 +243,11 @@ test('exports', () => {
       "decrypt",
       "encrypt",
       "fromPrf",
+      "fromSeed",
       "getKey",
       "randomSalt",
       "InvalidPrfSizeError",
+      "InvalidSeedSizeError",
     ]
   `)
 })

--- a/src/core/_test/AesGcm.test.ts
+++ b/src/core/_test/AesGcm.test.ts
@@ -1,4 +1,4 @@
-import { AesGcm, Bytes, Hex } from 'ox'
+import { AesGcm, Bytes, Hex, Mnemonic } from 'ox'
 import { describe, expect, test } from 'vp/test'
 
 describe('decrypt', () => {
@@ -159,6 +159,29 @@ describe('fromPrf', () => {
   })
 })
 
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', async () => {
+    const key = await AesGcm.fromMnemonic(mnemonic)
+    const expectedKey = await AesGcm.fromSeed(Mnemonic.toSeed(mnemonic))
+    const value = Bytes.fromString('i am a secret message')
+    const encrypted = await AesGcm.encrypt(value, key)
+
+    await expect(AesGcm.decrypt(encrypted, expectedKey)).resolves.toEqual(value)
+  })
+
+  test('options: passphrase', async () => {
+    const key = await AesGcm.fromMnemonic(mnemonic, {
+      passphrase: 'qwerty',
+    })
+    const defaultKey = await AesGcm.fromMnemonic(mnemonic)
+    const encrypted = await AesGcm.encrypt('0xdeadbeef', key)
+
+    await expect(AesGcm.decrypt(encrypted, defaultKey)).rejects.toThrowError()
+  })
+})
+
 describe('fromSeed', () => {
   const seed =
     '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
@@ -243,6 +266,7 @@ test('exports', () => {
       "decrypt",
       "encrypt",
       "fromPrf",
+      "fromMnemonic",
       "fromSeed",
       "getKey",
       "randomSalt",

--- a/src/core/_test/Ed25519.test-d.ts
+++ b/src/core/_test/Ed25519.test-d.ts
@@ -40,6 +40,18 @@ test('fromPrf', () => {
   ).toEqualTypeOf<Bytes.Bytes>()
 })
 
+test('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  expectTypeOf(Ed25519.fromSeed(seed)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Ed25519.fromSeed(new Uint8Array(32))).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Ed25519.fromSeed(seed, { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Ed25519.fromSeed(seed, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
 test('getPublicKey', () => {
   // Default behavior (Hex)
   {

--- a/src/core/_test/Ed25519.test-d.ts
+++ b/src/core/_test/Ed25519.test-d.ts
@@ -40,6 +40,18 @@ test('fromPrf', () => {
   ).toEqualTypeOf<Bytes.Bytes>()
 })
 
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(Ed25519.fromMnemonic(mnemonic)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Ed25519.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Ed25519.fromMnemonic(mnemonic, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
 test('fromSeed', () => {
   const seed =
     '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'

--- a/src/core/_test/Ed25519.test.ts
+++ b/src/core/_test/Ed25519.test.ts
@@ -1,4 +1,4 @@
-import { Bytes, Ed25519, Engine, Hex, X25519 } from 'ox'
+import { Bytes, Ed25519, Engine, Hex, Mnemonic, X25519 } from 'ox'
 import { describe, expect, test } from 'vp/test'
 
 describe('createKeyPair', () => {
@@ -143,6 +143,34 @@ describe('fromPrf', () => {
       .toThrowErrorMatchingInlineSnapshot(`
         [Ed25519.InvalidPrfSizeError: PRF output must be exactly 32 bytes. Received 33 bytes.]
       `)
+  })
+})
+
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', () => {
+    const privateKey = Ed25519.fromMnemonic(mnemonic)
+
+    expect(privateKey).toBe(Ed25519.fromSeed(Mnemonic.toSeed(mnemonic)))
+    expect(privateKey).toMatchInlineSnapshot(
+      `"0x23fb07a427d2bc36141d1e6c7e56c72679739eff374a8e8def282f1048674567"`,
+    )
+  })
+
+  test('options: passphrase', () => {
+    expect(
+      Ed25519.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+    ).toMatchInlineSnapshot(
+      `"0xe888791c9d783e772d92b0bf2aa326b1cda8214a03c3c07933615b1a98fc8651"`,
+    )
+  })
+
+  test('options: as', () => {
+    const privateKey = Ed25519.fromMnemonic(mnemonic, { as: 'Bytes' })
+
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
   })
 })
 
@@ -600,6 +628,7 @@ test('exports', () => {
       "noble",
       "createKeyPair",
       "fromPrf",
+      "fromMnemonic",
       "fromSeed",
       "getPublicKey",
       "randomPrivateKey",

--- a/src/core/_test/Ed25519.test.ts
+++ b/src/core/_test/Ed25519.test.ts
@@ -146,6 +146,61 @@ describe('fromPrf', () => {
   })
 })
 
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', () => {
+    expect(Ed25519.fromSeed(seed)).toMatchInlineSnapshot(
+      `"0xfd09c7b2acda46034df7e428377fdc37200094c9b51690fa1b733ee3c16a2d07"`,
+    )
+  })
+
+  test('value: Bytes', () => {
+    expect(Ed25519.fromSeed(Bytes.fromHex(seed))).toMatchInlineSnapshot(
+      `"0xfd09c7b2acda46034df7e428377fdc37200094c9b51690fa1b733ee3c16a2d07"`,
+    )
+  })
+
+  test('options: as', () => {
+    expect(Ed25519.fromSeed(seed, { as: 'Bytes' })).toEqual(
+      Bytes.fromHex(
+        '0xfd09c7b2acda46034df7e428377fdc37200094c9b51690fa1b733ee3c16a2d07',
+      ),
+    )
+  })
+
+  test('behavior: output signs and verifies', () => {
+    const privateKey = Ed25519.fromSeed(new Uint8Array(64))
+    const publicKey = Ed25519.getPublicKey({ privateKey })
+    const payload = '0xdeadbeef'
+    const signature = Ed25519.sign({ payload, privateKey })
+
+    expect(Ed25519.verify({ payload, publicKey, signature })).toBe(true)
+  })
+
+  test('behavior: zeroes intermediate key for Hex output', () => {
+    const candidate = new Uint8Array(32).fill(1)
+    Engine.with(
+      {
+        Hash: {
+          hmacSha256: () => candidate,
+        },
+      },
+      () => Ed25519.fromSeed(new Uint8Array(32)),
+    )
+
+    expect(candidate).toEqual(new Uint8Array(32))
+  })
+
+  test('error: seed is too short', () => {
+    expect(() => Ed25519.fromSeed(new Uint8Array(31)))
+      .toThrowErrorMatchingInlineSnapshot(`
+        [Ed25519.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]
+      `)
+  })
+})
+
 describe('getPublicKey', () => {
   const privateKey =
     '0x9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60'
@@ -545,6 +600,7 @@ test('exports', () => {
       "noble",
       "createKeyPair",
       "fromPrf",
+      "fromSeed",
       "getPublicKey",
       "randomPrivateKey",
       "sign",
@@ -552,6 +608,7 @@ test('exports', () => {
       "toX25519PublicKey",
       "toX25519PrivateKey",
       "InvalidPrfSizeError",
+      "InvalidSeedSizeError",
     ]
   `)
 })

--- a/src/core/_test/MlDsa44.test-d.ts
+++ b/src/core/_test/MlDsa44.test-d.ts
@@ -24,6 +24,18 @@ test('fromPrf', () => {
   ).toEqualTypeOf<Bytes.Bytes>()
 })
 
+test('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  expectTypeOf(MlDsa44.fromSeed(seed)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(MlDsa44.fromSeed(new Uint8Array(32))).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(MlDsa44.fromSeed(seed, { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    MlDsa44.fromSeed(seed, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
 test('getPublicKey', () => {
   expectTypeOf(
     MlDsa44.getPublicKey({ privateKey: '0x' }),

--- a/src/core/_test/MlDsa44.test-d.ts
+++ b/src/core/_test/MlDsa44.test-d.ts
@@ -24,6 +24,18 @@ test('fromPrf', () => {
   ).toEqualTypeOf<Bytes.Bytes>()
 })
 
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(MlDsa44.fromMnemonic(mnemonic)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    MlDsa44.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    MlDsa44.fromMnemonic(mnemonic, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
 test('fromSeed', () => {
   const seed =
     '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'

--- a/src/core/_test/MlDsa44.test.ts
+++ b/src/core/_test/MlDsa44.test.ts
@@ -139,6 +139,46 @@ describe('fromPrf', () => {
   })
 })
 
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', () => {
+    expect(MlDsa44.fromSeed(seed)).toMatchInlineSnapshot(
+      `"0xbee74160aef452ec0e90a4c347bbb0ac37e93fb94855f7a98dfe9afabebbdad6"`,
+    )
+  })
+
+  test('value: Bytes', () => {
+    expect(MlDsa44.fromSeed(Bytes.fromHex(seed))).toMatchInlineSnapshot(
+      `"0xbee74160aef452ec0e90a4c347bbb0ac37e93fb94855f7a98dfe9afabebbdad6"`,
+    )
+  })
+
+  test('options: as', () => {
+    expect(MlDsa44.fromSeed(seed, { as: 'Bytes' })).toEqual(
+      Bytes.fromHex(
+        '0xbee74160aef452ec0e90a4c347bbb0ac37e93fb94855f7a98dfe9afabebbdad6',
+      ),
+    )
+  })
+
+  test('behavior: output signs and verifies', () => {
+    const privateKey = MlDsa44.fromSeed(new Uint8Array(64))
+    const publicKey = MlDsa44.getPublicKey({ privateKey })
+    const signature = MlDsa44.sign({ payload, privateKey })
+
+    expect(MlDsa44.verify({ payload, publicKey, signature })).toBe(true)
+  })
+
+  test('error: seed is too short', () => {
+    expect(() => MlDsa44.fromSeed(new Uint8Array(31)))
+      .toThrowErrorMatchingInlineSnapshot(`
+        [MlDsa44.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]
+      `)
+  })
+})
+
 describe('getPublicKey', () => {
   test('default', () => {
     const publicKey = MlDsa44.getPublicKey({ privateKey })

--- a/src/core/_test/MlDsa44.test.ts
+++ b/src/core/_test/MlDsa44.test.ts
@@ -1,4 +1,4 @@
-import { Bytes, Engine, Hash, Hex, MlDsa44 } from 'ox'
+import { Bytes, Engine, Hash, Hex, MlDsa44, Mnemonic } from 'ox'
 import { describe, expect, test } from 'vp/test'
 
 const privateKey = Hex.fromBytes(new Uint8Array(32).fill(7))
@@ -136,6 +136,34 @@ describe('fromPrf', () => {
       .toThrowErrorMatchingInlineSnapshot(`
         [MlDsa44.InvalidPrfSizeError: PRF output must be exactly 32 bytes. Received 33 bytes.]
       `)
+  })
+})
+
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', () => {
+    const privateKey = MlDsa44.fromMnemonic(mnemonic)
+
+    expect(privateKey).toBe(MlDsa44.fromSeed(Mnemonic.toSeed(mnemonic)))
+    expect(privateKey).toMatchInlineSnapshot(
+      `"0x787f747b571a3511deac4d045a7876ae2349f45b9f9f4e3a6ee40342313a963f"`,
+    )
+  })
+
+  test('options: passphrase', () => {
+    expect(
+      MlDsa44.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+    ).toMatchInlineSnapshot(
+      `"0x51202c4aaf8b4090f94c43ae43234b133a2646642fbc4ca39d8883a0b39d2b44"`,
+    )
+  })
+
+  test('options: as', () => {
+    const privateKey = MlDsa44.fromMnemonic(mnemonic, { as: 'Bytes' })
+
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
   })
 })
 

--- a/src/core/_test/P256.test-d.ts
+++ b/src/core/_test/P256.test-d.ts
@@ -1,0 +1,14 @@
+import { type Bytes, type Hex, P256 } from 'ox'
+import { expectTypeOf, test } from 'vp/test'
+
+test('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  expectTypeOf(P256.fromSeed(seed)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(P256.fromSeed(new Uint8Array(32))).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(P256.fromSeed(seed, { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    P256.fromSeed(seed, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})

--- a/src/core/_test/P256.test-d.ts
+++ b/src/core/_test/P256.test-d.ts
@@ -1,6 +1,18 @@
 import { type Bytes, type Hex, P256 } from 'ox'
 import { expectTypeOf, test } from 'vp/test'
 
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(P256.fromMnemonic(mnemonic)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    P256.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    P256.fromMnemonic(mnemonic, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
 test('fromSeed', () => {
   const seed =
     '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -1,4 +1,4 @@
-import { Bytes, Hex, P256 } from 'ox'
+import { Bytes, Engine, Hex, P256 } from 'ox'
 import { describe, expect, test } from 'vp/test'
 import { accounts } from '../../../test/constants/accounts.js'
 
@@ -142,6 +142,72 @@ describe('createKeyPair', () => {
     const recoveredPublicKey = P256.recoverPublicKey({ payload, signature })
 
     expect(recoveredPublicKey).toEqual(keyPair.publicKey)
+  })
+})
+
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', () => {
+    expect(P256.fromSeed(seed)).toMatchInlineSnapshot(
+      `"0x724009e76eb27e34eb77b93db354b9015ecd4296deb57561f5214bab68b94a6f"`,
+    )
+  })
+
+  test('value: Bytes', () => {
+    expect(P256.fromSeed(Bytes.fromHex(seed))).toMatchInlineSnapshot(
+      `"0x724009e76eb27e34eb77b93db354b9015ecd4296deb57561f5214bab68b94a6f"`,
+    )
+  })
+
+  test('options: as', () => {
+    expect(P256.fromSeed(seed, { as: 'Bytes' })).toEqual(
+      Bytes.fromHex(
+        '0x724009e76eb27e34eb77b93db354b9015ecd4296deb57561f5214bab68b94a6f',
+      ),
+    )
+  })
+
+  test('behavior: output is a valid P256 private key', () => {
+    const privateKey = P256.fromSeed(new Uint8Array(64), { as: 'Bytes' })
+
+    expect(P256.noble.utils.isValidSecretKey(privateKey)).toBe(true)
+  })
+
+  test('behavior: skips invalid scalar candidates', () => {
+    const messages: Hex.Hex[] = []
+    const privateKey = Engine.with(
+      {
+        Hash: {
+          hmacSha256: (_key, message) => {
+            messages.push(Hex.fromBytes(message))
+            if (messages.length === 1) return new Uint8Array(32)
+            return Bytes.fromHex(
+              '0xef3f982137910a4c362017e69ba173fbb342325802ec827767aa6942027af35b',
+            )
+          },
+        },
+      },
+      () => P256.fromSeed(new Uint8Array(32)),
+    )
+
+    expect(privateKey).toBe(
+      '0xef3f982137910a4c362017e69ba173fbb342325802ec827767aa6942027af35b',
+    )
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "0x6f782e703235362e66726f6d536565642e763100000000",
+        "0x6f782e703235362e66726f6d536565642e763100000001",
+      ]
+    `)
+  })
+
+  test('error: seed is too short', () => {
+    expect(() => P256.fromSeed(new Uint8Array(31)))
+      .toThrowErrorMatchingInlineSnapshot(`
+        [P256.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]
+      `)
   })
 })
 
@@ -546,12 +612,14 @@ test('exports', () => {
     [
       "noble",
       "createKeyPair",
+      "fromSeed",
       "getPublicKey",
       "getSharedSecret",
       "randomPrivateKey",
       "recoverPublicKey",
       "sign",
       "verify",
+      "InvalidSeedSizeError",
     ]
   `)
 })

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -1,4 +1,4 @@
-import { Bytes, Engine, Hex, P256 } from 'ox'
+import { Bytes, Engine, Hex, Mnemonic, P256 } from 'ox'
 import { describe, expect, test } from 'vp/test'
 import { accounts } from '../../../test/constants/accounts.js'
 
@@ -142,6 +142,34 @@ describe('createKeyPair', () => {
     const recoveredPublicKey = P256.recoverPublicKey({ payload, signature })
 
     expect(recoveredPublicKey).toEqual(keyPair.publicKey)
+  })
+})
+
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', () => {
+    const privateKey = P256.fromMnemonic(mnemonic)
+
+    expect(privateKey).toBe(P256.fromSeed(Mnemonic.toSeed(mnemonic)))
+    expect(privateKey).toMatchInlineSnapshot(
+      `"0x882f5b02a84c96bceeebf9c868bec73041d51b041ae05380e66a41508648ebc3"`,
+    )
+  })
+
+  test('options: passphrase', () => {
+    expect(
+      P256.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+    ).toMatchInlineSnapshot(
+      `"0x364ff539f37ce477d49a35476c9ad32a2a3fed1d1237eaee7abdfd07655ad9f5"`,
+    )
+  })
+
+  test('options: as', () => {
+    const privateKey = P256.fromMnemonic(mnemonic, { as: 'Bytes' })
+
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
   })
 })
 
@@ -612,6 +640,7 @@ test('exports', () => {
     [
       "noble",
       "createKeyPair",
+      "fromMnemonic",
       "fromSeed",
       "getPublicKey",
       "getSharedSecret",

--- a/src/core/_test/Secp256k1.test-d.ts
+++ b/src/core/_test/Secp256k1.test-d.ts
@@ -23,6 +23,9 @@ test('fromMnemonic', () => {
   expectTypeOf(
     Secp256k1.fromMnemonic(mnemonic, { as: 'Bytes' }),
   ).toEqualTypeOf<Bytes.Bytes>()
+  expectTypeOf(
+    Secp256k1.fromMnemonic(mnemonic, { path: "m/44'/60'/0'/0/1" }),
+  ).toEqualTypeOf<Hex.Hex>()
 })
 
 test('fromSeed', () => {

--- a/src/core/_test/Secp256k1.test-d.ts
+++ b/src/core/_test/Secp256k1.test-d.ts
@@ -12,3 +12,15 @@ test('fromPrf', () => {
     Secp256k1.fromPrf(prf, { as: 'Bytes' }),
   ).toEqualTypeOf<Bytes.Bytes>()
 })
+
+test('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  expectTypeOf(Secp256k1.fromSeed(seed)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Secp256k1.fromSeed(new Uint8Array(32))).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Secp256k1.fromSeed(seed, { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Secp256k1.fromSeed(seed, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})

--- a/src/core/_test/Secp256k1.test-d.ts
+++ b/src/core/_test/Secp256k1.test-d.ts
@@ -13,6 +13,18 @@ test('fromPrf', () => {
   ).toEqualTypeOf<Bytes.Bytes>()
 })
 
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(Secp256k1.fromMnemonic(mnemonic)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Secp256k1.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Secp256k1.fromMnemonic(mnemonic, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
 test('fromSeed', () => {
   const seed =
     '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -1,4 +1,4 @@
-import { Address, Bytes, Engine, Hex, PublicKey, Secp256k1 } from 'ox'
+import { Address, Bytes, Engine, Hex, Mnemonic, PublicKey, Secp256k1 } from 'ox'
 import { describe, expect, test } from 'vp/test'
 import { accounts } from '../../../test/constants/accounts.js'
 
@@ -208,6 +208,34 @@ describe('fromPrf', () => {
       .toThrowErrorMatchingInlineSnapshot(`
         [Secp256k1.InvalidPrfSizeError: PRF output must be exactly 32 bytes. Received 33 bytes.]
       `)
+  })
+})
+
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', () => {
+    const privateKey = Secp256k1.fromMnemonic(mnemonic)
+
+    expect(privateKey).toBe(Secp256k1.fromSeed(Mnemonic.toSeed(mnemonic)))
+    expect(privateKey).toMatchInlineSnapshot(
+      `"0x1ccb5b6b0469535f8a21f52d998605e4b7318374bc0cefea30492b6af2ba5dfe"`,
+    )
+  })
+
+  test('options: passphrase', () => {
+    expect(
+      Secp256k1.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+    ).toMatchInlineSnapshot(
+      `"0x40495df06f9a3e745611074d590b9bb6a181d799a6c60961fb7771818a706389"`,
+    )
+  })
+
+  test('options: as', () => {
+    const privateKey = Secp256k1.fromMnemonic(mnemonic, { as: 'Bytes' })
+
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
   })
 })
 
@@ -644,6 +672,7 @@ test('exports', () => {
       "noble",
       "createKeyPair",
       "fromPrf",
+      "fromMnemonic",
       "fromSeed",
       "getPublicKey",
       "getSharedSecret",

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -217,9 +217,9 @@ describe('fromMnemonic', () => {
   test('default', () => {
     const privateKey = Secp256k1.fromMnemonic(mnemonic)
 
-    expect(privateKey).toBe(Secp256k1.fromSeed(Mnemonic.toSeed(mnemonic)))
+    expect(privateKey).toBe(Mnemonic.toPrivateKey(mnemonic, { as: 'Hex' }))
     expect(privateKey).toMatchInlineSnapshot(
-      `"0x1ccb5b6b0469535f8a21f52d998605e4b7318374bc0cefea30492b6af2ba5dfe"`,
+      `"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"`,
     )
   })
 
@@ -227,7 +227,7 @@ describe('fromMnemonic', () => {
     expect(
       Secp256k1.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
     ).toMatchInlineSnapshot(
-      `"0x40495df06f9a3e745611074d590b9bb6a181d799a6c60961fb7771818a706389"`,
+      `"0x0bef893b1cc27e9ce726d5f12f75d61a07d4df87c02106083463cd712ac5c478"`,
     )
   })
 
@@ -236,6 +236,14 @@ describe('fromMnemonic', () => {
 
     expect(privateKey).toBeInstanceOf(Uint8Array)
     expect(privateKey).toHaveLength(32)
+  })
+
+  test('options: path', () => {
+    const path = "m/44'/60'/0'/0/1"
+
+    expect(Secp256k1.fromMnemonic(mnemonic, { path })).toBe(
+      Mnemonic.toPrivateKey(mnemonic, { as: 'Hex', path }),
+    )
   })
 })
 

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -211,6 +211,78 @@ describe('fromPrf', () => {
   })
 })
 
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', () => {
+    expect(Secp256k1.fromSeed(seed)).toMatchInlineSnapshot(
+      `"0x5f7dcbba41adaafa378861d78b144f7b2827e79fa994a341628f5470d5bfbdd4"`,
+    )
+  })
+
+  test('value: Bytes', () => {
+    expect(Secp256k1.fromSeed(Bytes.fromHex(seed))).toMatchInlineSnapshot(
+      `"0x5f7dcbba41adaafa378861d78b144f7b2827e79fa994a341628f5470d5bfbdd4"`,
+    )
+  })
+
+  test('options: as', () => {
+    expect(Secp256k1.fromSeed(seed, { as: 'Bytes' })).toEqual(
+      Bytes.fromHex(
+        '0x5f7dcbba41adaafa378861d78b144f7b2827e79fa994a341628f5470d5bfbdd4',
+      ),
+    )
+  })
+
+  test('behavior: accepts seeds longer than 32 bytes', () => {
+    const privateKey = Secp256k1.fromSeed(new Uint8Array(64), { as: 'Bytes' })
+
+    expect(Secp256k1.noble.utils.isValidSecretKey(privateKey)).toBe(true)
+  })
+
+  test('behavior: domain is distinct from fromPrf', () => {
+    expect(Secp256k1.fromSeed(seed)).not.toBe(Secp256k1.fromPrf(seed))
+  })
+
+  test('behavior: skips invalid scalar candidates', () => {
+    const invalid = new Uint8Array(32).fill(0xff)
+    const messages: Hex.Hex[] = []
+    const privateKey = Engine.with(
+      {
+        Hash: {
+          hmacSha256: (_key, message) => {
+            messages.push(Hex.fromBytes(message))
+            if (messages.length === 1) return invalid
+            return Bytes.fromHex(
+              '0xef3f982137910a4c362017e69ba173fbb342325802ec827767aa6942027af35b',
+            )
+          },
+        },
+      },
+      () => Secp256k1.fromSeed(new Uint8Array(32)),
+    )
+
+    expect(privateKey).toBe(
+      '0xef3f982137910a4c362017e69ba173fbb342325802ec827767aa6942027af35b',
+    )
+    expect(invalid).toEqual(new Uint8Array(32))
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "0x6f782e736563703235366b312e66726f6d536565642e763100000000",
+        "0x6f782e736563703235366b312e66726f6d536565642e763100000001",
+      ]
+    `)
+  })
+
+  test('error: seed is too short', () => {
+    expect(() => Secp256k1.fromSeed(new Uint8Array(31)))
+      .toThrowErrorMatchingInlineSnapshot(`
+        [Secp256k1.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]
+      `)
+  })
+})
+
 describe('getSharedSecret', () => {
   test('default', () => {
     const privateKeyA = accounts[0].privateKey
@@ -572,6 +644,7 @@ test('exports', () => {
       "noble",
       "createKeyPair",
       "fromPrf",
+      "fromSeed",
       "getPublicKey",
       "getSharedSecret",
       "randomPrivateKey",
@@ -580,6 +653,7 @@ test('exports', () => {
       "sign",
       "verify",
       "InvalidPrfSizeError",
+      "InvalidSeedSizeError",
     ]
   `)
 })

--- a/src/core/internal/keyDerivation.ts
+++ b/src/core/internal/keyDerivation.ts
@@ -1,0 +1,34 @@
+import * as Bytes from '../Bytes.js'
+import type * as Errors from '../Errors.js'
+import * as Hash from '../Hash.js'
+
+/** @internal */
+export function derive(
+  seed: Bytes.Bytes,
+  domain: Bytes.Bytes,
+  options: derive.Options = {},
+): Bytes.Bytes {
+  const { validate } = options
+  for (let counter = 0; ; counter++) {
+    const key = Hash.hmac256(
+      seed,
+      Bytes.concat(domain, Bytes.fromNumber(counter, { size: 4 })),
+      { as: 'Bytes' },
+    )
+    if (!validate || validate(key)) return key
+    key.fill(0)
+  }
+}
+
+/** @internal */
+export declare namespace derive {
+  type Options = {
+    validate?: ((key: Bytes.Bytes) => boolean) | undefined
+  }
+
+  type ErrorType =
+    | Bytes.concat.ErrorType
+    | Bytes.fromNumber.ErrorType
+    | Hash.hmac256.ErrorType
+    | Errors.GlobalErrorType
+}


### PR DESCRIPTION
Adds `fromSeed` and `fromMnemonic` APIs across signing and encryption modules. Secp256k1 mnemonic derivation follows BIP-32 paths; other algorithms use domain-separated derivation with seed validation and guidance.