### PR TITLE
fix(siwe): validate RFC 3339 date-times

### DIFF
--- a/.changeset/siwe-date-time-validation.md
+++ b/.changeset/siwe-date-time-validation.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+**SIWE:** Rejected invalid RFC 3339 lifetime fields and invalid validation times.

--- a/.changeset/siwe-date-time-validation.md
+++ b/.changeset/siwe-date-time-validation.md
@@ -2,4 +2,4 @@
 'ox': patch
 ---
 
-**SIWE:** Rejected invalid RFC 3339 lifetime fields and invalid validation times.
+Rejected invalid RFC 3339 SIWE lifetime fields and invalid validation times.

--- a/src/core/Siwe.ts
+++ b/src/core/Siwe.ts
@@ -23,6 +23,36 @@ export const prefixRegex =
 export const suffixRegex =
   /(?:URI: (?<uri>.+))\n(?:Version: (?<version>.+))\n(?:Chain ID: (?<chainId>\d+))\n(?:Nonce: (?<nonce>[a-zA-Z0-9]+))\n(?:Issued At: (?<issuedAt>.+))(?:\nExpiration Time: (?<expirationTime>.+))?(?:\nNot Before: (?<notBefore>.+))?(?:\nRequest ID: (?<requestId>.+))?/
 
+const siweDateTimeRegex =
+  /^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])[Tt]([01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/
+
+function parseSiweDateTime(value: string): Date {
+  const match = value.match(siweDateTimeRegex)
+  if (!match) return new Date(Number.NaN)
+
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const days = [
+    31,
+    year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ]
+  const daysInMonth = days[month - 1]
+  if (!daysInMonth || day > daysInMonth) return new Date(Number.NaN)
+
+  return new Date(value.toUpperCase())
+}
+
 /** [EIP-4361](https://eips.ethereum.org/EIPS/eip-4361) message fields. */
 export type Message = {
   /**
@@ -388,9 +418,11 @@ export function parseMessage(message: string): ExactPartial<Message> {
     ...prefix,
     ...suffix,
     ...(chainId ? { chainId: Number(chainId) } : {}),
-    ...(expirationTime ? { expirationTime: new Date(expirationTime) } : {}),
-    ...(issuedAt ? { issuedAt: new Date(issuedAt) } : {}),
-    ...(notBefore ? { notBefore: new Date(notBefore) } : {}),
+    ...(expirationTime
+      ? { expirationTime: parseSiweDateTime(expirationTime) }
+      : {}),
+    ...(issuedAt ? { issuedAt: parseSiweDateTime(issuedAt) } : {}),
+    ...(notBefore ? { notBefore: parseSiweDateTime(notBefore) } : {}),
     ...(requestId ? { requestId } : {}),
     ...(resources ? { resources } : {}),
     ...(scheme ? { scheme } : {}),
@@ -431,8 +463,16 @@ export function validateMessage(value: validateMessage.Value): boolean {
   if (nonce && message.nonce !== nonce) return false
   if (scheme && message.scheme !== scheme) return false
 
-  if (message.expirationTime && time >= message.expirationTime) return false
-  if (message.notBefore && time < message.notBefore) return false
+  if (Number.isNaN(time.getTime())) return false
+
+  if (message.expirationTime) {
+    if (Number.isNaN(message.expirationTime.getTime())) return false
+    if (time >= message.expirationTime) return false
+  }
+  if (message.notBefore) {
+    if (Number.isNaN(message.notBefore.getTime())) return false
+    if (time < message.notBefore) return false
+  }
 
   try {
     if (!message.address) return false

--- a/src/core/_test/Siwe.test.ts
+++ b/src/core/_test/Siwe.test.ts
@@ -546,6 +546,81 @@ Expiration Time: 2022-02-04T00:00:00.000Z`
     )
   })
 
+  test.each([
+    ['never', '2023-02-01T00:00:00Z'],
+    ['2023-02-29T00:00:00Z', '2023-02-28T12:00:00Z'],
+    ['2023-04-31T00:00:00Z', '2023-04-30T12:00:00Z'],
+    ['2023-02-01T24:00:00Z', '2023-02-01T12:00:00Z'],
+  ])(
+    'behavior: invalid RFC 3339 expirationTime `%s`',
+    (expirationTime, time) => {
+      const message = `https://example.com wants you to sign in with your Ethereum account:
+0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
+
+URI: https://example.com/path
+Version: 1
+Chain ID: 1
+Nonce: foobarbaz
+Issued At: 2023-02-01T00:00:00.000Z
+Expiration Time: ${expirationTime}`
+      const parsed = Siwe.parseMessage(message)
+      expect({
+        invalid: Number.isNaN(parsed.expirationTime?.getTime()),
+        valid: Siwe.validateMessage({
+          message: parsed,
+          time: new Date(time),
+        }),
+      }).toMatchInlineSnapshot(`
+        {
+          "invalid": true,
+          "valid": false,
+        }
+      `)
+    },
+  )
+
+  test.each([
+    '2030-02-04t00:00:00Z',
+    '2030-02-04T00:00:00z',
+    '2030-02-04t00:00:00z',
+  ])('behavior: lowercase RFC 3339 expirationTime `%s`', (expirationTime) => {
+    const message = `https://example.com wants you to sign in with your Ethereum account:
+0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
+
+URI: https://example.com/path
+Version: 1
+Chain ID: 1
+Nonce: foobarbaz
+Issued At: 2023-02-01T00:00:00.000Z
+Expiration Time: ${expirationTime}`
+    const parsed = Siwe.parseMessage(message)
+    expect(parsed.expirationTime).toMatchInlineSnapshot(
+      '2030-02-04T00:00:00.000Z',
+    )
+    expect(
+      Siwe.validateMessage({
+        message: parsed,
+        time: new Date('2029-02-04T00:00:00Z'),
+      }),
+    ).toBeTruthy()
+  })
+
+  test('behavior: leap-year expirationTime', () => {
+    const message = `https://example.com wants you to sign in with your Ethereum account:
+0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
+
+URI: https://example.com/path
+Version: 1
+Chain ID: 1
+Nonce: foobarbaz
+Issued At: 2023-02-01T00:00:00.000Z
+Expiration Time: 2032-02-29T00:00:00Z`
+    const parsed = Siwe.parseMessage(message)
+    expect(parsed.expirationTime).toMatchInlineSnapshot(
+      '2032-02-29T00:00:00.000Z',
+    )
+  })
+
   test('behavior: with notBefore', () => {
     const message = `https://example.com wants you to sign in with your Ethereum account:
 0xA0Cf798816D4b9b9866b5330EEa46a18382f251e
@@ -726,6 +801,29 @@ describe('validateMessage', () => {
           expirationTime: new Date(Date.UTC(2024, 1, 1)),
         },
         time: new Date(Date.UTC(2025, 1, 1)),
+      }),
+    ).toBeFalsy()
+  })
+
+  test.each(['expirationTime', 'notBefore'] as const)(
+    'behavior: invalid %s',
+    (field) => {
+      expect(
+        Siwe.validateMessage({
+          message: {
+            ...message,
+            [field]: new Date('never'),
+          },
+        }),
+      ).toBeFalsy()
+    },
+  )
+
+  test('behavior: invalid time', () => {
+    expect(
+      Siwe.validateMessage({
+        message,
+        time: new Date('never'),
       }),
     ).toBeFalsy()
   })


### PR DESCRIPTION
Supersedes #393.

Rejected malformed SIWE date-times without rejecting valid lowercase RFC 3339 separators.