### PR TITLE
feat: add seed and mnemonic key derivation

### DIFF
--- a/.changeset/tidy-seeds-derive.md
+++ b/.changeset/tidy-seeds-derive.md
@@ -1,0 +1,5 @@
+---
+'ox': minor
+---
+
+Added seed and mnemonic derivation for P256, Secp256k1, Ed25519, and AES-GCM keys.

--- a/src/core/AesGcm.ts
+++ b/src/core/AesGcm.ts
@@ -1,6 +1,7 @@
 import * as Bytes from './Bytes.js'
-import type * as Errors from './Errors.js'
+import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
+import * as Mnemonic from './Mnemonic.js'
 
 export const ivLength = 16
 
@@ -131,6 +132,86 @@ export declare namespace encrypt {
 }
 
 /**
+ * Derives an AES-256-GCM key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to `AesGcm.fromSeed`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { AesGcm } from 'ox'
+ *
+ * const key = await AesGcm.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns A nonextractable AES-256-GCM key for encryption and decryption.
+ */
+export async function fromMnemonic(
+  mnemonic: string,
+  options: fromMnemonic.Options = {},
+): Promise<CryptoKey> {
+  const { passphrase } = options
+  const seed = Mnemonic.toSeed(mnemonic, { passphrase })
+  try {
+    return await fromSeed(seed)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options = {
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ErrorType = fromSeed.ErrorType
+}
+
+/**
+ * Derives an AES-256-GCM key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.aesGcm.fromSeed.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
+ *
+ * @example
+ * ```ts twoslash
+ * import { AesGcm } from 'ox'
+ *
+ * const key = await AesGcm.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @returns A nonextractable AES-256-GCM key for encryption and decryption.
+ */
+export async function fromSeed(
+  seed: Hex.Hex | Bytes.Bytes,
+): Promise<CryptoKey> {
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+  return deriveKey(bytes, fromSeedDomain)
+}
+
+export declare namespace fromSeed {
+  type ErrorType =
+    | Bytes.concat.ErrorType
+    | Bytes.from.ErrorType
+    | Bytes.fromNumber.ErrorType
+    | InvalidSeedSizeError
+    | Errors.GlobalErrorType
+}
+
+/**
  * Derives an AES-GCM key from a password using PBKDF2.
  *
  * @example
@@ -202,3 +283,58 @@ export function randomSalt(size = 32): Bytes.Bytes {
 export declare namespace randomSalt {
   type ErrorType = Bytes.random.ErrorType | Errors.GlobalErrorType
 }
+
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'AesGcm.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for `AesGcm.InvalidSeedSizeError`. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+async function deriveKey(
+  seed: Bytes.Bytes,
+  domain: Bytes.Bytes,
+): Promise<CryptoKey> {
+  const baseKey = await globalThis.crypto.subtle.importKey(
+    'raw',
+    seed,
+    {
+      name: 'HMAC',
+      hash: 'SHA-256',
+    },
+    false,
+    ['sign'],
+  )
+  const key = new Uint8Array(
+    await globalThis.crypto.subtle.sign(
+      'HMAC',
+      baseKey,
+      Bytes.concat(domain, Bytes.fromNumber(0, { size: 4 })),
+    ),
+  )
+  try {
+    return await globalThis.crypto.subtle.importKey(
+      'raw',
+      key,
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt'],
+    )
+  } finally {
+    key.fill(0)
+  }
+}
+
+const fromSeedDomain = Bytes.fromString('ox.aesGcm.fromSeed.v1')

--- a/src/core/Ed25519.ts
+++ b/src/core/Ed25519.ts
@@ -4,8 +4,10 @@ import {
   edwardsToMontgomeryPub,
 } from '@noble/curves/ed25519'
 import * as Bytes from './Bytes.js'
-import type * as Errors from './Errors.js'
+import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
+import * as keyDerivation from './internal/keyDerivation.js'
+import * as Mnemonic from './Mnemonic.js'
 
 /** Re-export of noble/curves Ed25519 utilities. */
 export const noble = ed25519
@@ -58,6 +60,115 @@ export declare namespace createKeyPair {
     | Hex.fromBytes.ErrorType
     | randomPrivateKey.ErrorType
     | getPublicKey.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives an Ed25519 private key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to `Ed25519.fromSeed`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const privateKey = Ed25519.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns An Ed25519 private key.
+ */
+export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  mnemonic: string,
+  options: fromMnemonic.Options<as> = {},
+): fromMnemonic.ReturnType<as> {
+  const { passphrase } = options
+  const seed = Mnemonic.toSeed(mnemonic, { passphrase })
+  try {
+    return fromSeed(seed, options)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = fromSeed.ReturnType<as>
+
+  type ErrorType = fromSeed.ErrorType
+}
+
+/**
+ * Derives an Ed25519 private key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.ed25519.fromSeed.v1` domain followed by a
+ * 32-bit big-endian counter set to zero.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Ed25519 } from 'ox'
+ *
+ * const privateKey = Ed25519.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @param options - Options.
+ * @returns An Ed25519 private key.
+ */
+export function fromSeed<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  seed: Hex.Hex | Bytes.Bytes,
+  options: fromSeed.Options<as> = {},
+): fromSeed.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+
+  const privateKey = keyDerivation.derive(bytes, fromSeedDomain)
+  if (as === 'Hex') {
+    const value = Hex.fromBytes(privateKey)
+    privateKey.fill(0)
+    return value as never
+  }
+  return privateKey as never
+}
+
+export declare namespace fromSeed {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | keyDerivation.derive.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -337,3 +448,24 @@ export declare namespace toX25519PrivateKey {
     | Hex.fromBytes.ErrorType
     | Errors.GlobalErrorType
 }
+
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'Ed25519.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for `Ed25519.InvalidSeedSizeError`. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+const fromSeedDomain = Bytes.fromString('ox.ed25519.fromSeed.v1')

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -1,8 +1,10 @@
 import { secp256r1 } from '@noble/curves/p256'
 import * as Bytes from './Bytes.js'
-import type * as Errors from './Errors.js'
+import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 import * as Entropy from './internal/entropy.js'
+import * as keyDerivation from './internal/keyDerivation.js'
+import * as Mnemonic from './Mnemonic.js'
 import * as PublicKey from './PublicKey.js'
 import type * as Signature from './Signature.js'
 
@@ -54,6 +56,117 @@ export declare namespace createKeyPair {
   type ErrorType =
     | Hex.fromBytes.ErrorType
     | PublicKey.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives a valid P256 private key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to passing `Mnemonic.toSeed(mnemonic, { passphrase })`
+ * to `P256.fromSeed`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { P256 } from 'ox'
+ *
+ * const privateKey = P256.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns A valid P256 private key.
+ */
+export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  mnemonic: string,
+  options: fromMnemonic.Options<as> = {},
+): fromMnemonic.ReturnType<as> {
+  const { passphrase } = options
+  const seed = Mnemonic.toSeed(mnemonic, { passphrase })
+  try {
+    return fromSeed(seed, options)
+  } finally {
+    seed.fill(0)
+  }
+}
+
+export declare namespace fromMnemonic {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> = fromSeed.ReturnType<as>
+
+  type ErrorType = fromSeed.ErrorType
+}
+
+/**
+ * Derives a valid P256 private key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.p256.fromSeed.v1` domain followed by a
+ * 32-bit big-endian counter starting at zero. Invalid scalars are skipped.
+ *
+ * @example
+ * ```ts twoslash
+ * import { P256 } from 'ox'
+ *
+ * const privateKey = P256.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @param options - Options.
+ * @returns A valid P256 private key.
+ */
+export function fromSeed<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  seed: Hex.Hex | Bytes.Bytes,
+  options: fromSeed.Options<as> = {},
+): fromSeed.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+
+  const privateKey = keyDerivation.derive(bytes, fromSeedDomain, {
+    validate: noble.utils.isValidPrivateKey,
+  })
+  if (as === 'Hex') {
+    const value = Hex.fromBytes(privateKey)
+    privateKey.fill(0)
+    return value as never
+  }
+  return privateKey as never
+}
+
+export declare namespace fromSeed {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | keyDerivation.derive.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -354,3 +467,24 @@ export declare namespace verify {
 
   type ErrorType = Errors.GlobalErrorType
 }
+
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'P256.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for `P256.InvalidSeedSizeError`. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+const fromSeedDomain = Bytes.fromString('ox.p256.fromSeed.v1')

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -1,10 +1,12 @@
 import { secp256k1 } from '@noble/curves/secp256k1'
 import * as Address from './Address.js'
 import * as Bytes from './Bytes.js'
-import type * as Errors from './Errors.js'
+import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 import * as Entropy from './internal/entropy.js'
+import * as keyDerivation from './internal/keyDerivation.js'
 import type { OneOf } from './internal/types.js'
+import * as Mnemonic from './Mnemonic.js'
 import * as PublicKey from './PublicKey.js'
 import type * as Signature from './Signature.js'
 
@@ -56,6 +58,115 @@ export declare namespace createKeyPair {
   type ErrorType =
     | Hex.fromBytes.ErrorType
     | PublicKey.from.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Derives a valid secp256k1 private key from a BIP-39 mnemonic.
+ *
+ * This is equivalent to `Mnemonic.toPrivateKey`, and derives the
+ * private key at `m/44'/60'/0'/0/0` by default.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Secp256k1 } from 'ox'
+ *
+ * const privateKey = Secp256k1.fromMnemonic(
+ *   'test test test test test test test test test test test junk'
+ * )
+ * ```
+ *
+ * @param mnemonic - BIP-39 mnemonic phrase.
+ * @param options - Options.
+ * @returns A valid secp256k1 private key.
+ */
+export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  mnemonic: string,
+  options: fromMnemonic.Options<as> = {},
+): fromMnemonic.ReturnType<as> {
+  const { as = 'Hex', passphrase, path } = options
+  return Mnemonic.toPrivateKey(mnemonic, { as, passphrase, path }) as never
+}
+
+export declare namespace fromMnemonic {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+    /** Derivation path. @default `m/44'/60'/0'/0/0` */
+    path?: string | undefined
+    /** Optional BIP-39 passphrase. */
+    passphrase?: string | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    Mnemonic.toPrivateKey.ReturnType<as>
+
+  type ErrorType = Mnemonic.toPrivateKey.ErrorType
+}
+
+/**
+ * Derives a valid secp256k1 private key from a seed.
+ *
+ * The seed must contain at least 32 bytes of cryptographically strong key
+ * material. Do not pass a password directly; use a password KDF first.
+ *
+ * The permanent derivation contract uses the seed as the HMAC-SHA256
+ * key. The HMAC message uses the `ox.secp256k1.fromSeed.v1` domain followed by
+ * a 32-bit big-endian counter starting at zero. Invalid scalars are skipped.
+ *
+ * @example
+ * ```ts twoslash
+ * import { Secp256k1 } from 'ox'
+ *
+ * const privateKey = Secp256k1.fromSeed(
+ *   '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+ * )
+ * ```
+ *
+ * @param seed - Seed containing at least 32 bytes of cryptographically strong key material.
+ * @param options - Options.
+ * @returns A valid secp256k1 private key.
+ */
+export function fromSeed<as extends 'Hex' | 'Bytes' = 'Hex'>(
+  seed: Hex.Hex | Bytes.Bytes,
+  options: fromSeed.Options<as> = {},
+): fromSeed.ReturnType<as> {
+  const { as = 'Hex' } = options
+  const bytes = Bytes.from(seed)
+  if (bytes.length < 32) throw new InvalidSeedSizeError({ size: bytes.length })
+
+  const privateKey = keyDerivation.derive(bytes, fromSeedDomain, {
+    validate: noble.utils.isValidPrivateKey,
+  })
+  if (as === 'Hex') {
+    const value = Hex.fromBytes(privateKey)
+    privateKey.fill(0)
+    return value as never
+  }
+  return privateKey as never
+}
+
+export declare namespace fromSeed {
+  type Options<as extends 'Hex' | 'Bytes' = 'Hex'> = {
+    /**
+     * Format of the returned private key.
+     * @default 'Hex'
+     */
+    as?: as | 'Hex' | 'Bytes' | undefined
+  }
+
+  type ReturnType<as extends 'Hex' | 'Bytes'> =
+    | (as extends 'Bytes' ? Bytes.Bytes : never)
+    | (as extends 'Hex' ? Hex.Hex : never)
+
+  type ErrorType =
+    | Bytes.from.ErrorType
+    | Hex.fromBytes.ErrorType
+    | keyDerivation.derive.ErrorType
+    | InvalidSeedSizeError
     | Errors.GlobalErrorType
 }
 
