### PR TITLE
feat(tempo): add multisig operation helpers

### DIFF
--- a/.changeset/fresh-mails-approve.md
+++ b/.changeset/fresh-mails-approve.md
@@ -1,0 +1,14 @@
+---
+'ox': patch
+---
+
+Added multisig operation hashing, approval selection, and transaction serialization helpers.
+
+```ts
+import { MultisigOperation } from 'ox/tempo'
+
+const selection = await MultisigOperation.selectApprovals(options)
+const transaction = MultisigOperation.serializeTransaction(operation, {
+  approvals: selection.selectedApprovals,
+})
+```

--- a/src/tempo/MultisigOperation.test-d.ts
+++ b/src/tempo/MultisigOperation.test-d.ts
@@ -1,6 +1,7 @@
 import { expectTypeOf, test } from 'vitest'
 import type * as Hex from '../core/Hex.js'
 import * as MultisigOperation from './MultisigOperation.js'
+import type * as TxEnvelopeTempo from './TxEnvelopeTempo.js'
 
 declare const transaction: MultisigOperation.TransactionOperation
 declare const transactionRpc: MultisigOperation.TransactionRpc
@@ -8,6 +9,9 @@ declare const keyAuthorization: MultisigOperation.KeyAuthorizationOperation
 declare const keyAuthorizationRpc: MultisigOperation.KeyAuthorizationRpc
 declare const operation: MultisigOperation.Operation
 declare const operationRpc: MultisigOperation.Rpc
