### PR TITLE
fix: reduce cjs key bundle size

### DIFF
--- a/.changeset/calm-keys-shrink.md
+++ b/.changeset/calm-keys-shrink.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Reduced CommonJS bundles that import `P256` or `Secp256k1`.

--- a/src/core/P256.ts
+++ b/src/core/P256.ts
@@ -4,7 +4,7 @@ import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 import * as Entropy from './internal/entropy.js'
 import * as keyDerivation from './internal/keyDerivation.js'
-import * as Mnemonic from './Mnemonic.js'
+import * as internal from './internal/mnemonic.js'
 import * as PublicKey from './PublicKey.js'
 import type * as Signature from './Signature.js'
 
@@ -83,7 +83,7 @@ export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
   options: fromMnemonic.Options<as> = {},
 ): fromMnemonic.ReturnType<as> {
   const { passphrase } = options
-  const seed = Mnemonic.toSeed(mnemonic, { passphrase })
+  const seed = internal.toSeed(mnemonic, { passphrase })
   try {
     return fromSeed(seed, options)
   } finally {

--- a/src/core/Secp256k1.ts
+++ b/src/core/Secp256k1.ts
@@ -5,8 +5,9 @@ import * as Errors from './Errors.js'
 import * as Hex from './Hex.js'
 import * as Entropy from './internal/entropy.js'
 import * as keyDerivation from './internal/keyDerivation.js'
+import * as internal from './internal/mnemonic.js'
 import type { OneOf } from './internal/types.js'
-import * as Mnemonic from './Mnemonic.js'
+import type * as Mnemonic from './Mnemonic.js'
 import * as PublicKey from './PublicKey.js'
 import type * as Signature from './Signature.js'
 
@@ -85,7 +86,7 @@ export function fromMnemonic<as extends 'Hex' | 'Bytes' = 'Hex'>(
   options: fromMnemonic.Options<as> = {},
 ): fromMnemonic.ReturnType<as> {
   const { as = 'Hex', passphrase, path } = options
-  return Mnemonic.toPrivateKey(mnemonic, { as, passphrase, path }) as never
+  return internal.toPrivateKey(mnemonic, { as, passphrase, path }) as never
 }
 
 export declare namespace fromMnemonic {

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -605,15 +605,15 @@ describe('verify', () => {
 })
 
 test('exports', () => {
-  expect(Object.keys(P256)).toMatchInlineSnapshot(`
+  expect(Object.keys(P256).sort()).toMatchInlineSnapshot(`
     [
-      "noble",
       "InvalidSeedSizeError",
       "createKeyPair",
       "fromMnemonic",
       "fromSeed",
       "getPublicKey",
       "getSharedSecret",
+      "noble",
       "randomPrivateKey",
       "recoverPublicKey",
       "sign",

--- a/src/core/_test/P256.test.ts
+++ b/src/core/_test/P256.test.ts
@@ -608,6 +608,7 @@ test('exports', () => {
   expect(Object.keys(P256)).toMatchInlineSnapshot(`
     [
       "noble",
+      "InvalidSeedSizeError",
       "createKeyPair",
       "fromMnemonic",
       "fromSeed",
@@ -617,7 +618,6 @@ test('exports', () => {
       "recoverPublicKey",
       "sign",
       "verify",
-      "InvalidSeedSizeError",
     ]
   `)
 })

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -557,6 +557,7 @@ test('exports', () => {
   expect(Object.keys(Secp256k1)).toMatchInlineSnapshot(`
     [
       "noble",
+      "InvalidSeedSizeError",
       "createKeyPair",
       "fromMnemonic",
       "fromSeed",
@@ -567,7 +568,6 @@ test('exports', () => {
       "recoverPublicKey",
       "sign",
       "verify",
-      "InvalidSeedSizeError",
     ]
   `)
 })

--- a/src/core/_test/Secp256k1.test.ts
+++ b/src/core/_test/Secp256k1.test.ts
@@ -554,15 +554,15 @@ describe('verify', () => {
 })
 
 test('exports', () => {
-  expect(Object.keys(Secp256k1)).toMatchInlineSnapshot(`
+  expect(Object.keys(Secp256k1).sort()).toMatchInlineSnapshot(`
     [
-      "noble",
       "InvalidSeedSizeError",
       "createKeyPair",
       "fromMnemonic",
       "fromSeed",
       "getPublicKey",
       "getSharedSecret",
+      "noble",
       "randomPrivateKey",
       "recoverAddress",
       "recoverPublicKey",

--- a/src/core/internal/mnemonic.ts
+++ b/src/core/internal/mnemonic.ts
@@ -3,6 +3,7 @@ import { mnemonicToSeedSync } from '@scure/bip39'
 import type * as Bytes from '../Bytes.js'
 import * as Hex from '../Hex.js'
 
+/** @internal */
 export function toPrivateKey<as extends 'Bytes' | 'Hex' = 'Bytes'>(
   mnemonic: string,
   options: {
@@ -21,6 +22,7 @@ export function toPrivateKey<as extends 'Bytes' | 'Hex' = 'Bytes'>(
   return Hex.fromBytes(privateKey) as never
 }
 
+/** @internal */
 export function toSeed(
   mnemonic: string,
   options: { passphrase?: string | undefined } = {},

--- a/src/core/internal/mnemonic.ts
+++ b/src/core/internal/mnemonic.ts
@@ -1,0 +1,29 @@
+import { HDKey } from '@scure/bip32'
+import { mnemonicToSeedSync } from '@scure/bip39'
+import type * as Bytes from '../Bytes.js'
+import * as Hex from '../Hex.js'
+
+export function toPrivateKey<as extends 'Bytes' | 'Hex' = 'Bytes'>(
+  mnemonic: string,
+  options: {
+    as?: as | undefined
+    passphrase?: string | undefined
+    path?: string | undefined
+  } = {},
+):
+  | (as extends 'Bytes' ? Bytes.Bytes : never)
+  | (as extends 'Hex' ? Hex.Hex : never) {
+  const { path = "m/44'/60'/0'/0/0", passphrase } = options
+  const privateKey = HDKey.fromMasterSeed(
+    toSeed(mnemonic, { passphrase }),
+  ).derive(path).privateKey!
+  if (options.as === 'Bytes') return privateKey as never
+  return Hex.fromBytes(privateKey) as never
+}
+
+export function toSeed(
+  mnemonic: string,
+  options: { passphrase?: string | undefined } = {},
+): Bytes.Bytes {
+  return mnemonicToSeedSync(mnemonic, options.passphrase)
+}


### PR DESCRIPTION
Loads mnemonic derivation without importing public wordlist exports, preventing CommonJS consumers of `P256` and `Secp256k1` from bundling every BIP-39 wordlist.