@@ -423,3 +534,24 @@ export declare namespace verify {
 
   type ErrorType = Errors.GlobalErrorType
 }
+
+/** Thrown when a seed contains fewer than 32 bytes. */
+export class InvalidSeedSizeError extends Errors.BaseError {
+  override readonly name = 'Secp256k1.InvalidSeedSizeError'
+
+  constructor(options: InvalidSeedSizeError.Options) {
+    super(
+      `Seed must contain at least 32 bytes. Received ${options.size} bytes.`,
+    )
+  }
+}
+
+export declare namespace InvalidSeedSizeError {
+  /** Options for `Secp256k1.InvalidSeedSizeError`. */
+  type Options = {
+    /** Received seed size. */
+    size: number
+  }
+}
+
+const fromSeedDomain = Bytes.fromString('ox.secp256k1.fromSeed.v1')

--- a/src/core/_test/AesGcm.test-d.ts
+++ b/src/core/_test/AesGcm.test-d.ts
@@ -1,0 +1,19 @@
+import { AesGcm } from 'ox'
+import { expectTypeOf, test } from 'vitest'
+
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(AesGcm.fromMnemonic(mnemonic)).toEqualTypeOf<
+    Promise<CryptoKey>
+  >()
+  expectTypeOf(
+    AesGcm.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Promise<CryptoKey>>()
+})
+
+test('fromSeed', () => {
+  expectTypeOf(AesGcm.fromSeed(new Uint8Array(32))).toEqualTypeOf<
+    Promise<CryptoKey>
+  >()
+})

