### PR TITLE
feat(tempo): add multisig RPC schema

### DIFF
--- a/src/tempo/RpcSchemaTempo.test-d.ts
+++ b/src/tempo/RpcSchemaTempo.test-d.ts
@@ -1,0 +1,56 @@
+import type { Provider } from 'ox'
+import type {
+  KeyAuthorization,
+  MultisigOperation,
+  RpcSchemaTempo,
+} from 'ox/tempo'
+import { expectTypeOf, test } from 'vitest'
+import type * as Hex from '../core/Hex.js'
+
+declare const provider: Provider.Provider<{ schema: RpcSchemaTempo.Multisig }>
+declare const hash: Hex.Hex
+declare const keyAuthorization: KeyAuthorization.Rpc
+declare const serializedTransaction: Hex.Hex
+declare const signature: Hex.Hex
+
+test('multisig provider methods', () => {
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveRawTransaction',
+      params: [serializedTransaction],
+    }),
+  ).resolves.toEqualTypeOf<Hex.Hex>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveRawTransactionSync',
+      params: [serializedTransaction],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.TransactionRpc>()
+
+  provider.request({
+    method: 'multisig_approveRawTransactionSync',
+    params: [serializedTransaction, 30_000],
+  })
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ keyAuthorization }],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ hash, signature }],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_getOperation',
+      params: [hash],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.Rpc | null>()
+})

--- a/src/tempo/RpcSchemaTempo.ts
+++ b/src/tempo/RpcSchemaTempo.ts
@@ -4,6 +4,8 @@ import type * as Hex from '../core/Hex.js'
 import type * as Log from '../core/Log.js'
 import type * as RpcSchema from '../core/RpcSchema.js'
 import type * as StateOverrides from '../core/StateOverrides.js'
+import type * as KeyAuthorization from './KeyAuthorization.js'
+import type * as MultisigOperation from './MultisigOperation.js'
 import type * as TransactionRequest from './TransactionRequest.js'
 
 /**
@@ -53,3 +55,38 @@ export type Tempo = RpcSchema.From<{
     }
   }
 }>
+
+/** Union of all JSON-RPC methods for the `multisig_` namespace. */
+export type Multisig = RpcSchema.From<
+  | {
+      Request: {
+        method: 'multisig_approveRawTransaction'
+        params: [serializedTransaction: Hex.Hex]
+      }
+      ReturnType: Hex.Hex
+    }
+  | {
+      Request: {
+        method: 'multisig_approveRawTransactionSync'
+        params: [serializedTransaction: Hex.Hex, timeout?: number]
+      }
+      ReturnType: MultisigOperation.TransactionRpc
+    }
+  | {
+      Request: {
+        method: 'multisig_approveKeyAuthorization'
+        params: [
+          | { keyAuthorization: KeyAuthorization.Rpc }
+          | { hash: Hex.Hex; signature: Hex.Hex },
+        ]
+      }
+      ReturnType: MultisigOperation.KeyAuthorizationRpc
+    }
+  | {
+      Request: {
+        method: 'multisig_getOperation'
+        params: [hash: Hex.Hex]
+      }
+      ReturnType: MultisigOperation.Rpc | null
+    }
+>

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -233,7 +233,7 @@ export * as PoolId from './PoolId.js'
  */
 export * as ReceivePolicyReceipt from './ReceivePolicyReceipt.js'
 /**
- * Union of all JSON-RPC Methods for the `tempo_` namespace.
+ * JSON-RPC schemas for the `tempo_` and `multisig_` namespaces.
  *
  * @example
  * ```ts twoslash
@@ -243,6 +243,7 @@ export * as ReceivePolicyReceipt from './ReceivePolicyReceipt.js'
  *
  * const schema = RpcSchema.from<
  *   | RpcSchema.Default
+ *   | RpcSchemaTempo.Multisig
  *   | RpcSchemaTempo.Tempo
  * >()
  *


### PR DESCRIPTION
Adds typed Ox provider schemas for multisig operation RPC methods, covering raw transaction approvals, coordinated key authorization approvals, and operation lookup.