+declare const getHashOptions: MultisigOperation.getHash.Options
+declare const selectApprovalsOptions: MultisigOperation.selectApprovals.Options
+declare const serializeTransactionOptions: MultisigOperation.serializeTransaction.Options
 
 test('preserves operation kinds during validation', () => {
   expectTypeOf(
@@ -49,4 +53,19 @@ test('uses JSON-RPC quantities only in RPC operations', () => {
   expectTypeOf<
     MultisigOperation.Rpc['configVersion']
   >().toEqualTypeOf<Hex.Hex>()
+})
+
+test('operation helpers return narrow types', async () => {
+  expectTypeOf(
+    MultisigOperation.getHash(getHashOptions),
+  ).toEqualTypeOf<Hex.Hex>()
+  expectTypeOf(
+    await MultisigOperation.selectApprovals(selectApprovalsOptions),
+  ).toEqualTypeOf<MultisigOperation.selectApprovals.ReturnValue>()
+  expectTypeOf(
+    MultisigOperation.serializeTransaction(
+      transaction,
+      serializeTransactionOptions,
+    ),
+  ).toEqualTypeOf<TxEnvelopeTempo.Serialized>()
 })

--- a/src/tempo/MultisigOperation.test.ts
+++ b/src/tempo/MultisigOperation.test.ts
@@ -1,4 +1,4 @@
-import { Address, P256 } from 'ox'
+import { Address, Hash, P256 } from 'ox'
 import {
   KeyAuthorization,
   MultisigConfig,
@@ -10,11 +10,14 @@ import { describe, expect, test } from 'vitest'
 
 const owners = [1n, 2n, 3n]
   .map((value, index) => {
+    const privateKey = `0x${value.toString(16).padStart(64, '0')}` as const
     const publicKey = P256.getPublicKey({
-      privateKey: `0x${value.toString(16).padStart(64, '0')}`,
+      privateKey,
     })
     return {
       address: Address.fromPublicKey(publicKey),
+      privateKey,
+      publicKey,
       signature: {
         prehash: false,
         publicKey,
@@ -100,6 +103,694 @@ const keyAuthorizationPending = {
   status: 'pending',
   type: 'keyAuthorization',
 } as const
+
+function signApproval(
+  owner: (typeof owners)[number],
+  hash: `0x${string}`,
+  extraEntropy: false | `0x${string}` = false,
+) {
+  return SignatureEnvelope.serialize({
+    prehash: false,
+    publicKey: owner.publicKey,
+    signature: P256.sign({
+      extraEntropy,
+      payload: hash,
+      privateKey: owner.privateKey,
+    }),
+    type: 'p256',
+  })
+}
+
+function approvalAddresses(
+  approvals: readonly `0x${string}`[],
+  hash: `0x${string}`,
+) {
+  return approvals.map((approval) =>
+    SignatureEnvelope.extractAddress({
+      payload: hash,
+      signature: SignatureEnvelope.deserialize(approval),
+    }),
+  )
+}
+
+describe('getHash', () => {
+  test('transaction and key authorization', () => {
+    expect({
+      keyAuthorization: MultisigOperation.getHash({
+        account,
+        configVersion: 1n,
+        keyAuthorization,
+        type: 'keyAuthorization',
+      }),
+      transaction: MultisigOperation.getHash({
+        account,
+        configVersion: 1n,
+        transaction,
+        type: 'transaction',
+      }),
+    }).toMatchInlineSnapshot(`
+      {
+        "keyAuthorization": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
+        "transaction": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
+      }
+    `)
+  })
+})
+
+describe('selectApprovals', () => {
+  test('selects a deterministic weighted quorum', async () => {
+    const config = MultisigConfig.from({
+      owners: [
+        { owner: owners[0]!.address, weight: 2 },
+        { owner: owners[1]!.address, weight: 1 },
+        { owner: owners[2]!.address, weight: 1 },
+      ],
+      threshold: 3,
+    })
+    const account = MultisigConfig.getAddress(config)
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 1n,
+      transaction,
+      type: 'transaction',
+    })
+    const approvals = owners.map((owner) => signApproval(owner, hash))
+    const alternate = signApproval(owners[0]!, hash, `0x${'01'.repeat(32)}`)
+    const selection = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [
+        approvals[2]!,
+        approvals[0]!,
+        approvals[1]!,
+        alternate,
+        approvals[0]!,
+      ],
+      config,
+      hash,
+    })
+    const reversed = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [
+        approvals[0]!,
+        alternate,
+        approvals[1]!,
+        approvals[0]!,
+        approvals[2]!,
+      ],
+      config,
+      hash,
+    })
+
+    expect(reversed).toStrictEqual(selection)
+    expect({
+      ...selection,
+      approvals: approvalAddresses(selection.approvals, hash),
+      selectedApprovals: approvalAddresses(selection.selectedApprovals, hash),
+    }).toMatchInlineSnapshot(`
+      {
+        "approvals": [
+          "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+          "0x288f0cd85005f34168f731a468aef268c2f9456f",
+          "0xd3a9f047ad43d7e2e4e7e491f1fe2e657a2651b6",
+        ],
+        "selectedApprovals": [
+          "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+          "0x288f0cd85005f34168f731a468aef268c2f9456f",
+        ],
+        "signatureCount": 2,
+        "threshold": 3,
+        "weight": 3,
+      }
+    `)
+  })
+
+  test('counts a nested owner only after its quorum', async () => {
+    const childConfig = MultisigConfig.from({
+      owners: [
+        { owner: owners[1]!.address, weight: 1 },
+        { owner: owners[2]!.address, weight: 1 },
+      ],
+      threshold: 2,
+    })
+    const child = MultisigConfig.getAddress(childConfig)
+    const config = MultisigConfig.from({
+      owners: [
+        { owner: owners[0]!.address, weight: 1 },
+        { owner: child, weight: 2 },
+      ],
+      threshold: 2,
+    })
+    const account = MultisigConfig.getAddress(config)
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 1n,
+      transaction,
+      type: 'transaction',
+    })
+    const childHash = MultisigConfig.getSignPayload({
+      account: child,
+      payload: hash,
+      version: 2n,
+    })
+    const childApprovals = [
+      signApproval(owners[1]!, childHash),
+      signApproval(owners[2]!, childHash),
+    ]
+    const rootApproval = signApproval(owners[0]!, hash)
+    const resolveConfig: MultisigOperation.selectApprovals.ResolveConfig = ({
+      account,
+    }) => {
+      if (!Address.isEqual(account, child)) throw new Error('unknown account')
+      return { config: childConfig, version: 2n }
+    }
+    const partial = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [
+        rootApproval,
+        SignatureEnvelope.serialize({
+          account: child,
+          signatures: [SignatureEnvelope.deserialize(childApprovals[0]!)],
+          type: 'multisig',
+        }),
+      ],
+      config,
+      hash,
+      resolveConfig,
+    })
+    const complete = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [
+        rootApproval,
+        SignatureEnvelope.serialize({
+          account: child,
+          signatures: childApprovals.map((approval) =>
+            SignatureEnvelope.deserialize(approval),
+          ),
+          type: 'multisig',
+        }),
+      ],
+      config,
+      hash,
+      resolveConfig,
+    })
+
+    expect({
+      complete: {
+        ...complete,
+        approvals: approvalAddresses(complete.approvals, hash),
+        selectedApprovals: approvalAddresses(complete.selectedApprovals, hash),
+      },
+      partial: {
+        ...partial,
+        approvals: approvalAddresses(partial.approvals, hash),
+        selectedApprovals: approvalAddresses(partial.selectedApprovals, hash),
+      },
+    }).toMatchInlineSnapshot(`
+      {
+        "complete": {
+          "approvals": [
+            "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+            "0xe2d2c3c2fc4b17af341cc5c1a459af9606167e8a",
+          ],
+          "selectedApprovals": [
+            "0xe2d2c3c2fc4b17af341cc5c1a459af9606167e8a",
+          ],
+          "signatureCount": 1,
+          "threshold": 2,
+          "weight": 2,
+        },
+        "partial": {
+          "approvals": [
+            "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+            "0xe2d2c3c2fc4b17af341cc5c1a459af9606167e8a",
+          ],
+          "selectedApprovals": [
+            "0x07e1ed8ea0e9601e5546b0a03aed683df3601407",
+          ],
+          "signatureCount": 1,
+          "threshold": 2,
+          "weight": 1,
+        },
+      }
+    `)
+  })
+
+  test('rejects invalid and non-owner approvals', async () => {
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 1n,
+      transaction,
+      type: 'transaction',
+    })
+    const invalid = signApproval(
+      owners[0]!,
+      `0x${'ff'.repeat(32)}` as `0x${string}`,
+    )
+    const nonOwner = signApproval(owners[2]!, hash)
+
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [invalid],
+        config,
+        hash,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: signature from owner 0x07e1ed8ea0e9601e5546b0a03aed683df3601407 is invalid.]`,
+    )
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [nonOwner],
+        config,
+        hash,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: signature is from non-owner 0xd3a9f047ad43d7e2e4e7e491f1fe2e657a2651b6.]`,
+    )
+  })
+
+  test('requires a resolver for nested owners', async () => {
+    const childConfig = MultisigConfig.from({
+      owners: [{ owner: owners[1]!.address, weight: 1 }],
+      threshold: 1,
+    })
+    const child = MultisigConfig.getAddress(childConfig)
+    const config = MultisigConfig.from({
+      owners: [{ owner: child, weight: 1 }],
+      threshold: 1,
+    })
+    const account = MultisigConfig.getAddress(config)
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 1n,
+      transaction,
+      type: 'transaction',
+    })
+    const childHash = MultisigConfig.getSignPayload({
+      account: child,
+      payload: hash,
+      version: 1n,
+    })
+
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          SignatureEnvelope.serialize({
+            account: child,
+            signatures: [
+              SignatureEnvelope.deserialize(
+                signApproval(owners[1]!, childHash),
+              ),
+            ],
+            type: 'multisig',
+          }),
+        ],
+        config,
+        hash,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0x7888d60e9cc26c8569d394fce435c248f1e49c3b requires a config resolver.]`,
+    )
+  })
+
+  test('rejects keychain and bootstrap nested approvals', async () => {
+    const childConfig = MultisigConfig.from({
+      owners: [{ owner: owners[1]!.address, weight: 1 }],
+      threshold: 1,
+    })
+    const child = MultisigConfig.getAddress(childConfig)
+    const config = MultisigConfig.from({
+      owners: [
+        { owner: owners[0]!.address, weight: 1 },
+        { owner: child, weight: 1 },
+      ],
+      threshold: 1,
+    })
+    const account = MultisigConfig.getAddress(config)
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 1n,
+      transaction,
+      type: 'transaction',
+    })
+    const childHash = MultisigConfig.getSignPayload({
+      account: child,
+      payload: hash,
+      version: 0n,
+    })
+
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          SignatureEnvelope.serialize({
+            inner: SignatureEnvelope.deserialize(
+              signApproval(owners[0]!, hash),
+            ),
+            type: 'keychain',
+            userAddress: owners[0]!.address,
+          }),
+        ],
+        config,
+        hash,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: keychain signatures cannot approve a multisig operation.]`,
+    )
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          SignatureEnvelope.serialize({
+            account: child,
+            init: childConfig,
+            signatures: [
+              SignatureEnvelope.deserialize(
+                signApproval(owners[1]!, childHash),
+              ),
+            ],
+            type: 'multisig',
+          }),
+        ],
+        config,
+        hash,
+        resolveConfig: () => ({ config: childConfig, version: 0n }),
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0x7888d60e9cc26c8569d394fce435c248f1e49c3b cannot carry init.]`,
+    )
+  })
+
+  test('rejects nested account cycles', async () => {
+    const config = MultisigConfig.from({
+      owners: [{ owner: account, weight: 1 }],
+      threshold: 1,
+    })
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 2n,
+      transaction,
+      type: 'transaction',
+    })
+    const nestedHash = MultisigConfig.getSignPayload({
+      account,
+      payload: hash,
+      version: 2n,
+    })
+
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          SignatureEnvelope.serialize({
+            account,
+            signatures: [
+              SignatureEnvelope.deserialize(
+                signApproval(owners[0]!, nestedHash),
+              ),
+            ],
+            type: 'multisig',
+          }),
+        ],
+        config,
+        hash,
+        resolveConfig: () => ({ config, version: 2n }),
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0xf81b7763d3a6876195d780865bd783dbd97dd36e is invalid.]`,
+    )
+  })
+
+  test('rejects excess nesting depth', async () => {
+    const grandchildConfig = MultisigConfig.from({
+      owners: [{ owner: owners[2]!.address, weight: 1 }],
+      threshold: 1,
+    })
+    const grandchild = MultisigConfig.getAddress(grandchildConfig)
+    const childConfig = MultisigConfig.from({
+      owners: [{ owner: grandchild, weight: 1 }],
+      threshold: 1,
+    })
+    const child = MultisigConfig.getAddress(childConfig)
+    const config = MultisigConfig.from({
+      owners: [{ owner: child, weight: 1 }],
+      threshold: 1,
+    })
+    const account = MultisigConfig.getAddress(config)
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 1n,
+      transaction,
+      type: 'transaction',
+    })
+    const childHash = MultisigConfig.getSignPayload({
+      account: child,
+      payload: hash,
+      version: 1n,
+    })
+    const grandchildHash = MultisigConfig.getSignPayload({
+      account: grandchild,
+      payload: childHash,
+      version: 1n,
+    })
+
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          SignatureEnvelope.serialize({
+            account: child,
+            signatures: [
+              {
+                account: grandchild,
+                signatures: [
+                  SignatureEnvelope.deserialize(
+                    signApproval(owners[2]!, grandchildHash),
+                  ),
+                ],
+                type: 'multisig',
+              },
+            ],
+            type: 'multisig',
+          }),
+        ],
+        config,
+        hash,
+        resolveConfig: ({ account }) => {
+          if (Address.isEqual(account, child))
+            return { config: childConfig, version: 1n }
+          return { config: grandchildConfig, version: 1n }
+        },
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0xf529c8f6b2b4c72102af4cfe5eeb55b7d45dede2 is invalid.]`,
+    )
+  })
+})
+
+describe('serializeTransaction', () => {
+  test('initialized and bootstrap transactions', async () => {
+    const results = []
+    for (const init of [false, true]) {
+      const configVersion = init ? 0n : 1n
+      const hash = MultisigOperation.getHash({
+        account,
+        configVersion,
+        transaction,
+        type: 'transaction',
+      })
+      const selection = await MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          signApproval(owners[1]!, hash),
+          signApproval(owners[0]!, hash),
+        ],
+        config,
+        hash,
+      })
+      const operation = MultisigOperation.from({
+        account,
+        approvals: selection.approvals,
+        config,
+        configVersion,
+        createdAt: 1,
+        hash,
+        init,
+        signatureCount: selection.signatureCount,
+        status: 'pending',
+        threshold: selection.threshold,
+        transaction,
+        type: 'transaction',
+        updatedAt: 1,
+        weight: selection.weight,
+      })
+      const serialized = MultisigOperation.serializeTransaction(operation, {
+        approvals: selection.selectedApprovals,
+      })
+      const value = TxEnvelopeTempo.deserialize(serialized)
+      results.push({
+        account: value.signature?.account,
+        hash: Hash.keccak256(serialized),
+        init: value.signature?.type === 'multisig' && !!value.signature.init,
+        signatureCount:
+          value.signature?.type === 'multisig'
+            ? value.signature.signatures.length
+            : 0,
+        type: serialized.slice(0, 4),
+      })
+    }
+
+    expect(results).toMatchInlineSnapshot(`
+      [
+        {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "hash": "0x704768725a4e798e2656f0f355f99507522c97b2947f551a5ee696216a2ba6fe",
+          "init": false,
+          "signatureCount": 2,
+          "type": "0x76",
+        },
+        {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "hash": "0x08131922349c385f9112fefc617fa6f6258a71df1125ec243bb3ee7cff59b700",
+          "init": true,
+          "signatureCount": 2,
+          "type": "0x76",
+        },
+      ]
+    `)
+  })
+
+  test('fee-payer transactions', async () => {
+    const envelope = TxEnvelopeTempo.from({
+      calls: [{ data: '0x1234', to: owner_1 }],
+      chainId: 4217,
+    })
+    const transactions = [
+      TxEnvelopeTempo.serialize(envelope, {
+        format: 'feePayer',
+        sender: account,
+      }),
+      TxEnvelopeTempo.serialize(
+        {
+          ...envelope,
+          feePayerSignature: { r: 5n, s: 6n, yParity: 0 },
+        },
+        { format: 'feePayer' },
+      ),
+    ] as const
+    const results = []
+    for (const transaction of transactions) {
+      const hash = MultisigOperation.getHash({
+        account,
+        configVersion: 1n,
+        transaction,
+        type: 'transaction',
+      })
+      const selection = await MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          signApproval(owners[0]!, hash),
+          signApproval(owners[1]!, hash),
+        ],
+        config,
+        hash,
+      })
+      const serialized = MultisigOperation.serializeTransaction(
+        MultisigOperation.from({
+          account,
+          approvals: selection.approvals,
+          config,
+          configVersion: 1n,
+          createdAt: 1,
+          hash,
+          init: false,
+          signatureCount: selection.signatureCount,
+          status: 'pending',
+          threshold: selection.threshold,
+          transaction,
+          type: 'transaction',
+          updatedAt: 1,
+          weight: selection.weight,
+        }),
+        { approvals: selection.selectedApprovals },
+      )
+      const value = TxEnvelopeTempo.deserialize(serialized)
+      results.push({
+        feePayerSignature: value.feePayerSignature,
+        from: value.from,
+        signatureCount:
+          value.signature?.type === 'multisig'
+            ? value.signature.signatures.length
+            : 0,
+        type: serialized.slice(0, 4),
+      })
+    }
+
+    expect(results).toMatchInlineSnapshot(`
+      [
+        {
+          "feePayerSignature": null,
+          "from": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "signatureCount": 2,
+          "type": "0x78",
+        },
+        {
+          "feePayerSignature": {
+            "r": 5n,
+            "s": 6n,
+            "yParity": 0,
+          },
+          "from": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "signatureCount": 2,
+          "type": "0x78",
+        },
+      ]
+    `)
+  })
+
+  test('rejects an approval not retained by the operation', async () => {
+    const hash = MultisigOperation.getHash({
+      account,
+      configVersion: 1n,
+      transaction,
+      type: 'transaction',
+    })
+    const approval_1 = signApproval(owners[0]!, hash)
+    const approval_2 = signApproval(owners[1]!, hash)
+    const selection = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [approval_1],
+      config,
+      hash,
+    })
+    const operation = MultisigOperation.from({
+      account,
+      approvals: selection.approvals,
+      config,
+      configVersion: 1n,
+      createdAt: 1,
+      hash,
+      init: false,
+      signatureCount: selection.signatureCount,
+      status: 'pending',
+      threshold: selection.threshold,
+      transaction,
+      type: 'transaction',
+      updatedAt: 1,
+      weight: selection.weight,
+    })
+
+    expect(() =>
+      MultisigOperation.serializeTransaction(operation, {
+        approvals: [approval_2],
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidOperationError: Invalid multisig operation: transaction signature is not a retained approval.]`,
+    )
+  })
+})
 
 describe('from', () => {
   test('transaction states', () => {

--- a/src/tempo/MultisigOperation.ts
+++ b/src/tempo/MultisigOperation.ts
@@ -77,6 +77,255 @@ export type Rpc = Operation<Hex.Hex>
 const maxConfigVersion = 2n ** 64n - 1n
 
 /**
+ * Derives the deterministic hash for a multisig operation.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigOperation } from 'ox/tempo'
+ *
+ * const hash = MultisigOperation.getHash({
+ *   account,
+ *   configVersion: 1n,
+ *   transaction,
+ *   type: 'transaction',
+ * })
+ * ```
+ *
+ * @param options - Operation payload and multisig identity.
+ * @returns The operation hash signed by each owner.
+ */
+export function getHash(options: getHash.Options): Hex.Hex {
+  const { account, configVersion } = options
+  const payload =
+    options.type === 'transaction'
+      ? TxEnvelopeTempo.getSignPayload(
+          TxEnvelopeTempo.deserialize(
+            options.transaction as TxEnvelopeTempo.Serialized,
+          ),
+        )
+      : KeyAuthorization_.getSignPayload(
+          KeyAuthorization_.deserialize(options.keyAuthorization),
+        )
+  return MultisigConfig.getSignPayload({
+    account,
+    payload,
+    version: configVersion,
+  })
+}
+
+export declare namespace getHash {
+  /** Parameters for `getHash`. */
+  export type Options = {
+    /** Root multisig account. */
+    account: Address.Address
+    /** Root configuration version. */
+    configVersion: bigint
+  } & (
+    | {
+        /** Canonical serialized key authorization. */
+        keyAuthorization: Hex.Hex
+        /** Operation kind. */
+        type: 'keyAuthorization'
+      }
+    | {
+        /** Canonical serialized Tempo envelope without its outer sender signature. */
+        transaction: Hex.Hex
+        /** Operation kind. */
+        type: 'transaction'
+      }
+  )
+
+  /** Error type for `getHash`. */
+  export type ErrorType =
+    | KeyAuthorization_.deserialize.ErrorType
+    | KeyAuthorization_.getSignPayload.ErrorType
+    | MultisigConfig.getSignPayload.ErrorType
+    | TxEnvelopeTempo.deserialize.ErrorType
+    | TxEnvelopeTempo.getSignPayload.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Validates, deduplicates, and selects owner approvals for an operation.
+ *
+ * The function retains one canonical approval per owner. It selects the
+ * smallest deterministic quorum by owner weight, then orders the selected
+ * approvals by owner address for serialization.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigOperation } from 'ox/tempo'
+ *
+ * const selection = await MultisigOperation.selectApprovals({
+ *   account,
+ *   approvals,
+ *   config,
+ *   hash,
+ *   resolveConfig,
+ * })
+ * ```
+ *
+ * @param options - Approval selection parameters.
+ * @returns The retained approvals and deterministic quorum selection.
+ */
+export async function selectApprovals(
+  options: selectApprovals.Options,
+): Promise<selectApprovals.ReturnValue> {
+  const { account, approvals, hash, resolveConfig } = options
+  if (!Address.validate(account) || Hex.toBigInt(account) === 0n)
+    throw new InvalidApprovalError({ reason: 'account is invalid' })
+  if (!Hash.validate(hash))
+    throw new InvalidApprovalError({ reason: 'hash is invalid' })
+  return selectApprovals_internal(
+    {
+      account,
+      approvals,
+      config: MultisigConfig.from(options.config),
+      hash,
+      resolveConfig,
+    },
+    [account.toLowerCase()],
+  )
+}
+
+export declare namespace selectApprovals {
+  /** Parameters for `selectApprovals`. */
+  export type Options = {
+    /** Root multisig account. */
+    account: Address.Address
+    /** Serialized primitive or nested owner approvals. */
+    approvals: readonly SignatureEnvelope.Serialized[]
+    /** Current root multisig configuration. */
+    config: MultisigConfig.Config
+    /** Deterministic operation hash approved by root owners. */
+    hash: Hex.Hex
+    /** Resolves the current configuration of a nested multisig owner. */
+    resolveConfig?: ResolveConfig | undefined
+  }
+
+  /** Resolves an initialized nested multisig configuration. */
+  export type ResolveConfig = (
+    options: ResolveConfigOptions,
+  ) => ResolvedConfig | Promise<ResolvedConfig>
+
+  /** Nested multisig configuration lookup parameters. */
+  export type ResolveConfigOptions = {
+    /** Nested multisig account. */
+    account: Address.Address
+  }
+
+  /** Resolved nested multisig configuration. */
+  export type ResolvedConfig = {
+    /** Current nested multisig configuration. */
+    config: MultisigConfig.Config
+    /** Current nested multisig configuration version. */
+    version: bigint
+  }
+
+  /** Result of validating and selecting approvals. */
+  export type ReturnValue = {
+    /** Every retained approval, ordered by owner address. */
+    approvals: readonly SignatureEnvelope.Serialized[]
+    /** Number of approvals selected for quorum evaluation. */
+    signatureCount: number
+    /** Approvals selected for serialization, ordered by owner address. */
+    selectedApprovals: readonly SignatureEnvelope.Serialized[]
+    /** Required owner weight. */
+    threshold: number
+    /** Owner weight reached by the selected approvals. */
+    weight: number
+  }
+
+  /** Error type for `selectApprovals`. */
+  export type ErrorType =
+    | InvalidApprovalError
+    | MultisigConfig.assert.ErrorType
+    | MultisigConfig.getSignPayload.ErrorType
+    | SignatureEnvelope.CoercionError
+    | SignatureEnvelope.extractAddress.ErrorType
+    | SignatureEnvelope.serialize.ErrorType
+    | SignatureEnvelope.VerificationError
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Serializes a multisig transaction operation with selected owner approvals.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigOperation } from 'ox/tempo'
+ *
+ * const transaction = MultisigOperation.serializeTransaction(operation, {
+ *   approvals: selection.selectedApprovals,
+ * })
+ * ```
+ *
+ * @param operation - Multisig transaction operation.
+ * @param options - Transaction serialization options.
+ * @returns The signed serialized Tempo transaction.
+ */
+export function serializeTransaction(
+  operation: TransactionOperation,
+  options: serializeTransaction.Options,
+): TxEnvelopeTempo.Serialized {
+  const value = from(operation)
+  const envelope = TxEnvelopeTempo.deserialize(
+    value.transaction as TxEnvelopeTempo.Serialized,
+  )
+  const approvals = options.approvals.map((approval) =>
+    SignatureEnvelope.from(approval),
+  )
+  assertRetainedApprovals(value, approvals)
+  const signatures = SignatureEnvelope.sortMultisigApprovals({
+    account: value.account,
+    payload: TxEnvelopeTempo.getSignPayload(envelope),
+    signatures: approvals,
+    version: value.configVersion,
+  })
+  const signature = value.init
+    ? SignatureEnvelope.from({
+        init: true,
+        initialConfig: value.config,
+        signatures,
+      })
+    : SignatureEnvelope.from({
+        account: value.account,
+        signatures,
+      })
+  return TxEnvelopeTempo.serialize(
+    envelope,
+    value.transaction.startsWith(TxEnvelopeTempo.feePayerMagic)
+      ? {
+          format: 'feePayer',
+          sender: envelope.from,
+          signature,
+        }
+      : { signature },
+  )
+}
+
+export declare namespace serializeTransaction {
+  /** Options for `serializeTransaction`. */
+  export type Options = {
+    /** Selected retained approvals to attach to the transaction. */
+    approvals: readonly SignatureEnvelope.Serialized[]
+  }
+
+  /** Error type for `serializeTransaction`. */
+  export type ErrorType =
+    | from.ErrorType
+    | InvalidOperationError
+    | SignatureEnvelope.sortMultisigApprovals.ErrorType
+    | TxEnvelopeTempo.deserialize.ErrorType
+    | TxEnvelopeTempo.getSignPayload.ErrorType
+    | TxEnvelopeTempo.serialize.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Validates and normalizes a multisig operation.
  *
  * @example
@@ -206,6 +455,220 @@ export declare namespace toRpc {
 
   /** Error type for `toRpc`. */
   export type ErrorType = from.ErrorType | Hex.fromNumber.ErrorType
+}
+
+/**
+ * Validates and selects approvals recursively.
+ *
+ * @internal
+ */
+async function selectApprovals_internal(
+  options: selectApprovals.Options,
+  path: readonly string[],
+): Promise<selectApprovals.ReturnValue> {
+  const owners = new Map(
+    options.config.owners.map((owner) => [
+      owner.owner.toLowerCase(),
+      { address: owner.owner, weight: Number(owner.weight) },
+    ]),
+  )
+  const groups = new Map<string, ApprovalGroup>()
+  for (const serialized of options.approvals) {
+    const signature = SignatureEnvelope.from(serialized)
+    if (signature.type === 'keychain')
+      throw new InvalidApprovalError({
+        reason: 'keychain signatures cannot approve a multisig operation',
+      })
+    const address =
+      signature.type === 'multisig'
+        ? signature.account
+        : SignatureEnvelope.extractAddress({
+            payload: options.hash,
+            signature,
+          })
+    const owner = owners.get(address.toLowerCase())
+    if (!owner)
+      throw new InvalidApprovalError({
+        reason: `signature is from non-owner ${address}`,
+      })
+    const key = address.toLowerCase()
+    const group = groups.get(key)
+    if (group) group.signatures.push(signature)
+    else
+      groups.set(key, {
+        address: owner.address,
+        signatures: [signature],
+        weight: owner.weight,
+      })
+  }
+
+  const valid: SelectedApproval[] = []
+  const retained: RetainedApproval[] = []
+  for (const group of groups.values()) {
+    const nested = group.signatures.filter(
+      (signature) => signature.type === 'multisig',
+    )
+    if (nested.length > 0) {
+      if (nested.length !== group.signatures.length)
+        throw new InvalidApprovalError({
+          reason: `owner ${group.address} has conflicting signature types`,
+        })
+      if (nested.some((signature) => signature.init))
+        throw new InvalidApprovalError({
+          reason: `nested multisig owner ${group.address} cannot carry init`,
+        })
+      if (
+        path.length >= MultisigConfig.maxNestingDepth ||
+        path.includes(group.address.toLowerCase())
+      )
+        throw new InvalidApprovalError({
+          reason: `nested multisig owner ${group.address} is invalid`,
+        })
+      if (!options.resolveConfig)
+        throw new InvalidApprovalError({
+          reason: `nested multisig owner ${group.address} requires a config resolver`,
+        })
+      const resolved = await options.resolveConfig({ account: group.address })
+      const selected = await selectApprovals_internal(
+        {
+          account: group.address,
+          approvals: nested.flatMap((signature) =>
+            signature.signatures.map((approval) =>
+              SignatureEnvelope.serialize(approval),
+            ),
+          ),
+          config: MultisigConfig.from(resolved.config),
+          hash: MultisigConfig.getSignPayload({
+            account: group.address,
+            payload: options.hash,
+            version: resolved.version,
+          }),
+          resolveConfig: options.resolveConfig,
+        },
+        [...path, group.address.toLowerCase()],
+      )
+      retained.push({
+        address: group.address,
+        signature: SignatureEnvelope.serialize(
+          SignatureEnvelope.from({
+            account: group.address,
+            signatures: selected.approvals.map((approval) =>
+              SignatureEnvelope.from(approval),
+            ),
+          }),
+        ),
+      })
+      if (selected.weight >= selected.threshold)
+        valid.push({
+          address: group.address,
+          signature: SignatureEnvelope.serialize(
+            SignatureEnvelope.from({
+              account: group.address,
+              signatures: selected.selectedApprovals.map((approval) =>
+                SignatureEnvelope.from(approval),
+              ),
+            }),
+          ),
+          weight: group.weight,
+        })
+      continue
+    }
+
+    const signatures = group.signatures.map((signature) => {
+      if (
+        !SignatureEnvelope.verify(signature, {
+          address: group.address,
+          payload: options.hash,
+        })
+      )
+        throw new InvalidApprovalError({
+          reason: `signature from owner ${group.address} is invalid`,
+        })
+      return SignatureEnvelope.serialize(signature)
+    })
+    const signature = signatures.sort(compareHex)[0]!
+    valid.push({
+      address: group.address,
+      signature,
+      weight: group.weight,
+    })
+    retained.push({ address: group.address, signature })
+  }
+
+  const ranked = valid.sort(
+    (a, b) => b.weight - a.weight || compareApprovalAddress(a, b),
+  )
+  const selected: typeof ranked = []
+  let weight = 0
+  for (const approval of ranked.slice(0, MultisigConfig.maxSignatures)) {
+    if (weight >= Number(options.config.threshold)) break
+    selected.push(approval)
+    weight += approval.weight
+  }
+  selected.sort(compareApprovalAddress)
+
+  return {
+    approvals: retained
+      .sort(compareApprovalAddress)
+      .map((approval) => approval.signature),
+    selectedApprovals: selected.map((approval) => approval.signature),
+    signatureCount: selected.length,
+    threshold: Number(options.config.threshold),
+    weight,
+  }
+}
+
+/** Approval selected for quorum evaluation. @internal */
+type SelectedApproval = {
+  /** Configured owner address. */
+  address: Address.Address
+  /** Serialized owner signature. */
+  signature: SignatureEnvelope.Serialized
+  /** Configured owner weight. */
+  weight: number
+}
+
+/** Approvals submitted for one configured owner. @internal */
+type ApprovalGroup = {
+  /** Configured owner address. */
+  address: Address.Address
+  /** Submitted signatures that resolve to the owner. */
+  signatures: SignatureEnvelope.SignatureEnvelope[]
+  /** Configured owner weight. */
+  weight: number
+}
+
+/** Approval retained in operation storage. @internal */
+type RetainedApproval = {
+  /** Configured owner address. */
+  address: Address.Address
+  /** Serialized primitive or normalized nested approval. */
+  signature: SignatureEnvelope.Serialized
+}
+
+/**
+ * Orders approval records by owner address.
+ *
+ * @internal
+ */
+function compareApprovalAddress(
+  a: SelectedApproval | RetainedApproval,
+  b: SelectedApproval | RetainedApproval,
+) {
+  const addressA = Hex.toBigInt(a.address)
+  const addressB = Hex.toBigInt(b.address)
+  return addressA < addressB ? -1 : addressA > addressB ? 1 : 0
+}
+
+/**
+ * Orders hexadecimal data bytewise.
+ *
+ * @internal
+ */
+function compareHex(a: Hex.Hex, b: Hex.Hex) {
+  const hexA = a.toLowerCase()
+  const hexB = b.toLowerCase()
+  return hexA < hexB ? -1 : hexA > hexB ? 1 : 0
 }
 
 /**
@@ -527,6 +990,30 @@ function assertApproval(
 }
 
 /**
+ * Checks that selected transaction approvals are retained by the operation.
+ *
+ * @internal
+ */
+function assertRetainedApprovals(
+  operation: TransactionOperation,
+  selected: readonly SignatureEnvelope.SignatureEnvelope[],
+): void {
+  const retained = operation.approvals.map((approval) =>
+    SignatureEnvelope.deserialize(approval),
+  )
+  for (const approval of selected) {
+    const index = retained.findIndex((candidate) =>
+      includesApproval(candidate, approval),
+    )
+    if (index === -1)
+      throw new InvalidOperationError({
+        reason: 'transaction signature is not a retained approval',
+      })
+    retained.splice(index, 1)
+  }
+}
+
+/**
  * Checks that a successful key authorization uses retained approvals in canonical order.
  *
  * @internal
@@ -679,6 +1166,44 @@ function sameConfig(
       )
     })
   )
+}
+
+/** Thrown when a multisig owner approval is invalid. */
+export class InvalidApprovalError extends Errors.BaseError<Error | undefined> {
+  override readonly name = 'MultisigOperation.InvalidApprovalError'
+
+  /**
+   * Creates an invalid multisig approval error.
+   *
+   * @example
+   * ```ts twoslash
+   * import { MultisigOperation } from 'ox/tempo'
+   *
+   * throw new MultisigOperation.InvalidApprovalError({
+   *   reason: 'signature is from a non-owner',
+   * })
+   * ```
+   *
+   * @param options - Error options.
+   */
+  constructor(options: InvalidApprovalError.Options = {}) {
+    super(
+      options.reason
+        ? `Invalid multisig approval: ${options.reason}.`
+        : 'Invalid multisig approval.',
+      { cause: options.cause as Error | undefined },
+    )
+  }
+}
+
+export declare namespace InvalidApprovalError {
+  /** Error construction options. */
+  export type Options = {
+    /** Underlying error. */
+    cause?: unknown | undefined
+    /** Validation failure. */
+    reason?: string | undefined
+  }
 }
 
 /** Thrown when a multisig operation is malformed or internally inconsistent. */

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -153,8 +153,8 @@ export * as MultisigConfig from './MultisigConfig.js'
 /**
  * Offchain multisig transaction and key authorization operation utilities.
  *
- * Validates operation state, serialized payloads, and deterministic operation
- * hashes, and converts between domain and JSON-RPC representations.
+ * Derives operation hashes, selects owner approvals, serializes transactions,
+ * validates operation state, and converts JSON-RPC representations.
  *
  * @category Reference
  */


### PR DESCRIPTION
Adds operation hash derivation, weighted and nested approval selection, and signed transaction serialization to `MultisigOperation` for reuse by Viem's multisig relay.

Related: https://github.com/wevm/viem/pull/5029