--- a/src/core/_test/AesGcm.test.ts
+++ b/src/core/_test/AesGcm.test.ts
@@ -1,4 +1,4 @@
-import { AesGcm, Bytes, Hex } from 'ox'
+import { AesGcm, Bytes, Hex, Mnemonic } from 'ox'
 import { describe, expect, test } from 'vitest'
 
 describe('decrypt', () => {
@@ -85,6 +85,92 @@ describe('encrypt', () => {
   })
 })
 
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', async () => {
+    const key = await AesGcm.fromMnemonic(mnemonic)
+    const expectedKey = await AesGcm.fromSeed(Mnemonic.toSeed(mnemonic))
+    const value = Bytes.fromString('i am a secret message')
+    const encrypted = await AesGcm.encrypt(value, key)
+
+    await expect(AesGcm.decrypt(encrypted, expectedKey)).resolves.toEqual(value)
+  })
+
+  test('options: passphrase', async () => {
+    const key = await AesGcm.fromMnemonic(mnemonic, {
+      passphrase: 'qwerty',
+    })
+    const defaultKey = await AesGcm.fromMnemonic(mnemonic)
+    const encrypted = await AesGcm.encrypt('0xdeadbeef', key)
+
+    await expect(AesGcm.decrypt(encrypted, defaultKey)).rejects.toThrowError()
+  })
+})
+
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', async () => {
+    const key = await AesGcm.fromSeed(seed)
+    const expectedKey = await globalThis.crypto.subtle.importKey(
+      'raw',
+      Bytes.fromHex(
+        '0xd42ffe5cb894ce61e9f448e8083f53b2ab90d2acad0929e80b0abb85e915cb3a',
+      ),
+      { name: 'AES-GCM' },
+      false,
+      ['decrypt'],
+    )
+    const value = Bytes.fromString('i am a secret message')
+    const encrypted = await AesGcm.encrypt(value, key)
+
+    await expect(AesGcm.decrypt(encrypted, expectedKey)).resolves.toEqual(value)
+  })
+
+  test('value: Bytes', async () => {
+    const key = await AesGcm.fromSeed(Bytes.fromHex(seed))
+    const value = Bytes.fromString('i am a secret message')
+
+    await expect(
+      AesGcm.decrypt(await AesGcm.encrypt(value, key), key),
+    ).resolves.toEqual(value)
+  })
+
+  test('behavior: accepts seeds longer than 32 bytes', async () => {
+    const key = await AesGcm.fromSeed(new Uint8Array(64))
+
+    expect({
+      algorithm: key.algorithm,
+      extractable: key.extractable,
+      type: key.type,
+      usages: key.usages,
+    }).toMatchInlineSnapshot(`
+      {
+        "algorithm": {
+          "length": 256,
+          "name": "AES-GCM",
+        },
+        "extractable": false,
+        "type": "secret",
+        "usages": [
+          "encrypt",
+          "decrypt",
+        ],
+      }
+    `)
+  })
+
+  test('error: seed is too short', async () => {
+    await expect(
+      AesGcm.fromSeed(new Uint8Array(31)),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AesGcm.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]`,
+    )
+  })
+})
+
 describe('getKey', () => {
   test('default', async () => {
     const key = await AesGcm.getKey({ password: 'qwerty' })
@@ -103,8 +189,11 @@ test('exports', () => {
   expect(Object.keys(AesGcm)).toMatchInlineSnapshot(`
     [
       "ivLength",
+      "InvalidSeedSizeError",
       "decrypt",
       "encrypt",
+      "fromMnemonic",
+      "fromSeed",
       "getKey",
       "randomSalt",
     ]

--- a/src/core/_test/Ed25519.test-d.ts
+++ b/src/core/_test/Ed25519.test-d.ts
@@ -1,6 +1,30 @@
 import { attest } from '@ark/attest'
-import { Ed25519 } from 'ox'
+import { type Bytes, Ed25519, type Hex } from 'ox'
 import { expectTypeOf, test } from 'vitest'
+
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(Ed25519.fromMnemonic(mnemonic)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Ed25519.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Ed25519.fromMnemonic(mnemonic, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
+test('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  expectTypeOf(Ed25519.fromSeed(seed)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Ed25519.fromSeed(new Uint8Array(32))).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Ed25519.fromSeed(seed, { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Ed25519.fromSeed(seed, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
 
 test('createKeyPair', () => {
   // Default behavior (Hex)

--- a/src/core/_test/Ed25519.test.ts
+++ b/src/core/_test/Ed25519.test.ts
@@ -1,4 +1,4 @@
-import { Bytes, Ed25519, Hex, X25519 } from 'ox'
+import { Bytes, Ed25519, Hex, Mnemonic, X25519 } from 'ox'
 import { describe, expect, test } from 'vitest'
 
 describe('createKeyPair', () => {
@@ -41,6 +41,76 @@ describe('createKeyPair', () => {
 
     expect(keyPair1.privateKey).not.toBe(keyPair2.privateKey)
     expect(keyPair1.publicKey).not.toBe(keyPair2.publicKey)
+  })
+})
+
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', () => {
+    const privateKey = Ed25519.fromMnemonic(mnemonic)
+
+    expect(privateKey).toBe(Ed25519.fromSeed(Mnemonic.toSeed(mnemonic)))
+    expect(privateKey).toMatchInlineSnapshot(
+      `"0x23fb07a427d2bc36141d1e6c7e56c72679739eff374a8e8def282f1048674567"`,
+    )
+  })
+
+  test('options: passphrase', () => {
+    expect(
+      Ed25519.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+    ).toMatchInlineSnapshot(
+      `"0xe888791c9d783e772d92b0bf2aa326b1cda8214a03c3c07933615b1a98fc8651"`,
+    )
+  })
+
+  test('options: as', () => {
+    const privateKey = Ed25519.fromMnemonic(mnemonic, { as: 'Bytes' })
+
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
+  })
+})
+
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', () => {
+    expect(Ed25519.fromSeed(seed)).toMatchInlineSnapshot(
+      `"0xfd09c7b2acda46034df7e428377fdc37200094c9b51690fa1b733ee3c16a2d07"`,
+    )
+  })
+
+  test('value: Bytes', () => {
+    expect(Ed25519.fromSeed(Bytes.fromHex(seed))).toMatchInlineSnapshot(
+      `"0xfd09c7b2acda46034df7e428377fdc37200094c9b51690fa1b733ee3c16a2d07"`,
+    )
+  })
+
+  test('options: as', () => {
+    expect(Ed25519.fromSeed(seed, { as: 'Bytes' })).toEqual(
+      Bytes.fromHex(
+        '0xfd09c7b2acda46034df7e428377fdc37200094c9b51690fa1b733ee3c16a2d07',
+      ),
+    )
+  })
+
+  test('behavior: output signs and verifies', () => {
+    const privateKey = Ed25519.fromSeed(new Uint8Array(64))
+    const publicKey = Ed25519.getPublicKey({ privateKey })
+    const payload = '0xdeadbeef'
+    const signature = Ed25519.sign({ payload, privateKey })
+
+    expect(Ed25519.verify({ payload, publicKey, signature })).toBe(true)
+  })
+
+  test('error: seed is too short', () => {
+    expect(() =>
+      Ed25519.fromSeed(new Uint8Array(31)),
+    ).toThrowErrorMatchingInlineSnapshot(`
+        [Ed25519.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]
+      `)
   })
 })
 

