### PR TITLE
feat(tempo): add multisig operations

### DIFF
--- a/.changeset/bright-taxis-approve.md
+++ b/.changeset/bright-taxis-approve.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Added `MultisigOperation` utilities, matching Zod schemas, and typed `multisig_` JSON-RPC methods.

--- a/package.json
+++ b/package.json
@@ -771,6 +771,11 @@
       "types": "./dist/tempo/MultisigConfig.d.ts",
       "default": "./dist/tempo/MultisigConfig.js"
     },
+    "./tempo/MultisigOperation": {
+      "src": "./src/tempo/MultisigOperation.ts",
+      "types": "./dist/tempo/MultisigOperation.d.ts",
+      "default": "./dist/tempo/MultisigOperation.js"
+    },
     "./tempo/Period": {
       "src": "./src/tempo/Period.ts",
       "types": "./dist/tempo/Period.d.ts",
@@ -1185,6 +1190,11 @@
       "src": "./src/zod/tempo/MultisigConfig.ts",
       "types": "./dist/zod/tempo/MultisigConfig.d.ts",
       "default": "./dist/zod/tempo/MultisigConfig.js"
+    },
+    "./zod/tempo/MultisigOperation": {
+      "src": "./src/zod/tempo/MultisigOperation.ts",
+      "types": "./dist/zod/tempo/MultisigOperation.d.ts",
+      "default": "./dist/zod/tempo/MultisigOperation.js"
     },
     "./zod/tempo/PoolId": {
       "src": "./src/zod/tempo/PoolId.ts",

--- a/src/core/Hash.ts
+++ b/src/core/Hash.ts
@@ -493,7 +493,7 @@ export declare namespace sha256 {
  * @returns Whether the value is a valid hash.
  */
 export function validate(value: string): value is Hex.Hex {
-  return Hex.validate(value) && Hex.size(value) === 32
+  return value.length === 66 && Hex.validate(value, { strict: true })
 }
 
 export declare namespace validate {

--- a/src/core/_test/Hash.test.ts
+++ b/src/core/_test/Hash.test.ts
@@ -764,6 +764,21 @@ describe('validate', () => {
     ).toBeFalsy()
     expect(
       Hash.validate(
+        '0xgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg',
+      ),
+    ).toBeFalsy()
+    expect(
+      Hash.validate(
+        '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72f',
+      ),
+    ).toBeFalsy()
+    expect(
+      Hash.validate(
+        '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe0',
+      ),
+    ).toBeFalsy()
+    expect(
+      Hash.validate(
         '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
       ),
     ).toBeTruthy()

--- a/src/tempo/MultisigOperation.test-d.ts
+++ b/src/tempo/MultisigOperation.test-d.ts
@@ -1,0 +1,52 @@
+import { expectTypeOf, test } from 'vp/test'
+import type * as Hex from '../core/Hex.js'
+import * as MultisigOperation from './MultisigOperation.js'
+
+declare const transaction: MultisigOperation.TransactionOperation
+declare const transactionRpc: MultisigOperation.TransactionRpc
+declare const keyAuthorization: MultisigOperation.KeyAuthorizationOperation
+declare const keyAuthorizationRpc: MultisigOperation.KeyAuthorizationRpc
+declare const operation: MultisigOperation.Operation
+declare const operationRpc: MultisigOperation.Rpc
+
+test('preserves operation kinds during validation', () => {
+  expectTypeOf(
+    MultisigOperation.from(transaction),
+  ).toEqualTypeOf<MultisigOperation.TransactionOperation>()
+  expectTypeOf(
+    MultisigOperation.from(keyAuthorization),
+  ).toEqualTypeOf<MultisigOperation.KeyAuthorizationOperation>()
+  expectTypeOf(
+    MultisigOperation.from(operation),
+  ).toEqualTypeOf<MultisigOperation.Operation>()
+})
+
+test('preserves operation kinds during RPC conversion', () => {
+  expectTypeOf(
+    MultisigOperation.fromRpc(transactionRpc),
+  ).toEqualTypeOf<MultisigOperation.TransactionOperation>()
+  expectTypeOf(
+    MultisigOperation.fromRpc(keyAuthorizationRpc),
+  ).toEqualTypeOf<MultisigOperation.KeyAuthorizationOperation>()
+  expectTypeOf(
+    MultisigOperation.toRpc(transaction),
+  ).toEqualTypeOf<MultisigOperation.TransactionRpc>()
+  expectTypeOf(
+    MultisigOperation.toRpc(keyAuthorization),
+  ).toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+  expectTypeOf(
+    MultisigOperation.fromRpc(operationRpc),
+  ).toEqualTypeOf<MultisigOperation.Operation>()
+  expectTypeOf(
+    MultisigOperation.toRpc(operation),
+  ).toEqualTypeOf<MultisigOperation.Rpc>()
+})
+
+test('uses JSON-RPC quantities only in RPC operations', () => {
+  expectTypeOf<
+    MultisigOperation.Operation['configVersion']
+  >().toEqualTypeOf<bigint>()
+  expectTypeOf<
+    MultisigOperation.Rpc['configVersion']
+  >().toEqualTypeOf<Hex.Hex>()
+})

--- a/src/tempo/MultisigOperation.test.ts
+++ b/src/tempo/MultisigOperation.test.ts
@@ -1,0 +1,1069 @@
+import { Address, Hex, P256 } from 'ox'
+import {
+  KeyAuthorization,
+  MultisigConfig,
+  MultisigOperation,
+  SignatureEnvelope,
+  TxEnvelopeTempo,
+} from 'ox/tempo'
+import { describe, expect, test } from 'vp/test'
+
+const owners = [1n, 2n, 3n]
+  .map((value, index) => {
+    const publicKey = P256.getPublicKey({
+      privateKey: `0x${value.toString(16).padStart(64, '0')}`,
+    })
+    return {
+      address: Address.fromPublicKey(publicKey),
+      signature: {
+        prehash: false,
+        publicKey,
+        signature: {
+          r: `0x${(index * 2 + 1).toString(16).padStart(64, '0')}`,
+          s: `0x${(index * 2 + 2).toString(16).padStart(64, '0')}`,
+        },
+        type: 'p256',
+      },
+    } as const
+  })
+  .sort((a, b) => a.address.localeCompare(b.address))
+const owner_1 = owners[0]!.address
+const owner_2 = owners[1]!.address
+const config = MultisigConfig.from({
+  owners: [
+    { owner: owner_1, weight: 1 },
+    { owner: owner_2, weight: 1 },
+  ],
+  threshold: 2,
+})
+const account = MultisigConfig.getAddress(config)
+const ownerSignature_1 = owners[0]!.signature
+const approval_1 = SignatureEnvelope.serialize(ownerSignature_1)
+const approval_2 = SignatureEnvelope.serialize(owners[1]!.signature)
+const approval_3 = SignatureEnvelope.serialize(owners[2]!.signature)
+const transaction = TxEnvelopeTempo.serialize(
+  TxEnvelopeTempo.from({
+    calls: [{ data: '0x1234', to: owner_1 }],
+    chainId: 4217,
+  }),
+)
+const transactionHash = `0x${'aa'.repeat(32)}` as const
+const submissionId = `0x${'bb'.repeat(32)}` as const
+const keyAuthorization = KeyAuthorization.serialize(
+  KeyAuthorization.from({
+    account,
+    address: '0x3333333333333333333333333333333333333333',
+    chainId: 4217n,
+    expiry: 1_800_000_000,
+    isAdmin: false,
+    type: 'secp256k1',
+  }),
+)
+
+const transactionHash_ = MultisigConfig.getSignPayload({
+  account,
+  payload: TxEnvelopeTempo.getSignPayload(
+    TxEnvelopeTempo.deserialize(transaction),
+  ),
+  version: 1n,
+})
+const keyAuthorizationHash = MultisigConfig.getSignPayload({
+  account,
+  payload: KeyAuthorization.getSignPayload(
+    KeyAuthorization.deserialize(keyAuthorization),
+  ),
+  version: 1n,
+})
+
+const base = {
+  account,
+  approvals: [approval_1],
+  config,
+  configVersion: 1n,
+  createdAt: 1,
+  init: false,
+  signatureCount: 1,
+  threshold: 2,
+  updatedAt: 2,
+  weight: 1,
+} as const
+
+const transactionPending = {
+  ...base,
+  hash: transactionHash_,
+  status: 'pending',
+  transaction,
+  type: 'transaction',
+} as const
+
+const keyAuthorizationPending = {
+  ...base,
+  hash: keyAuthorizationHash,
+  keyAuthorization,
+  status: 'pending',
+  type: 'keyAuthorization',
+} as const
+
+describe('from', () => {
+  test('transaction states', () => {
+    const pending = MultisigOperation.from(transactionPending)
+    const submitting = MultisigOperation.from({
+      ...transactionPending,
+      approvals: [approval_1, approval_2],
+      expiresAt: 10,
+      signatureCount: 2,
+      status: 'submitting',
+      submissionId,
+      weight: 2,
+    })
+    const success = MultisigOperation.from({
+      ...transactionPending,
+      approvals: [approval_1, approval_2],
+      signatureCount: 2,
+      status: 'success',
+      transactionHash,
+      weight: 2,
+    })
+
+    expect({ pending, submitting, success }).toMatchInlineSnapshot(`
+      {
+        "pending": {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "approvals": [
+            "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+          ],
+          "config": {
+            "owners": [
+              {
+                "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+                "weight": 1,
+              },
+              {
+                "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 2,
+          },
+          "configVersion": 1n,
+          "createdAt": 1,
+          "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
+          "init": false,
+          "signatureCount": 1,
+          "status": "pending",
+          "threshold": 2,
+          "transaction": "0x76e9821079808080dad99407e1ed8ea0e9601e5546b0a03aed683df360140780821234c0808080808080c0",
+          "type": "transaction",
+          "updatedAt": 2,
+          "weight": 1,
+        },
+        "submitting": {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "approvals": [
+            "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+            "0x01000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
+          ],
+          "config": {
+            "owners": [
+              {
+                "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+                "weight": 1,
+              },
+              {
+                "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 2,
+          },
+          "configVersion": 1n,
+          "createdAt": 1,
+          "expiresAt": 10,
+          "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
+          "init": false,
+          "signatureCount": 2,
+          "status": "submitting",
+          "submissionId": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "threshold": 2,
+          "transaction": "0x76e9821079808080dad99407e1ed8ea0e9601e5546b0a03aed683df360140780821234c0808080808080c0",
+          "type": "transaction",
+          "updatedAt": 2,
+          "weight": 2,
+        },
+        "success": {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "approvals": [
+            "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+            "0x01000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
+          ],
+          "config": {
+            "owners": [
+              {
+                "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+                "weight": 1,
+              },
+              {
+                "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 2,
+          },
+          "configVersion": 1n,
+          "createdAt": 1,
+          "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
+          "init": false,
+          "signatureCount": 2,
+          "status": "success",
+          "threshold": 2,
+          "transaction": "0x76e9821079808080dad99407e1ed8ea0e9601e5546b0a03aed683df360140780821234c0808080808080c0",
+          "transactionHash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "type": "transaction",
+          "updatedAt": 2,
+          "weight": 2,
+        },
+      }
+    `)
+  })
+
+  test('fee-payer transaction', () => {
+    const transaction = TxEnvelopeTempo.serialize(
+      TxEnvelopeTempo.from({
+        calls: [{ data: '0x1234', to: owner_1 }],
+        chainId: 4217,
+      }),
+      { format: 'feePayer', sender: account },
+    )
+    const operation = MultisigOperation.from({
+      ...transactionPending,
+      hash: MultisigConfig.getSignPayload({
+        account,
+        payload: TxEnvelopeTempo.getSignPayload(
+          TxEnvelopeTempo.deserialize(
+            Hex.concat(
+              TxEnvelopeTempo.serializedType,
+              Hex.slice(transaction, 1),
+            ) as TxEnvelopeTempo.Serialized,
+          ),
+        ),
+        version: 1n,
+      }),
+      transaction,
+    })
+
+    expect(operation).toMatchInlineSnapshot(
+      {
+        hash: expect.any(String),
+        transaction: expect.stringMatching(/^0x78/),
+      },
+      `
+      {
+        "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+        "approvals": [
+          "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+        ],
+        "config": {
+          "owners": [
+            {
+              "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+              "weight": 1,
+            },
+            {
+              "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "threshold": 2,
+        },
+        "configVersion": 1n,
+        "createdAt": 1,
+        "hash": Any<String>,
+        "init": false,
+        "signatureCount": 1,
+        "status": "pending",
+        "threshold": 2,
+        "transaction": StringMatching /\\^0x78/,
+        "type": "transaction",
+        "updatedAt": 2,
+        "weight": 1,
+      }
+    `,
+    )
+  })
+
+  test('fee-payer-signed transaction', () => {
+    const transaction = TxEnvelopeTempo.serialize(
+      TxEnvelopeTempo.from({
+        calls: [{ data: '0x1234', to: owner_1 }],
+        chainId: 4217,
+        feePayerSignature: {
+          r: `0x${'05'.padStart(64, '0')}`,
+          s: `0x${'06'.padStart(64, '0')}`,
+          yParity: 0,
+        },
+      }),
+      { format: 'feePayer' },
+    )
+    const operation = MultisigOperation.from({
+      ...transactionPending,
+      hash: MultisigConfig.getSignPayload({
+        account,
+        payload: TxEnvelopeTempo.getSignPayload(
+          TxEnvelopeTempo.deserialize(
+            Hex.concat(
+              TxEnvelopeTempo.serializedType,
+              Hex.slice(transaction, 1),
+            ) as TxEnvelopeTempo.Serialized,
+          ),
+        ),
+        version: 1n,
+      }),
+      transaction,
+    })
+
+    expect(operation.transaction).toBe(transaction)
+  })
+
+  test('bootstrap transaction', () => {
+    const operation = MultisigOperation.from({
+      ...transactionPending,
+      configVersion: 0n,
+      hash: MultisigConfig.getSignPayload({
+        account,
+        payload: TxEnvelopeTempo.getSignPayload(
+          TxEnvelopeTempo.deserialize(transaction),
+        ),
+        version: 0n,
+      }),
+      init: true,
+    })
+
+    expect(operation).toMatchInlineSnapshot(
+      {
+        hash: expect.any(String),
+        transaction: expect.any(String),
+      },
+      `
+      {
+        "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+        "approvals": [
+          "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+        ],
+        "config": {
+          "owners": [
+            {
+              "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+              "weight": 1,
+            },
+            {
+              "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "threshold": 2,
+        },
+        "configVersion": 0n,
+        "createdAt": 1,
+        "hash": Any<String>,
+        "init": true,
+        "signatureCount": 1,
+        "status": "pending",
+        "threshold": 2,
+        "transaction": Any<String>,
+        "type": "transaction",
+        "updatedAt": 2,
+        "weight": 1,
+      }
+    `,
+    )
+  })
+
+  test('initialized transaction at config version zero', () => {
+    const operation = MultisigOperation.from({
+      ...transactionPending,
+      configVersion: 0n,
+      hash: MultisigConfig.getSignPayload({
+        account,
+        payload: TxEnvelopeTempo.getSignPayload(
+          TxEnvelopeTempo.deserialize(transaction),
+        ),
+        version: 0n,
+      }),
+    })
+
+    expect({
+      configVersion: operation.configVersion,
+      init: operation.init,
+    }).toMatchInlineSnapshot(`
+      {
+        "configVersion": 0n,
+        "init": false,
+      }
+    `)
+  })
+
+  test('key authorization states', () => {
+    const pending = MultisigOperation.from(keyAuthorizationPending)
+    const authorization = KeyAuthorization.deserialize(keyAuthorization)
+    const success = MultisigOperation.from({
+      ...keyAuthorizationPending,
+      approvals: [approval_1, approval_2],
+      keyAuthorization: KeyAuthorization.serialize(
+        KeyAuthorization.from(authorization, {
+          signature: {
+            account,
+            signatures: [
+              SignatureEnvelope.deserialize(approval_1),
+              SignatureEnvelope.deserialize(approval_2),
+            ],
+            type: 'multisig',
+          },
+        }),
+      ),
+      signatureCount: 2,
+      status: 'success',
+      weight: 2,
+    })
+
+    expect({ pending, success }).toMatchInlineSnapshot(`
+      {
+        "pending": {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "approvals": [
+            "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+          ],
+          "config": {
+            "owners": [
+              {
+                "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+                "weight": 1,
+              },
+              {
+                "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 2,
+          },
+          "configVersion": 1n,
+          "createdAt": 1,
+          "hash": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
+          "init": false,
+          "keyAuthorization": "0xf838f782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36e",
+          "signatureCount": 1,
+          "status": "pending",
+          "threshold": 2,
+          "type": "keyAuthorization",
+          "updatedAt": 2,
+          "weight": 1,
+        },
+        "success": {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "approvals": [
+            "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+            "0x01000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
+          ],
+          "config": {
+            "owners": [
+              {
+                "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+                "weight": 1,
+              },
+              {
+                "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 2,
+          },
+          "configVersion": 1n,
+          "createdAt": 1,
+          "hash": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
+          "init": false,
+          "keyAuthorization": "0xf9015ff782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36eb9012405f9012094f81b7763d3a6876195d780865bd783dbd97dd36ef90108b88201000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200b88201000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
+          "signatureCount": 2,
+          "status": "success",
+          "threshold": 2,
+          "type": "keyAuthorization",
+          "updatedAt": 2,
+          "weight": 2,
+        },
+      }
+    `)
+  })
+
+  test('bootstrap key authorization', () => {
+    const authorization = KeyAuthorization.deserialize(keyAuthorization)
+    const keyAuthorization_ = KeyAuthorization.serialize(
+      KeyAuthorization.from(authorization, {
+        signature: {
+          account,
+          init: config,
+          signatures: [
+            SignatureEnvelope.deserialize(approval_1),
+            SignatureEnvelope.deserialize(approval_2),
+          ],
+          type: 'multisig',
+        },
+      }),
+    )
+    const operation = MultisigOperation.from({
+      ...keyAuthorizationPending,
+      approvals: [approval_1, approval_2],
+      configVersion: 0n,
+      hash: MultisigConfig.getSignPayload({
+        account,
+        payload: KeyAuthorization.getSignPayload(authorization),
+        version: 0n,
+      }),
+      init: true,
+      keyAuthorization: keyAuthorization_,
+      signatureCount: 2,
+      status: 'success',
+      weight: 2,
+    })
+
+    expect(operation).toMatchInlineSnapshot(
+      {
+        hash: expect.any(String),
+        keyAuthorization: expect.any(String),
+      },
+      `
+      {
+        "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+        "approvals": [
+          "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+          "0x01000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
+        ],
+        "config": {
+          "owners": [
+            {
+              "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+              "weight": 1,
+            },
+            {
+              "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "threshold": 2,
+        },
+        "configVersion": 0n,
+        "createdAt": 1,
+        "hash": Any<String>,
+        "init": true,
+        "keyAuthorization": Any<String>,
+        "signatureCount": 2,
+        "status": "success",
+        "threshold": 2,
+        "type": "keyAuthorization",
+        "updatedAt": 2,
+        "weight": 2,
+      }
+    `,
+    )
+  })
+})
+
+describe('RPC conversion', () => {
+  test('round-trips transaction and key authorization operations', () => {
+    const transactionRpc = MultisigOperation.toRpc(transactionPending)
+    const keyAuthorizationRpc = MultisigOperation.toRpc(keyAuthorizationPending)
+
+    expect({ keyAuthorizationRpc, transactionRpc }).toMatchInlineSnapshot(`
+      {
+        "keyAuthorizationRpc": {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "approvals": [
+            "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+          ],
+          "config": {
+            "owners": [
+              {
+                "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+                "weight": 1,
+              },
+              {
+                "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 2,
+          },
+          "configVersion": "0x1",
+          "createdAt": 1,
+          "hash": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
+          "init": false,
+          "keyAuthorization": "0xf838f782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36e",
+          "signatureCount": 1,
+          "status": "pending",
+          "threshold": 2,
+          "type": "keyAuthorization",
+          "updatedAt": 2,
+          "weight": 1,
+        },
+        "transactionRpc": {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "approvals": [
+            "0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200",
+          ],
+          "config": {
+            "owners": [
+              {
+                "owner": "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+                "weight": 1,
+              },
+              {
+                "owner": "0x288f0cd85005f34168f731a468aef268c2f9456f",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 2,
+          },
+          "configVersion": "0x1",
+          "createdAt": 1,
+          "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
+          "init": false,
+          "signatureCount": 1,
+          "status": "pending",
+          "threshold": 2,
+          "transaction": "0x76e9821079808080dad99407e1ed8ea0e9601e5546b0a03aed683df360140780821234c0808080808080c0",
+          "type": "transaction",
+          "updatedAt": 2,
+          "weight": 1,
+        },
+      }
+    `)
+    expect(MultisigOperation.fromRpc(transactionRpc)).toStrictEqual(
+      MultisigOperation.from(transactionPending),
+    )
+    expect(MultisigOperation.fromRpc(keyAuthorizationRpc)).toStrictEqual(
+      MultisigOperation.from(keyAuthorizationPending),
+    )
+  })
+})
+
+describe('validation', () => {
+  test.each([
+    {
+      name: 'mismatched hash',
+      operation: { ...transactionPending, hash: transactionHash },
+    },
+    {
+      name: 'outer transaction signature',
+      operation: {
+        ...transactionPending,
+        transaction: TxEnvelopeTempo.serialize(
+          TxEnvelopeTempo.deserialize(transaction),
+          { signature: SignatureEnvelope.deserialize(approval_1) },
+        ),
+      },
+    },
+    {
+      name: 'pending transaction submission fields',
+      operation: { ...transactionPending, submissionId },
+    },
+    {
+      name: 'submitting transaction without lease',
+      operation: { ...transactionPending, status: 'submitting', weight: 2 },
+    },
+    {
+      name: 'successful transaction without hash',
+      operation: { ...transactionPending, status: 'success', weight: 2 },
+    },
+    {
+      name: 'signed pending key authorization',
+      operation: {
+        ...keyAuthorizationPending,
+        keyAuthorization: KeyAuthorization.serialize(
+          KeyAuthorization.from(
+            KeyAuthorization.deserialize(keyAuthorization),
+            {
+              signature: ownerSignature_1,
+            },
+          ),
+        ),
+      },
+    },
+    {
+      name: 'successful key authorization without quorum',
+      operation: { ...keyAuthorizationPending, status: 'success' },
+    },
+    {
+      name: 'pending key authorization with quorum',
+      operation: {
+        ...keyAuthorizationPending,
+        approvals: [approval_1, approval_2],
+        signatureCount: 2,
+        weight: 2,
+      },
+    },
+    {
+      name: 'key authorization with transaction fields',
+      operation: { ...keyAuthorizationPending, transaction },
+    },
+    {
+      name: 'transaction with key authorization fields',
+      operation: { ...transactionPending, keyAuthorization },
+    },
+    {
+      name: 'selected signature without weight',
+      operation: { ...transactionPending, weight: 0 },
+    },
+    {
+      name: 'string config threshold',
+      operation: {
+        ...transactionPending,
+        config: { ...config, threshold: '2' },
+      },
+    },
+    {
+      name: 'bigint config owner weight',
+      operation: {
+        ...transactionPending,
+        config: {
+          ...config,
+          owners: config.owners.map((owner) => ({ ...owner, weight: 1n })),
+        },
+      },
+    },
+    {
+      name: 'weight unreachable by the selected signature count',
+      operation: { ...transactionPending, weight: 2 },
+    },
+    {
+      name: 'weight unreachable by the retained owner approvals',
+      operation: {
+        ...transactionPending,
+        config: MultisigConfig.from({
+          owners: [
+            { owner: owner_1, weight: 1 },
+            { owner: owner_2, weight: 2 },
+          ],
+          threshold: 2,
+        }),
+        weight: 2,
+      },
+    },
+    {
+      name: 'non-owner approval',
+      operation: { ...transactionPending, approvals: [approval_3] },
+    },
+    {
+      name: 'zero account',
+      operation: {
+        ...transactionPending,
+        account: '0x0000000000000000000000000000000000000000',
+        hash: MultisigConfig.getSignPayload({
+          account: '0x0000000000000000000000000000000000000000',
+          payload: TxEnvelopeTempo.getSignPayload(
+            TxEnvelopeTempo.deserialize(transaction),
+          ),
+          version: 1n,
+        }),
+      },
+    },
+    {
+      name: 'non-hex transaction hash',
+      operation: {
+        ...transactionPending,
+        approvals: [approval_1, approval_2],
+        signatureCount: 2,
+        status: 'success',
+        transactionHash: `0x${'gg'.repeat(32)}`,
+        weight: 2,
+      },
+    },
+    {
+      name: 'non-hex submission ID',
+      operation: {
+        ...transactionPending,
+        approvals: [approval_1, approval_2],
+        expiresAt: 10,
+        signatureCount: 2,
+        status: 'submitting',
+        submissionId: `0x${'gg'.repeat(32)}`,
+        weight: 2,
+      },
+    },
+    {
+      name: 'odd-length transaction hash',
+      operation: {
+        ...transactionPending,
+        approvals: [approval_1, approval_2],
+        signatureCount: 2,
+        status: 'success',
+        transactionHash: `0x${'a'.repeat(63)}`,
+        weight: 2,
+      },
+    },
+    {
+      name: 'odd-length submission ID',
+      operation: {
+        ...transactionPending,
+        approvals: [approval_1, approval_2],
+        expiresAt: 10,
+        signatureCount: 2,
+        status: 'submitting',
+        submissionId: `0x${'b'.repeat(63)}`,
+        weight: 2,
+      },
+    },
+    {
+      name: 'keychain owner approval',
+      operation: {
+        ...transactionPending,
+        approvals: [
+          SignatureEnvelope.serialize({
+            inner: ownerSignature_1,
+            type: 'keychain',
+            userAddress: owner_1,
+          }),
+        ],
+      },
+    },
+    {
+      name: 'nested bootstrap owner approval',
+      operation: {
+        ...transactionPending,
+        approvals: [
+          SignatureEnvelope.serialize({
+            account,
+            init: config,
+            signatures: [ownerSignature_1],
+            type: 'multisig',
+          }),
+        ],
+      },
+    },
+    {
+      name: 'bootstrap with initialized version',
+      operation: { ...transactionPending, init: true },
+    },
+  ])('rejects $name', ({ operation }) => {
+    expect(() =>
+      MultisigOperation.from(operation as MultisigOperation.Operation),
+    ).toThrowError(MultisigOperation.InvalidOperationError)
+  })
+
+  test('rejects noncanonical RPC quantities', () => {
+    expect(() =>
+      MultisigOperation.fromRpc({
+        ...MultisigOperation.toRpc(transactionPending),
+        configVersion: '0x01',
+      }),
+    ).toThrowError(
+      'Invalid multisig operation: configVersion must use canonical quantity encoding.',
+    )
+  })
+
+  test('rejects key authorization signatures absent from retained approvals', () => {
+    const authorization = KeyAuthorization.deserialize(keyAuthorization)
+    const operation = {
+      ...keyAuthorizationPending,
+      approvals: [approval_1, approval_2],
+      keyAuthorization: KeyAuthorization.serialize(
+        KeyAuthorization.from(authorization, {
+          signature: {
+            account,
+            signatures: [
+              SignatureEnvelope.deserialize(approval_1),
+              SignatureEnvelope.deserialize(approval_3),
+            ],
+            type: 'multisig',
+          },
+        }),
+      ),
+      signatureCount: 2,
+      status: 'success',
+      weight: 2,
+    } as const
+
+    expect(() => MultisigOperation.from(operation)).toThrowError(
+      'Invalid multisig operation: key authorization signature is not a retained approval.',
+    )
+  })
+
+  test('rejects unordered key authorization approvals', () => {
+    const authorization = KeyAuthorization.deserialize(keyAuthorization)
+    const signatures = [
+      ...SignatureEnvelope.sortMultisigApprovals({
+        account,
+        payload: KeyAuthorization.getSignPayload(authorization),
+        signatures: [
+          SignatureEnvelope.deserialize(approval_1),
+          SignatureEnvelope.deserialize(approval_2),
+        ],
+        version: 1n,
+      }),
+    ].reverse()
+    const operation = {
+      ...keyAuthorizationPending,
+      approvals: [approval_1, approval_2],
+      keyAuthorization: KeyAuthorization.serialize(
+        KeyAuthorization.from(authorization, {
+          signature: { account, signatures, type: 'multisig' },
+        }),
+      ),
+      signatureCount: 2,
+      status: 'success',
+      weight: 2,
+    } as const
+
+    expect(() => MultisigOperation.from(operation)).toThrowError(
+      'Invalid multisig operation: key authorization approvals are not canonically ordered.',
+    )
+  })
+
+  test('rejects duplicate key authorization approvals', () => {
+    const authorization = KeyAuthorization.deserialize(keyAuthorization)
+    const operation = {
+      ...keyAuthorizationPending,
+      approvals: [approval_1, approval_1],
+      keyAuthorization: KeyAuthorization.serialize(
+        KeyAuthorization.from(authorization, {
+          signature: {
+            account,
+            signatures: [
+              SignatureEnvelope.deserialize(approval_1),
+              SignatureEnvelope.deserialize(approval_1),
+            ],
+            type: 'multisig',
+          },
+        }),
+      ),
+      signatureCount: 2,
+      status: 'success',
+      weight: 2,
+    } as const
+
+    expect(() => MultisigOperation.from(operation)).toThrowError(
+      'Invalid multisig operation: key authorization contains duplicate owner approvals.',
+    )
+  })
+
+  test('rejects reordered nested key authorization approvals', () => {
+    const authorization = KeyAuthorization.deserialize(keyAuthorization)
+    const childSignatures = SignatureEnvelope.sortMultisigApprovals({
+      account: owner_1,
+      payload: keyAuthorizationHash,
+      signatures: [
+        SignatureEnvelope.deserialize(approval_1),
+        SignatureEnvelope.deserialize(approval_2),
+      ],
+      version: 1n,
+    })
+    const retainedNested = SignatureEnvelope.from({
+      account: owner_1,
+      signatures: childSignatures,
+      type: 'multisig',
+    })
+    const selectedNested = SignatureEnvelope.from({
+      account: owner_1,
+      signatures: [...childSignatures].reverse(),
+      type: 'multisig',
+    })
+    const selected = SignatureEnvelope.sortMultisigApprovals({
+      account,
+      payload: KeyAuthorization.getSignPayload(authorization),
+      signatures: [selectedNested, SignatureEnvelope.deserialize(approval_2)],
+      version: 1n,
+    })
+    const operation = {
+      ...keyAuthorizationPending,
+      approvals: [SignatureEnvelope.serialize(retainedNested), approval_2],
+      keyAuthorization: KeyAuthorization.serialize(
+        KeyAuthorization.from(authorization, {
+          signature: { account, signatures: selected, type: 'multisig' },
+        }),
+      ),
+      signatureCount: 2,
+      status: 'success',
+      weight: 2,
+    } as const
+
+    expect(() => MultisigOperation.from(operation)).toThrowError(
+      'Invalid multisig operation: key authorization signature is not a retained approval.',
+    )
+  })
+
+  test('accepts case-insensitive bootstrap configs', () => {
+    const config = MultisigConfig.from({
+      owners: [
+        {
+          owner: Address.checksum(owner_1),
+          weight: 1,
+        },
+        {
+          owner: Address.checksum(owner_2),
+          weight: 1,
+        },
+      ],
+      salt: `0x${'AB'.repeat(32)}`,
+      threshold: 2,
+    })
+    const account = MultisigConfig.getAddress(config)
+    const authorization = KeyAuthorization.from({
+      account,
+      address: '0x3333333333333333333333333333333333333333',
+      chainId: 4217n,
+      expiry: 1_800_000_000,
+      isAdmin: false,
+      type: 'secp256k1',
+    })
+    const signatures = SignatureEnvelope.sortMultisigApprovals({
+      account,
+      payload: KeyAuthorization.getSignPayload(authorization),
+      signatures: [
+        SignatureEnvelope.deserialize(approval_1),
+        SignatureEnvelope.deserialize(approval_2),
+      ],
+      version: 0n,
+    })
+    const approvals = signatures.map((signature) =>
+      SignatureEnvelope.serialize(signature),
+    )
+
+    const operation = MultisigOperation.from({
+      account,
+      approvals,
+      config,
+      configVersion: 0n,
+      createdAt: 1,
+      hash: MultisigConfig.getSignPayload({
+        account,
+        payload: KeyAuthorization.getSignPayload(authorization),
+        version: 0n,
+      }),
+      init: true,
+      keyAuthorization: KeyAuthorization.serialize(
+        KeyAuthorization.from(authorization, {
+          signature: {
+            account,
+            init: config,
+            signatures,
+            type: 'multisig',
+          },
+        }),
+      ),
+      signatureCount: 2,
+      status: 'success',
+      threshold: 2,
+      type: 'keyAuthorization',
+      updatedAt: 2,
+      weight: 2,
+    })
+
+    expect(operation.config).toStrictEqual(config)
+  })
+})

--- a/src/tempo/MultisigOperation.ts
+++ b/src/tempo/MultisigOperation.ts
@@ -1,0 +1,726 @@
+import * as Address from '../core/Address.js'
+import * as Errors from '../core/Errors.js'
+import * as Hash from '../core/Hash.js'
+import * as Hex from '../core/Hex.js'
+import * as KeyAuthorization_ from './KeyAuthorization.js'
+import * as MultisigConfig from './MultisigConfig.js'
+import * as SignatureEnvelope from './SignatureEnvelope.js'
+import * as TxEnvelopeTempo from './TxEnvelopeTempo.js'
+
+/** Fields shared by every multisig operation. */
+export type Base<quantity = bigint> = {
+  /** Root multisig account. */
+  account: Address.Address
+  /** Every retained serialized owner approval. */
+  approvals: readonly Hex.Hex[]
+  /** Root configuration used to verify approvals. */
+  config: MultisigConfig.Config
+  /** Root configuration version. */
+  configVersion: quantity
+  /** Unix creation time in milliseconds. */
+  createdAt: number
+  /** Deterministic multisig operation hash. */
+  hash: Hex.Hex
+  /** Whether the operation initializes the root multisig account. */
+  init: boolean
+  /** Number of approvals selected for quorum evaluation. */
+  signatureCount: number
+  /** Required root owner weight. */
+  threshold: number
+  /** Unix time of the last update in milliseconds. */
+  updatedAt: number
+  /** Root owner weight reached by the selected approvals. */
+  weight: number
+}
+
+/** Multisig transaction approval operation. */
+export type TransactionOperation<quantity = bigint> = Base<quantity> & {
+  /** Time when another relay may reclaim the submission lease. */
+  expiresAt?: number | undefined
+  /** Current operation state. */
+  status: 'pending' | 'submitting' | 'success'
+  /** Fencing token owned by the current submitter. */
+  submissionId?: Hex.Hex | undefined
+  /** Canonical serialized Tempo envelope without its outer sender signature. */
+  transaction: Hex.Hex
+  /** Hash returned after the downstream submitter accepts the transaction. */
+  transactionHash?: Hex.Hex | undefined
+  /** Operation kind. */
+  type: 'transaction'
+}
+
+/** Multisig key authorization approval operation. */
+export type KeyAuthorizationOperation<quantity = bigint> = Base<quantity> & {
+  /** Canonical serialized key authorization. */
+  keyAuthorization: Hex.Hex
+  /** Current operation state. */
+  status: 'pending' | 'success'
+  /** Operation kind. */
+  type: 'keyAuthorization'
+}
+
+/** Transaction or key authorization multisig operation. */
+export type Operation<quantity = bigint> =
+  | TransactionOperation<quantity>
+  | KeyAuthorizationOperation<quantity>
+
+/** JSON-RPC multisig transaction operation. */
+export type TransactionRpc = TransactionOperation<Hex.Hex>
+
+/** JSON-RPC multisig key authorization operation. */
+export type KeyAuthorizationRpc = KeyAuthorizationOperation<Hex.Hex>
+
+/** JSON-RPC multisig operation. */
+export type Rpc = Operation<Hex.Hex>
+
+/** Maximum supported multisig configuration version. */
+const maxConfigVersion = 2n ** 64n - 1n
+
+/**
+ * Validates and normalizes a multisig operation.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigOperation } from 'ox/tempo'
+ *
+ * const operation = MultisigOperation.from(value)
+ * ```
+ *
+ * @param operation - Multisig operation.
+ * @returns The validated operation.
+ */
+export function from<const operation extends Operation>(
+  operation: operation,
+): from.ReturnValue<operation> {
+  try {
+    const config = MultisigConfig.from(operation.config)
+    if (
+      typeof config.threshold !== 'number' ||
+      config.owners.some((owner) => typeof owner.weight !== 'number')
+    )
+      throw new InvalidOperationError({
+        reason: 'config threshold and owner weights must be numbers',
+      })
+    assertBase(operation, config)
+    if (operation.type === 'transaction') assertTransaction(operation)
+    else if (operation.type === 'keyAuthorization')
+      assertKeyAuthorization(operation, config)
+    else throw new InvalidOperationError({ reason: 'unknown operation type' })
+    return { ...operation, config } as never
+  } catch (cause) {
+    if (cause instanceof InvalidOperationError) throw cause
+    throw new InvalidOperationError({ cause })
+  }
+}
+
+export declare namespace from {
+  /** Return type for `from`. */
+  export type ReturnValue<operation extends Operation> =
+    operation extends TransactionOperation
+      ? TransactionOperation
+      : KeyAuthorizationOperation
+
+  /** Error type for `from`. */
+  export type ErrorType = InvalidOperationError | Errors.GlobalErrorType
+}
+
+/**
+ * Converts a JSON-RPC multisig operation to its domain representation.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigOperation } from 'ox/tempo'
+ *
+ * const operation = MultisigOperation.fromRpc(value)
+ * ```
+ *
+ * @param operation - JSON-RPC multisig operation.
+ * @returns The validated operation.
+ */
+export function fromRpc<const operation extends Rpc>(
+  operation: operation,
+): fromRpc.ReturnValue<operation> {
+  try {
+    if (
+      typeof operation.configVersion !== 'string' ||
+      !Hex.validate(operation.configVersion)
+    )
+      throw new InvalidOperationError({
+        reason: 'configVersion must be a hexadecimal quantity',
+      })
+    const configVersion = Hex.toBigInt(operation.configVersion)
+    if (Hex.fromNumber(configVersion) !== operation.configVersion)
+      throw new InvalidOperationError({
+        reason: 'configVersion must use canonical quantity encoding',
+      })
+    return from({ ...operation, configVersion } as Operation) as never
+  } catch (cause) {
+    if (cause instanceof InvalidOperationError) throw cause
+    throw new InvalidOperationError({ cause })
+  }
+}
+
+export declare namespace fromRpc {
+  /** Return type for `fromRpc`. */
+  export type ReturnValue<operation extends Rpc> =
+    operation extends TransactionRpc
+      ? TransactionOperation
+      : KeyAuthorizationOperation
+
+  /** Error type for `fromRpc`. */
+  export type ErrorType = InvalidOperationError | Errors.GlobalErrorType
+}
+
+/**
+ * Converts a multisig operation to its JSON-RPC representation.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigOperation } from 'ox/tempo'
+ *
+ * const operationRpc = MultisigOperation.toRpc(operation)
+ * ```
+ *
+ * @param operation - Multisig operation.
+ * @returns The JSON-RPC operation.
+ */
+export function toRpc<const operation extends Operation>(
+  operation: operation,
+): toRpc.ReturnValue<operation> {
+  const value = from(operation)
+  return {
+    ...value,
+    configVersion: Hex.fromNumber(value.configVersion),
+  } as never
+}
+
+export declare namespace toRpc {
+  /** Return type for `toRpc`. */
+  export type ReturnValue<operation extends Operation> =
+    operation extends TransactionOperation
+      ? TransactionRpc
+      : KeyAuthorizationRpc
+
+  /** Error type for `toRpc`. */
+  export type ErrorType = from.ErrorType | Hex.fromNumber.ErrorType
+}
+
+/**
+ * Validates fields shared by every operation.
+ *
+ * @internal
+ */
+function assertBase(operation: Operation, config: MultisigConfig.Config): void {
+  if (!Address.validate(operation.account))
+    throw new InvalidOperationError({ reason: 'account is invalid' })
+  if (Hex.toBigInt(operation.account) === 0n)
+    throw new InvalidOperationError({ reason: 'account cannot be zero' })
+  if (!Hash.validate(operation.hash))
+    throw new InvalidOperationError({ reason: 'hash is invalid' })
+  if (typeof operation.init !== 'boolean')
+    throw new InvalidOperationError({ reason: 'init must be a boolean' })
+  if (
+    typeof operation.configVersion !== 'bigint' ||
+    operation.configVersion < 0n ||
+    operation.configVersion > maxConfigVersion
+  )
+    throw new InvalidOperationError({
+      reason: 'configVersion must be an unsigned 64-bit integer',
+    })
+  assertInteger(operation.createdAt, 'createdAt')
+  assertInteger(operation.updatedAt, 'updatedAt')
+  if (operation.updatedAt < operation.createdAt)
+    throw new InvalidOperationError({
+      reason: 'updatedAt cannot precede createdAt',
+    })
+  assertInteger(operation.signatureCount, 'signatureCount')
+  assertInteger(operation.threshold, 'threshold')
+  assertInteger(operation.weight, 'weight')
+  if (operation.threshold !== Number(config.threshold))
+    throw new InvalidOperationError({
+      reason: 'threshold must equal config.threshold',
+    })
+  if (operation.weight > 0xff)
+    throw new InvalidOperationError({ reason: 'weight exceeds u8 max' })
+  if (operation.signatureCount > MultisigConfig.maxSignatures)
+    throw new InvalidOperationError({ reason: 'too many selected signatures' })
+  if (!Array.isArray(operation.approvals))
+    throw new InvalidOperationError({ reason: 'approvals must be an array' })
+  if (operation.approvals.length > config.owners.length)
+    throw new InvalidOperationError({ reason: 'too many retained approvals' })
+  if (operation.signatureCount > operation.approvals.length)
+    throw new InvalidOperationError({
+      reason: 'signatureCount exceeds retained approvals',
+    })
+  if ((operation.signatureCount === 0) !== (operation.weight === 0))
+    throw new InvalidOperationError({
+      reason: 'signatureCount and weight must both be zero or nonzero',
+    })
+  const owners = new Map(
+    config.owners.map((owner) => [
+      owner.owner.toLowerCase(),
+      Number(owner.weight),
+    ]),
+  )
+  const approvalWeights: number[] = []
+  const seen = new Set<string>()
+  for (const approval of operation.approvals) {
+    if (
+      typeof approval !== 'string' ||
+      !Hex.validate(approval, { strict: true })
+    )
+      throw new InvalidOperationError({ reason: 'approval is invalid' })
+    const signature = assertApproval(
+      operation.account,
+      approval as SignatureEnvelope.Serialized,
+    )
+    const address = SignatureEnvelope.extractAddress({
+      payload: operation.hash,
+      signature,
+    })
+    const key = address.toLowerCase()
+    const weight = owners.get(key)
+    if (weight === undefined)
+      throw new InvalidOperationError({
+        reason: 'approval is from a non-owner',
+      })
+    if (seen.has(key))
+      throw new InvalidOperationError({
+        reason:
+          operation.type === 'keyAuthorization'
+            ? 'key authorization contains duplicate owner approvals'
+            : 'duplicate owner approval',
+      })
+    seen.add(key)
+    approvalWeights.push(weight)
+  }
+  if (
+    !isWeightReachable(
+      approvalWeights,
+      operation.signatureCount,
+      operation.weight,
+    )
+  )
+    throw new InvalidOperationError({
+      reason:
+        'weight is not reachable by signatureCount retained owner approvals',
+    })
+  if (operation.init) {
+    if (operation.configVersion !== 0n)
+      throw new InvalidOperationError({
+        reason: 'bootstrap operations must use config version zero',
+      })
+    if (
+      MultisigConfig.getAddress(config).toLowerCase() !==
+      operation.account.toLowerCase()
+    )
+      throw new InvalidOperationError({
+        reason: 'bootstrap config does not derive the operation account',
+      })
+  }
+}
+
+/**
+ * Validates a transaction operation and its state-specific fields.
+ *
+ * @internal
+ */
+function assertTransaction(operation: TransactionOperation): void {
+  if (
+    'keyAuthorization' in operation &&
+    operation.keyAuthorization !== undefined
+  )
+    throw new InvalidOperationError({
+      reason: 'transaction operations cannot contain keyAuthorization',
+    })
+  const expiresAt = operation.expiresAt
+  const submissionId = operation.submissionId
+  const transactionHash = operation.transactionHash
+  if (operation.status === 'pending') {
+    if (
+      expiresAt !== undefined ||
+      submissionId !== undefined ||
+      transactionHash !== undefined
+    )
+      throw new InvalidOperationError({
+        reason: 'pending transactions cannot contain submission fields',
+      })
+  } else if (operation.status === 'submitting') {
+    assertInteger(expiresAt, 'expiresAt')
+    if (!Hash.validate(submissionId ?? ''))
+      throw new InvalidOperationError({ reason: 'submissionId is invalid' })
+    if (submissionId!.toLowerCase() === operation.hash.toLowerCase())
+      throw new InvalidOperationError({
+        reason: 'submissionId must differ from the operation hash',
+      })
+    if (transactionHash !== undefined)
+      throw new InvalidOperationError({
+        reason: 'submitting transactions cannot contain transactionHash',
+      })
+  } else if (operation.status === 'success') {
+    if (!Hash.validate(transactionHash ?? ''))
+      throw new InvalidOperationError({ reason: 'transactionHash is invalid' })
+    if (expiresAt !== undefined || submissionId !== undefined)
+      throw new InvalidOperationError({
+        reason: 'successful transactions cannot contain submission fields',
+      })
+  } else
+    throw new InvalidOperationError({ reason: 'invalid transaction status' })
+  if (
+    operation.status !== 'pending' &&
+    (operation.weight < operation.threshold || operation.signatureCount === 0)
+  )
+    throw new InvalidOperationError({
+      reason: 'submitted transactions must have quorum',
+    })
+
+  if (typeof operation.transaction !== 'string')
+    throw new InvalidOperationError({ reason: 'transaction is invalid' })
+  const feePayer = operation.transaction.startsWith(
+    TxEnvelopeTempo.feePayerMagic,
+  )
+  const serialized = feePayer
+    ? Hex.concat(
+        TxEnvelopeTempo.serializedType,
+        Hex.slice(operation.transaction, 1),
+      )
+    : operation.transaction
+  const transaction = TxEnvelopeTempo.deserialize(
+    serialized as TxEnvelopeTempo.Serialized,
+  )
+  if (transaction.signature)
+    throw new InvalidOperationError({
+      reason: 'transaction must not contain an outer sender signature',
+    })
+  if (
+    transaction.from &&
+    transaction.from.toLowerCase() !== operation.account.toLowerCase()
+  )
+    throw new InvalidOperationError({
+      reason: 'transaction sender does not match the operation account',
+    })
+  assertOperationHash(operation, TxEnvelopeTempo.getSignPayload(transaction))
+  const normalized = TxEnvelopeTempo.serialize(
+    transaction,
+    feePayer
+      ? transaction.from
+        ? { format: 'feePayer', sender: transaction.from }
+        : { format: 'feePayer' }
+      : {},
+  )
+  if (normalized.toLowerCase() !== operation.transaction.toLowerCase())
+    throw new InvalidOperationError({
+      reason: 'transaction is not canonically serialized',
+    })
+}
+
+/**
+ * Validates a key authorization operation and its serialized payload.
+ *
+ * @internal
+ */
+function assertKeyAuthorization(
+  operation: KeyAuthorizationOperation,
+  config: MultisigConfig.Config,
+): void {
+  const transactionFields = operation as KeyAuthorizationOperation & {
+    expiresAt?: unknown
+    submissionId?: unknown
+    transaction?: unknown
+    transactionHash?: unknown
+  }
+  if (
+    transactionFields.expiresAt !== undefined ||
+    transactionFields.submissionId !== undefined ||
+    transactionFields.transaction !== undefined ||
+    transactionFields.transactionHash !== undefined
+  )
+    throw new InvalidOperationError({
+      reason: 'key authorization operations cannot contain transaction fields',
+    })
+  if (operation.status !== 'pending' && operation.status !== 'success')
+    throw new InvalidOperationError({
+      reason: 'invalid key authorization status',
+    })
+  if (
+    operation.status === 'success' &&
+    (operation.weight < operation.threshold || operation.signatureCount === 0)
+  )
+    throw new InvalidOperationError({
+      reason: 'successful key authorizations must have quorum',
+    })
+  if (operation.status === 'pending' && operation.weight >= operation.threshold)
+    throw new InvalidOperationError({
+      reason: 'pending key authorizations cannot have quorum',
+    })
+  if (typeof operation.keyAuthorization !== 'string')
+    throw new InvalidOperationError({ reason: 'keyAuthorization is invalid' })
+  const authorization = KeyAuthorization_.deserialize(
+    operation.keyAuthorization,
+  )
+  if (
+    !authorization.account ||
+    authorization.account.toLowerCase() !== operation.account.toLowerCase()
+  )
+    throw new InvalidOperationError({
+      reason: 'key authorization account does not match the operation account',
+    })
+  const signature = authorization.signature
+  if (operation.status === 'pending' && signature)
+    throw new InvalidOperationError({
+      reason: 'pending key authorizations must be unsigned',
+    })
+  if (operation.status === 'success') {
+    if (signature?.type !== 'multisig')
+      throw new InvalidOperationError({
+        reason: 'successful key authorizations require a multisig signature',
+      })
+    if (signature.account.toLowerCase() !== operation.account.toLowerCase())
+      throw new InvalidOperationError({
+        reason: 'key authorization signature account does not match',
+      })
+    if (signature.signatures.length !== operation.signatureCount)
+      throw new InvalidOperationError({
+        reason: 'key authorization signatureCount does not match its signature',
+      })
+    assertSelectedApprovals(operation, signature.signatures, authorization)
+    if (!!signature.init !== operation.init)
+      throw new InvalidOperationError({
+        reason: 'key authorization bootstrap state does not match',
+      })
+    if (signature.init && !sameConfig(signature.init, config))
+      throw new InvalidOperationError({
+        reason: 'key authorization bootstrap config does not match',
+      })
+  }
+  assertOperationHash(
+    operation,
+    KeyAuthorization_.getSignPayload(authorization),
+  )
+  if (
+    KeyAuthorization_.serialize(authorization).toLowerCase() !==
+    operation.keyAuthorization.toLowerCase()
+  )
+    throw new InvalidOperationError({
+      reason: 'keyAuthorization is not canonically serialized',
+    })
+}
+
+/**
+ * Validates a retained signature in the root owner's approval context.
+ *
+ * @internal
+ */
+function assertApproval(
+  account: Address.Address,
+  serialized: SignatureEnvelope.Serialized,
+): SignatureEnvelope.SignatureEnvelope {
+  const approval = SignatureEnvelope.deserialize(serialized)
+  SignatureEnvelope.assert({
+    account,
+    signatures: [approval],
+    type: 'multisig',
+  })
+  if (
+    SignatureEnvelope.serialize(approval).toLowerCase() !==
+    serialized.toLowerCase()
+  )
+    throw new InvalidOperationError({ reason: 'approval is not canonical' })
+  return approval
+}
+
+/**
+ * Checks that a successful key authorization uses retained approvals in canonical order.
+ *
+ * @internal
+ */
+function assertSelectedApprovals(
+  operation: KeyAuthorizationOperation,
+  selected: readonly SignatureEnvelope.SignatureEnvelope[],
+  authorization: KeyAuthorization_.KeyAuthorization,
+): void {
+  const retained = operation.approvals.map((approval) =>
+    SignatureEnvelope.deserialize(approval),
+  )
+  for (const approval of selected) {
+    const index = retained.findIndex((candidate) =>
+      includesApproval(candidate, approval),
+    )
+    if (index === -1)
+      throw new InvalidOperationError({
+        reason: 'key authorization signature is not a retained approval',
+      })
+    retained.splice(index, 1)
+  }
+
+  const digest = MultisigConfig.getSignPayload({
+    account: operation.account,
+    payload: KeyAuthorization_.getSignPayload(authorization),
+    version: operation.configVersion,
+  })
+  const addresses = selected.map((signature) =>
+    SignatureEnvelope.extractAddress({ payload: digest, signature }),
+  )
+  for (let index = 1; index < addresses.length; index++) {
+    const previous = Hex.toBigInt(addresses[index - 1]!)
+    const current = Hex.toBigInt(addresses[index]!)
+    if (previous === current)
+      throw new InvalidOperationError({
+        reason: 'key authorization contains duplicate owner approvals',
+      })
+    if (previous > current)
+      throw new InvalidOperationError({
+        reason: 'key authorization approvals are not canonically ordered',
+      })
+  }
+}
+
+/**
+ * Checks whether a selected approval is contained in a retained approval tree.
+ *
+ * @internal
+ */
+function includesApproval(
+  retained: SignatureEnvelope.SignatureEnvelope,
+  selected: SignatureEnvelope.SignatureEnvelope,
+): boolean {
+  if (retained.type !== 'multisig' || selected.type !== 'multisig')
+    return (
+      SignatureEnvelope.serialize(retained).toLowerCase() ===
+      SignatureEnvelope.serialize(selected).toLowerCase()
+    )
+  if (retained.account.toLowerCase() !== selected.account.toLowerCase())
+    return false
+  // Nested versions are not serialized, so selected child approvals must preserve the validated retained order.
+  let index = 0
+  for (const approval of selected.signatures) {
+    while (
+      index < retained.signatures.length &&
+      !includesApproval(retained.signatures[index]!, approval)
+    )
+      index++
+    if (index === retained.signatures.length) return false
+    index++
+  }
+  return true
+}
+
+/**
+ * Checks whether exactly `signatureCount` retained owners can produce `weight`.
+ *
+ * @internal
+ */
+function isWeightReachable(
+  weights: readonly number[],
+  signatureCount: number,
+  weight: number,
+): boolean {
+  const reachable = Array.from(
+    { length: signatureCount + 1 },
+    () => new Set<number>(),
+  )
+  reachable[0]!.add(0)
+  for (const ownerWeight of weights)
+    for (let count = signatureCount; count > 0; count--)
+      for (const current of reachable[count - 1]!)
+        reachable[count]!.add(current + ownerWeight)
+  return reachable[signatureCount]!.has(weight)
+}
+
+/**
+ * Validates the deterministic operation hash.
+ *
+ * @internal
+ */
+function assertOperationHash(operation: Operation, payload: Hex.Hex): void {
+  const hash = MultisigConfig.getSignPayload({
+    account: operation.account,
+    payload,
+    version: operation.configVersion,
+  })
+  if (hash.toLowerCase() !== operation.hash.toLowerCase())
+    throw new InvalidOperationError({
+      reason: 'hash does not match the operation payload',
+    })
+}
+
+/**
+ * Validates a nonnegative safe integer field.
+ *
+ * @internal
+ */
+function assertInteger(value: unknown, field: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0)
+    throw new InvalidOperationError({
+      reason: `${field} must be a nonnegative safe integer`,
+    })
+}
+
+/**
+ * Compares normalized multisig configurations.
+ *
+ * @internal
+ */
+function sameConfig(
+  a: MultisigConfig.Config,
+  b: MultisigConfig.Config,
+): boolean {
+  const configA = MultisigConfig.from(a)
+  const configB = MultisigConfig.from(b)
+  return (
+    Hex.isEqual(
+      configA.salt ?? MultisigConfig.zeroSalt,
+      configB.salt ?? MultisigConfig.zeroSalt,
+    ) &&
+    configA.threshold === configB.threshold &&
+    configA.owners.length === configB.owners.length &&
+    configA.owners.every((owner, index) => {
+      const other = configB.owners[index]!
+      return (
+        Address.isEqual(owner.owner, other.owner) &&
+        owner.weight === other.weight
+      )
+    })
+  )
+}
+
+/** Thrown when a multisig operation is malformed or internally inconsistent. */
+export class InvalidOperationError extends Errors.BaseError<Error | undefined> {
+  override readonly name = 'MultisigOperation.InvalidOperationError'
+
+  /**
+   * Creates an invalid multisig operation error.
+   *
+   * @example
+   * ```ts twoslash
+   * import { MultisigOperation } from 'ox/tempo'
+   *
+   * throw new MultisigOperation.InvalidOperationError({
+   *   reason: 'hash does not match the operation payload',
+   * })
+   * ```
+   *
+   * @param options - Error options.
+   */
+  constructor(options: InvalidOperationError.Options = {}) {
+    super(
+      options.reason
+        ? `Invalid multisig operation: ${options.reason}.`
+        : 'Invalid multisig operation.',
+      { cause: options.cause as Error | undefined },
+    )
+  }
+}
+
+export declare namespace InvalidOperationError {
+  /** Error construction options. */
+  export type Options = {
+    /** Underlying error. */
+    cause?: unknown | undefined
+    /** Validation failure. */
+    reason?: string | undefined
+  }
+}

--- a/src/tempo/MultisigOperation.ts
+++ b/src/tempo/MultisigOperation.ts
@@ -699,7 +699,7 @@ export class InvalidOperationError extends Errors.BaseError<Error | undefined> {
    * import { MultisigOperation } from 'ox/tempo'
    *
    * throw new MultisigOperation.InvalidOperationError({
-   *   reason: 'hash does not match the operation payload',
+   *   reason: 'hash does not match the operation payload'
    * })
    * ```
    *

--- a/src/tempo/RpcSchemaTempo.test-d.ts
+++ b/src/tempo/RpcSchemaTempo.test-d.ts
@@ -1,0 +1,56 @@
+import type { Provider } from 'ox'
+import type {
+  KeyAuthorization,
+  MultisigOperation,
+  RpcSchemaTempo,
+} from 'ox/tempo'
+import { expectTypeOf, test } from 'vp/test'
+import type * as Hex from '../core/Hex.js'
+
+declare const provider: Provider.Provider<{ schema: RpcSchemaTempo.Multisig }>
+declare const hash: Hex.Hex
+declare const keyAuthorization: KeyAuthorization.Rpc
+declare const serializedTransaction: Hex.Hex
+declare const signature: Hex.Hex
+
+test('multisig provider methods', () => {
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveRawTransaction',
+      params: [serializedTransaction],
+    }),
+  ).resolves.toEqualTypeOf<Hex.Hex>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveRawTransactionSync',
+      params: [serializedTransaction],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.TransactionRpc>()
+
+  void provider.request({
+    method: 'multisig_approveRawTransactionSync',
+    params: [serializedTransaction, 30_000],
+  })
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ keyAuthorization }],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ hash, signature }],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_getOperation',
+      params: [hash],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.Rpc | null>()
+})

--- a/src/tempo/RpcSchemaTempo.ts
+++ b/src/tempo/RpcSchemaTempo.ts
@@ -4,6 +4,8 @@ import type * as Hex from '../core/Hex.js'
 import type * as Log from '../core/Log.js'
 import type * as RpcSchema from '../core/RpcSchema.js'
 import type * as StateOverrides from '../core/StateOverrides.js'
+import type * as KeyAuthorization from './KeyAuthorization.js'
+import type * as MultisigOperation from './MultisigOperation.js'
 import type * as TransactionRequest from './TransactionRequest.js'
 
 /**
@@ -53,3 +55,38 @@ export type Tempo = RpcSchema.From<{
     }
   }
 }>
+
+/** Union of all JSON-RPC methods for the `multisig_` namespace. */
+export type Multisig = RpcSchema.From<
+  | {
+      Request: {
+        method: 'multisig_approveRawTransaction'
+        params: [serializedTransaction: Hex.Hex]
+      }
+      ReturnType: Hex.Hex
+    }
+  | {
+      Request: {
+        method: 'multisig_approveRawTransactionSync'
+        params: [serializedTransaction: Hex.Hex, timeout?: number]
+      }
+      ReturnType: MultisigOperation.TransactionRpc
+    }
+  | {
+      Request: {
+        method: 'multisig_approveKeyAuthorization'
+        params: [
+          | { keyAuthorization: KeyAuthorization.Rpc }
+          | { hash: Hex.Hex; signature: Hex.Hex },
+        ]
+      }
+      ReturnType: MultisigOperation.KeyAuthorizationRpc
+    }
+  | {
+      Request: {
+        method: 'multisig_getOperation'
+        params: [hash: Hex.Hex]
+      }
+      ReturnType: MultisigOperation.Rpc | null
+    }
+>

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -174,6 +174,15 @@ export * as KeyAuthorization from './KeyAuthorization.js'
  */
 export * as MultisigConfig from './MultisigConfig.js'
 /**
+ * Offchain multisig transaction and key authorization operation utilities.
+ *
+ * Validates operation state, serialized payloads, and deterministic operation
+ * hashes, and converts between domain and JSON-RPC representations.
+ *
+ * @category Reference
+ */
+export * as MultisigOperation from './MultisigOperation.js'
+/**
  * Utilities for constructing period durations (in seconds) for recurring spending limits.
  *
  * Periods define the reset interval for access key spending limits. A spending limit with a
@@ -251,7 +260,7 @@ export * as PoolId from './PoolId.js'
  */
 export * as ReceivePolicyReceipt from './ReceivePolicyReceipt.js'
 /**
- * Union of all JSON-RPC Methods for the `tempo_` namespace.
+ * JSON-RPC schemas for the `tempo_` and `multisig_` namespaces.
  *
  * @example
  * ```ts twoslash
@@ -260,7 +269,9 @@ export * as ReceivePolicyReceipt from './ReceivePolicyReceipt.js'
  * import { RpcSchemaTempo } from 'ox/tempo'
  *
  * const schema = RpcSchema.from<
- *   RpcSchema.Default | RpcSchemaTempo.Tempo
+ *   | RpcSchema.Default
+ *   | RpcSchemaTempo.Multisig
+ *   | RpcSchemaTempo.Tempo
  * >()
  *
  * const provider = Provider.from(window.ethereum!, { schema })

--- a/src/zod/tempo/MultisigOperation.ts
+++ b/src/zod/tempo/MultisigOperation.ts
@@ -1,0 +1,69 @@
+/* eslint-disable jsdoc-js/require-jsdoc, jsdoc-js/require-description, jsdoc-js/require-example */
+import * as core_MultisigOperation from '../../tempo/MultisigOperation.js'
+import * as z_Address from '../Address.js'
+import * as z_Hash from '../Hash.js'
+import * as z_Hex from '../Hex.js'
+import * as z_Uint from '../Uint.js'
+import * as z from 'zod/mini'
+import * as z_MultisigConfig from './MultisigConfig.js'
+
+function baseFields() {
+  return {
+    account: z_Address.Address,
+    approvals: z.readonly(z.array(z_Hex.Hex)),
+    config: z_MultisigConfig.Config,
+    configVersion: z_Uint.Uint64,
+    createdAt: z.number(),
+    hash: z_Hash.Hash,
+    init: z.boolean(),
+    signatureCount: z.number(),
+    threshold: z.number(),
+    updatedAt: z.number(),
+    weight: z.number(),
+  }
+}
+
+const valid = z.refine((value) => {
+  try {
+    core_MultisigOperation.from(value as never)
+    return true
+  } catch {
+    return false
+  }
+}, 'expected valid multisig operation')
+
+/** Fields shared by every multisig operation schema. */
+export const Base = z.object(baseFields())
+
+/** Multisig transaction approval operation schema. */
+export const TransactionOperation = z
+  .object({
+    ...baseFields(),
+    expiresAt: z.optional(z.number()),
+    status: z.union([
+      z.literal('pending'),
+      z.literal('submitting'),
+      z.literal('success'),
+    ]),
+    submissionId: z.optional(z_Hash.Hash),
+    transaction: z_Hex.Hex,
+    transactionHash: z.optional(z_Hash.Hash),
+    type: z.literal('transaction'),
+  })
+  .check(valid)
+
+/** Multisig key authorization approval operation schema. */
+export const KeyAuthorizationOperation = z
+  .object({
+    ...baseFields(),
+    keyAuthorization: z_Hex.Hex,
+    status: z.union([z.literal('pending'), z.literal('success')]),
+    type: z.literal('keyAuthorization'),
+  })
+  .check(valid)
+
+/** Transaction or key authorization multisig operation schema. */
+export const Operation = z.union([
+  TransactionOperation,
+  KeyAuthorizationOperation,
+])

--- a/src/zod/tempo/RpcSchemaTempo.ts
+++ b/src/zod/tempo/RpcSchemaTempo.ts
@@ -6,6 +6,8 @@ import * as z_Log from '../Log.js'
 import * as z_StateOverrides from '../StateOverrides.js'
 import { from } from '../internal/rpcSchemas/from.js'
 import * as z from 'zod/mini'
+import * as z_KeyAuthorization from './KeyAuthorization.js'
+import * as z_MultisigOperation from './MultisigOperation.js'
 import * as z_TransactionRequest from './TransactionRequest.js'
 
 const BlockNumberOrTagOrIdentifier = z.union([
@@ -85,3 +87,44 @@ export const tempo_simulateV1 = from({
 
 /** JSON-RPC method schemas for the `tempo_` namespace. */
 export const Tempo = { tempo_simulateV1 }
+
+/** Schema for the `multisig_approveRawTransaction` JSON-RPC method. */
+export const multisig_approveRawTransaction = from({
+  method: 'multisig_approveRawTransaction',
+  params: z.tuple([z_Hex.Hex]),
+  returns: z_Hex.Hex,
+})
+
+/** Schema for the `multisig_approveRawTransactionSync` JSON-RPC method. */
+export const multisig_approveRawTransactionSync = from({
+  method: 'multisig_approveRawTransactionSync',
+  params: z.tuple([z_Hex.Hex, z.optional(z.number())]),
+  returns: z_MultisigOperation.TransactionOperation,
+})
+
+/** Schema for the `multisig_approveKeyAuthorization` JSON-RPC method. */
+export const multisig_approveKeyAuthorization = from({
+  method: 'multisig_approveKeyAuthorization',
+  params: z.tuple([
+    z.union([
+      z.object({ keyAuthorization: z_KeyAuthorization.Rpc }),
+      z.object({ hash: z_Hex.Hex, signature: z_Hex.Hex }),
+    ]),
+  ]),
+  returns: z_MultisigOperation.KeyAuthorizationOperation,
+})
+
+/** Schema for the `multisig_getOperation` JSON-RPC method. */
+export const multisig_getOperation = from({
+  method: 'multisig_getOperation',
+  params: z.tuple([z_Hex.Hex]),
+  returns: z.nullable(z_MultisigOperation.Operation),
+})
+
+/** JSON-RPC method schemas for the `multisig_` namespace. */
+export const Multisig = {
+  multisig_approveKeyAuthorization,
+  multisig_approveRawTransaction,
+  multisig_approveRawTransactionSync,
+  multisig_getOperation,
+}

--- a/src/zod/tempo/_test/MultisigConfig.test.ts
+++ b/src/zod/tempo/_test/MultisigConfig.test.ts
@@ -21,8 +21,8 @@ describe('Config', () => {
     expect(
       z.safeDecode(z_MultisigConfig.Config, {
         ...config,
-        owners: [{ ...config.owners[0], weight: 9 }],
-        threshold: 9,
+        owners: [{ ...config.owners[0], weight: 255 }],
+        threshold: 256,
       }).success,
     ).toMatchInlineSnapshot(`false`)
   })

--- a/src/zod/tempo/_test/MultisigOperation.test-d.ts
+++ b/src/zod/tempo/_test/MultisigOperation.test-d.ts
@@ -1,0 +1,27 @@
+import type * as core_MultisigOperation from '../../../tempo/MultisigOperation.js'
+import type * as z from 'zod/mini'
+import { expectTypeOf, test } from 'vp/test'
+import * as z_MultisigOperation from '../MultisigOperation.js'
+
+test('operation schemas decode RPC operations', () => {
+  expectTypeOf<core_MultisigOperation.TransactionRpc>().toMatchTypeOf<
+    z.input<typeof z_MultisigOperation.TransactionOperation>
+  >()
+  expectTypeOf<
+    z.output<typeof z_MultisigOperation.TransactionOperation>
+  >().toMatchTypeOf<core_MultisigOperation.TransactionOperation>()
+
+  expectTypeOf<core_MultisigOperation.KeyAuthorizationRpc>().toMatchTypeOf<
+    z.input<typeof z_MultisigOperation.KeyAuthorizationOperation>
+  >()
+  expectTypeOf<
+    z.output<typeof z_MultisigOperation.KeyAuthorizationOperation>
+  >().toMatchTypeOf<core_MultisigOperation.KeyAuthorizationOperation>()
+
+  expectTypeOf<core_MultisigOperation.Rpc>().toMatchTypeOf<
+    z.input<typeof z_MultisigOperation.Operation>
+  >()
+  expectTypeOf<
+    z.output<typeof z_MultisigOperation.Operation>
+  >().toMatchTypeOf<core_MultisigOperation.Operation>()
+})

--- a/src/zod/tempo/_test/MultisigOperation.test.ts
+++ b/src/zod/tempo/_test/MultisigOperation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vp/test'
+import * as core_MultisigOperation from '../../../tempo/MultisigOperation.js'
+import * as z_MultisigOperation from '../MultisigOperation.js'
+import * as z from 'zod/mini'
+
+const rpc = {
+  account: '0xf81b7763d3a6876195d780865bd783dbd97dd36e',
+  approvals: [
+    '0x01000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200',
+  ],
+  config: {
+    owners: [
+      {
+        owner: '0x07e1ed8ea0e9601e5546b0a03aed683df3601407',
+        weight: 1,
+      },
+      {
+        owner: '0x288f0cd85005f34168f731a468aef268c2f9456f',
+        weight: 1,
+      },
+    ],
+    salt: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    threshold: 2,
+  },
+  configVersion: '0x1',
+  createdAt: 1,
+  hash: '0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02',
+  init: false,
+  signatureCount: 1,
+  status: 'pending',
+  threshold: 2,
+  transaction:
+    '0x76e9821079808080dad99407e1ed8ea0e9601e5546b0a03aed683df360140780821234c0808080808080c0',
+  type: 'transaction',
+  updatedAt: 2,
+  weight: 1,
+} as const
+
+describe('TransactionOperation', () => {
+  test('decodes an RPC operation', () => {
+    expect(z.decode(z_MultisigOperation.TransactionOperation, rpc)).toEqual(
+      core_MultisigOperation.fromRpc(rpc),
+    )
+  })
+
+  test('round-trips via encode', () => {
+    const operation = z.decode(z_MultisigOperation.TransactionOperation, rpc)
+    expect(
+      z.encode(z_MultisigOperation.TransactionOperation, operation),
+    ).toEqual(core_MultisigOperation.toRpc(operation))
+  })
+
+  test('rejects internally inconsistent operations', () => {
+    expect(
+      z.safeDecode(z_MultisigOperation.TransactionOperation, {
+        ...rpc,
+        weight: 2,
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('Operation', () => {
+  test('accepts transaction operations', () => {
+    expect(z.safeDecode(z_MultisigOperation.Operation, rpc).success).toBe(true)
+  })
+})

--- a/src/zod/tempo/_test/RpcSchemaTempo.test-d.ts
+++ b/src/zod/tempo/_test/RpcSchemaTempo.test-d.ts
@@ -1,3 +1,4 @@
+import type * as core_MultisigOperation from '../../../tempo/MultisigOperation.js'
 import type * as z from 'zod/mini'
 import { expectTypeOf, test } from 'vp/test'
 import * as z_RpcSchemaTempo from '../RpcSchemaTempo.js'
@@ -19,4 +20,34 @@ test('Tempo namespace exposes tempo_simulateV1', () => {
   expectTypeOf<typeof z_RpcSchemaTempo.Tempo.tempo_simulateV1>().toEqualTypeOf<
     typeof z_RpcSchemaTempo.tempo_simulateV1
   >()
+})
+
+test('multisig methods have the expected method names', () => {
+  expectTypeOf<
+    typeof z_RpcSchemaTempo.multisig_approveRawTransaction.method
+  >().toEqualTypeOf<'multisig_approveRawTransaction'>()
+  expectTypeOf<
+    typeof z_RpcSchemaTempo.multisig_approveRawTransactionSync.method
+  >().toEqualTypeOf<'multisig_approveRawTransactionSync'>()
+  expectTypeOf<
+    typeof z_RpcSchemaTempo.multisig_approveKeyAuthorization.method
+  >().toEqualTypeOf<'multisig_approveKeyAuthorization'>()
+  expectTypeOf<
+    typeof z_RpcSchemaTempo.multisig_getOperation.method
+  >().toEqualTypeOf<'multisig_getOperation'>()
+})
+
+test('multisig return schemas decode RPC operations', () => {
+  expectTypeOf<
+    z.output<typeof z_RpcSchemaTempo.multisig_approveRawTransactionSync.returns>
+  >().toMatchTypeOf<core_MultisigOperation.TransactionOperation>()
+  expectTypeOf<
+    z.output<typeof z_RpcSchemaTempo.multisig_getOperation.returns>
+  >().toMatchTypeOf<core_MultisigOperation.Operation | null>()
+})
+
+test('Multisig namespace exposes multisig methods', () => {
+  expectTypeOf<
+    typeof z_RpcSchemaTempo.Multisig.multisig_getOperation
+  >().toEqualTypeOf<typeof z_RpcSchemaTempo.multisig_getOperation>()
 })

--- a/src/zod/tempo/_test/RpcSchemaTempo.test.ts
+++ b/src/zod/tempo/_test/RpcSchemaTempo.test.ts
@@ -54,3 +54,44 @@ describe('tempo_simulateV1', () => {
     ).toBe(true)
   })
 })
+
+describe('multisig methods', () => {
+  test('decodes raw transaction params', () => {
+    expect(
+      z_RpcSchema.decodeParams(
+        z_RpcSchemaTempo.Multisig,
+        'multisig_approveRawTransactionSync',
+        ['0x76', 30_000],
+      ),
+    ).toEqual(['0x76', 30_000])
+  })
+
+  test('decodes key authorization approval params', () => {
+    expect(
+      z_RpcSchema.decodeParams(
+        z_RpcSchemaTempo.Multisig,
+        'multisig_approveKeyAuthorization',
+        [{ hash: '0x01', signature: '0x02' }],
+      ),
+    ).toEqual([{ hash: '0x01', signature: '0x02' }])
+  })
+
+  test('accepts a missing operation result', () => {
+    expect(
+      z_RpcSchema.decodeReturns(
+        z_RpcSchemaTempo.Multisig,
+        'multisig_getOperation',
+        null,
+      ),
+    ).toBeNull()
+  })
+
+  test('exposes method and request schemas', () => {
+    expect(
+      z.safeDecode(z_RpcSchemaTempo.multisig_getOperation.request, {
+        method: 'multisig_getOperation',
+        params: ['0x01'],
+      }).success,
+    ).toBe(true)
+  })
+})

--- a/src/zod/tempo/z.ts
+++ b/src/zod/tempo/z.ts
@@ -2,6 +2,7 @@
 export * as AuthorizationTempo from './AuthorizationTempo.js'
 export * as KeyAuthorization from './KeyAuthorization.js'
 export * as MultisigConfig from './MultisigConfig.js'
+export * as MultisigOperation from './MultisigOperation.js'
 export * as PoolId from './PoolId.js'
 export * as RpcSchemaTempo from './RpcSchemaTempo.js'
 export * as SignatureEnvelope from './SignatureEnvelope.js'


### PR DESCRIPTION
Ports Tempo multisig operation validation, RPC method schemas, and Zod codecs to Ox v1, preserving the API introduced in https://github.com/wevm/ox/pull/404 and https://github.com/wevm/ox/pull/406.