--- a/src/core/_test/P256.test-d.ts
+++ b/src/core/_test/P256.test-d.ts
@@ -1,0 +1,26 @@
+import { type Bytes, type Hex, P256 } from 'ox'
+import { expectTypeOf, test } from 'vitest'
+
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(P256.fromMnemonic(mnemonic)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    P256.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    P256.fromMnemonic(mnemonic, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})
+
+test('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  expectTypeOf(P256.fromSeed(seed)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(P256.fromSeed(new Uint8Array(32))).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(P256.fromSeed(seed, { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    P256.fromSeed(seed, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -1,4 +1,4 @@
-import { Bytes, Hex, P256 } from 'ox'
+import { Bytes, Hex, Mnemonic, P256 } from 'ox'
 import { describe, expect, test } from 'vitest'
 import { accounts } from '../../../test/constants/accounts.js'
 
@@ -142,6 +142,73 @@ describe('createKeyPair', () => {
     const recoveredPublicKey = P256.recoverPublicKey({ payload, signature })
 
     expect(recoveredPublicKey).toEqual(keyPair.publicKey)
+  })
+})
+
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', () => {
+    const privateKey = P256.fromMnemonic(mnemonic)
+
+    expect(privateKey).toBe(P256.fromSeed(Mnemonic.toSeed(mnemonic)))
+    expect(privateKey).toMatchInlineSnapshot(
+      `"0x882f5b02a84c96bceeebf9c868bec73041d51b041ae05380e66a41508648ebc3"`,
+    )
+  })
+
+  test('options: passphrase', () => {
+    expect(
+      P256.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+    ).toMatchInlineSnapshot(
+      `"0x364ff539f37ce477d49a35476c9ad32a2a3fed1d1237eaee7abdfd07655ad9f5"`,
+    )
+  })
+
+  test('options: as', () => {
+    const privateKey = P256.fromMnemonic(mnemonic, { as: 'Bytes' })
+
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
+  })
+})
+
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', () => {
+    expect(P256.fromSeed(seed)).toMatchInlineSnapshot(
+      `"0x724009e76eb27e34eb77b93db354b9015ecd4296deb57561f5214bab68b94a6f"`,
+    )
+  })
+
+  test('value: Bytes', () => {
+    expect(P256.fromSeed(Bytes.fromHex(seed))).toMatchInlineSnapshot(
+      `"0x724009e76eb27e34eb77b93db354b9015ecd4296deb57561f5214bab68b94a6f"`,
+    )
+  })
+
+  test('options: as', () => {
+    expect(P256.fromSeed(seed, { as: 'Bytes' })).toEqual(
+      Bytes.fromHex(
+        '0x724009e76eb27e34eb77b93db354b9015ecd4296deb57561f5214bab68b94a6f',
+      ),
+    )
+  })
+
+  test('behavior: output is a valid P256 private key', () => {
+    const privateKey = P256.fromSeed(new Uint8Array(64), { as: 'Bytes' })
+
+    expect(P256.noble.utils.isValidPrivateKey(privateKey)).toBe(true)
+  })
+
+  test('error: seed is too short', () => {
+    expect(() =>
+      P256.fromSeed(new Uint8Array(31)),
+    ).toThrowErrorMatchingInlineSnapshot(`
+        [P256.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]
+      `)
   })
 })
 
@@ -541,7 +608,10 @@ test('exports', () => {
   expect(Object.keys(P256)).toMatchInlineSnapshot(`
     [
       "noble",
+      "InvalidSeedSizeError",
       "createKeyPair",
+      "fromMnemonic",
+      "fromSeed",
       "getPublicKey",
       "getSharedSecret",
       "randomPrivateKey",

--- a/src/core/_test/Secp256k1.test-d.ts
+++ b/src/core/_test/Secp256k1.test-d.ts
@@ -1,0 +1,29 @@
+import { type Bytes, type Hex, Secp256k1 } from 'ox'
+import { expectTypeOf, test } from 'vitest'
+
+test('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  expectTypeOf(Secp256k1.fromMnemonic(mnemonic)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Secp256k1.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Secp256k1.fromMnemonic(mnemonic, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+  expectTypeOf(
+    Secp256k1.fromMnemonic(mnemonic, { path: "m/44'/60'/0'/0/1" }),
+  ).toEqualTypeOf<Hex.Hex>()
+})
+
+test('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  expectTypeOf(Secp256k1.fromSeed(seed)).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Secp256k1.fromSeed(new Uint8Array(32))).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(Secp256k1.fromSeed(seed, { as: 'Hex' })).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    Secp256k1.fromSeed(seed, { as: 'Bytes' }),
+  ).toEqualTypeOf<Bytes.Bytes>()
+})

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -1,4 +1,4 @@
-import { Address, Bytes, Hex, PublicKey, Secp256k1 } from 'ox'
+import { Address, Bytes, Hex, Mnemonic, PublicKey, Secp256k1 } from 'ox'
 import { describe, expect, test } from 'vitest'
 import { accounts } from '../../../test/constants/accounts.js'
 
@@ -120,6 +120,81 @@ describe('createKeyPair', () => {
     })
 
     expect(keyPair.publicKey).toEqual(derivedPublicKey)
+  })
+})
+
+describe('fromMnemonic', () => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+
+  test('default', () => {
+    const privateKey = Secp256k1.fromMnemonic(mnemonic)
+
+    expect(privateKey).toBe(Mnemonic.toPrivateKey(mnemonic, { as: 'Hex' }))
+    expect(privateKey).toMatchInlineSnapshot(
+      `"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"`,
+    )
+  })
+
+  test('options: passphrase', () => {
+    expect(
+      Secp256k1.fromMnemonic(mnemonic, { passphrase: 'qwerty' }),
+    ).toMatchInlineSnapshot(
+      `"0x0bef893b1cc27e9ce726d5f12f75d61a07d4df87c02106083463cd712ac5c478"`,
+    )
+  })
+
+  test('options: as', () => {
+    const privateKey = Secp256k1.fromMnemonic(mnemonic, { as: 'Bytes' })
+
+    expect(privateKey).toBeInstanceOf(Uint8Array)
+    expect(privateKey).toHaveLength(32)
+  })
+
+  test('options: path', () => {
+    const path = "m/44'/60'/0'/0/1"
+
+    expect(Secp256k1.fromMnemonic(mnemonic, { path })).toBe(
+      Mnemonic.toPrivateKey(mnemonic, { as: 'Hex', path }),
+    )
+  })
+})
+
+describe('fromSeed', () => {
+  const seed =
+    '0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+
+  test('vector', () => {
+    expect(Secp256k1.fromSeed(seed)).toMatchInlineSnapshot(
+      `"0x5f7dcbba41adaafa378861d78b144f7b2827e79fa994a341628f5470d5bfbdd4"`,
+    )
+  })
+
+  test('value: Bytes', () => {
+    expect(Secp256k1.fromSeed(Bytes.fromHex(seed))).toMatchInlineSnapshot(
+      `"0x5f7dcbba41adaafa378861d78b144f7b2827e79fa994a341628f5470d5bfbdd4"`,
+    )
+  })
+
+  test('options: as', () => {
+    expect(Secp256k1.fromSeed(seed, { as: 'Bytes' })).toEqual(
+      Bytes.fromHex(
+        '0x5f7dcbba41adaafa378861d78b144f7b2827e79fa994a341628f5470d5bfbdd4',
+      ),
+    )
+  })
+
+  test('behavior: accepts seeds longer than 32 bytes', () => {
+    const privateKey = Secp256k1.fromSeed(new Uint8Array(64), { as: 'Bytes' })
+
+    expect(Secp256k1.noble.utils.isValidPrivateKey(privateKey)).toBe(true)
+  })
+
+  test('error: seed is too short', () => {
+    expect(() =>
+      Secp256k1.fromSeed(new Uint8Array(31)),
+    ).toThrowErrorMatchingInlineSnapshot(`
+        [Secp256k1.InvalidSeedSizeError: Seed must contain at least 32 bytes. Received 31 bytes.]
+      `)
   })
 })
 
@@ -482,7 +557,10 @@ test('exports', () => {
   expect(Object.keys(Secp256k1)).toMatchInlineSnapshot(`
     [
       "noble",
+      "InvalidSeedSizeError",
       "createKeyPair",
+      "fromMnemonic",
+      "fromSeed",
       "getPublicKey",
       "getSharedSecret",
       "randomPrivateKey",

--- a/src/core/internal/keyDerivation.ts
+++ b/src/core/internal/keyDerivation.ts
@@ -1,0 +1,33 @@
+import * as Bytes from '../Bytes.js'
+import type * as Errors from '../Errors.js'
+import * as Hash from '../Hash.js'
+
+/** @internal */
+export function derive(
+  seed: Bytes.Bytes,
+  domain: Bytes.Bytes,
+  options: derive.Options = {},
+): Bytes.Bytes {
+  const { validate } = options
+  for (let counter = 0; ; counter++) {
+    const key = Hash.hmac256(
+      seed,
+      Bytes.concat(domain, Bytes.fromNumber(counter, { size: 4 })),
+      { as: 'Bytes' },
+    )
+    if (!validate || validate(key)) return key
+    key.fill(0)
+  }
+}
+
+export declare namespace derive {
+  type Options = {
+    validate?: ((key: Bytes.Bytes) => boolean) | undefined
+  }
+
+  type ErrorType =
+    | Bytes.concat.ErrorType
+    | Bytes.fromNumber.ErrorType
+    | Hash.hmac256.ErrorType
+    | Errors.GlobalErrorType
+}


### PR DESCRIPTION
Adds deterministic seed and mnemonic derivation for Secp256k1, P256, Ed25519, and AES-GCM on the 0.x release line, preserving BIP-32 compatibility for Secp256k1 mnemonics.