### PR TITLE
feat(tempo): add multisig configuration witnesses

### DIFF
--- a/.changeset/calm-witnesses-sign.md
+++ b/.changeset/calm-witnesses-sign.md
@@ -8,6 +8,6 @@ Updated native multisig configurations and signatures to use TIP-1061 configurat
 const config = MultisigConfig.from({
   owners,
   threshold: 2,
-  version: 1n,
+  version: 1,
 })
 ```

--- a/.changeset/calm-witnesses-sign.md
+++ b/.changeset/calm-witnesses-sign.md
@@ -1,8 +1,8 @@
 ---
-'ox': patch
+'ox': minor
 ---
 
-Updated native multisig configurations and signatures to use TIP-1061 configuration witnesses.
+Changed native multisig configuration and signature APIs to require complete TIP-1061 witnesses with a `version`.
 
 ```ts
 const config = MultisigConfig.from({

--- a/.changeset/calm-witnesses-sign.md
+++ b/.changeset/calm-witnesses-sign.md
@@ -1,5 +1,5 @@
 ---
-'ox': minor
+'ox': patch
 ---
 
 Changed native multisig configuration and signature APIs to require complete TIP-1061 witnesses with a `version`.

--- a/.changeset/calm-witnesses-sign.md
+++ b/.changeset/calm-witnesses-sign.md
@@ -1,0 +1,13 @@
+---
+'ox': patch
+---
+
+Updated native multisig configurations and signatures to use TIP-1061 configuration witnesses.
+
+```ts
+const config = MultisigConfig.from({
+  owners,
+  threshold: 2,
+  version: 1n,
+})
+```

--- a/src/tempo/KeyAuthorization.test-d.ts
+++ b/src/tempo/KeyAuthorization.test-d.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
 import * as KeyAuthorization from './KeyAuthorization.js'
+import * as MultisigConfig from './MultisigConfig.js'
 import type * as SignatureEnvelope from './SignatureEnvelope.js'
 
 const authorization = {
@@ -19,6 +20,16 @@ const signature = {
 
 const multisig = {
   account: '0x2222222222222222222222222222222222222222',
+  config: MultisigConfig.from({
+    owners: [
+      {
+        owner: '0x1111111111111111111111111111111111111111',
+        weight: 1,
+      },
+    ],
+    threshold: 1,
+    version: 1n,
+  }),
   signatures: [signature],
   type: 'multisig',
 } as const satisfies SignatureEnvelope.Multisig
@@ -46,6 +57,7 @@ test('accepts multisig signatures', () => {
 
   const multisigRpc = {
     account: multisig.account,
+    config: MultisigConfig.toRpc(multisig.config),
     signatures: [
       {
         r: '0x01',

--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'ox'
 import { describe, expect, test } from 'vitest'
 import * as KeyAuthorization from './KeyAuthorization.js'
+import * as MultisigConfig from './MultisigConfig.js'
 import * as Period from './Period.js'
 import * as SignatureEnvelope from './SignatureEnvelope.js'
 
@@ -55,6 +56,16 @@ const signature_webauthn = SignatureEnvelope.from({
 
 const signature_multisig = {
   account: address,
+  config: MultisigConfig.from({
+    owners: [
+      {
+        owner: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        weight: 1,
+      },
+    ],
+    threshold: 1,
+    version: 1n,
+  }),
   signatures: [SignatureEnvelope.from(signature_secp256k1)],
   type: 'multisig',
 } as const satisfies SignatureEnvelope.Multisig
@@ -1105,6 +1116,49 @@ describe('getSignPayload', () => {
 })
 
 describe('deserialize', () => {
+  test('example: matches the frozen multisig witness vector', () => {
+    const serialized =
+      '0xf8f1f85382107980941eff47bc3a10a45d4b230b5d10e37751fe6aa718808080a0535353535353535353535353535353535353535353535353535353535353535380949dba7f426b711d4893c11611eacf7cc334e7146bb89a05f897949dba7f426b711d4893c11611eacf7cc334e7146bf83ba000000000000000000000000000000000000000000000000000000000000000008001d7d6947e5f4552091a69125d5dfcb7b8c2659029395bdf01f843b8412cfed9350faf80e4115e3c4c967356b80a8e6ee42e4a49ab953c8c8a3537d8d8359bf035a9bea18f32b0da7129cdce3ce701abc09ad8919b93da21a0d57e21451b' as const
+    const authorization = KeyAuthorization.deserialize(serialized)
+
+    expect(authorization).toMatchInlineSnapshot(`
+      {
+        "account": "0x9dba7f426b711d4893c11611eacf7cc334e7146b",
+        "address": "0x1eff47bc3a10a45d4b230b5d10e37751fe6aa718",
+        "chainId": 4217n,
+        "isAdmin": false,
+        "signature": {
+          "account": "0x9dba7f426b711d4893c11611eacf7cc334e7146b",
+          "config": {
+            "owners": [
+              {
+                "owner": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 1,
+            "version": 0n,
+          },
+          "signatures": [
+            {
+              "signature": {
+                "r": 20352043601603739938552089215678686496502071349800253093806146960015285016792n,
+                "s": 24248100135830369623517016370647991375751195948759416747839894916952879931717n,
+                "yParity": 0,
+              },
+              "type": "secp256k1",
+            },
+          ],
+          "type": "multisig",
+        },
+        "type": "secp256k1",
+        "witness": "0x5353535353535353535353535353535353535353535353535353535353535353",
+      }
+    `)
+    expect(KeyAuthorization.serialize(authorization)).toBe(serialized)
+  })
+
   test('multisig', () => {
     const serialized = Rlp.fromHex([
       ['0x1', '0x', address],

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -159,7 +159,7 @@ type SignatureValue =
   | UnionPartialBy<Signature, 'prehash' | 'type'>
   | SignatureEnvelope.Secp256k1Flat
   | SignatureEnvelope.Serialized
-  | SignatureEnvelope.from.MultisigFromInitialConfig
+  | SignatureEnvelope.from.MultisigFromConfig
 
 type BaseTuple = readonly [
   chainId: Hex.Hex,

--- a/src/tempo/MultisigConfig.test-d.ts
+++ b/src/tempo/MultisigConfig.test-d.ts
@@ -1,0 +1,48 @@
+import { expectTypeOf, test } from 'vitest'
+import * as MultisigConfig from './MultisigConfig.js'
+
+const input = {
+  owners: [
+    {
+      owner: '0x1111111111111111111111111111111111111111',
+      weight: 1,
+    },
+  ],
+  threshold: 1,
+} as const satisfies MultisigConfig.Input
+
+test('from returns a complete configuration', () => {
+  const config = MultisigConfig.from(input)
+
+  expectTypeOf(config).toMatchTypeOf<MultisigConfig.Config>()
+  expectTypeOf(config.version).toEqualTypeOf<0n>()
+})
+
+test('RPC configurations use hexadecimal versions', () => {
+  const rpc = MultisigConfig.toRpc(MultisigConfig.from(input))
+
+  expectTypeOf(rpc).toEqualTypeOf<MultisigConfig.Rpc>()
+  expectTypeOf(rpc.version).toEqualTypeOf<`0x${string}`>()
+})
+
+test('complete configurations require a version', () => {
+  // @ts-expect-error Complete configurations include their version.
+  const config: MultisigConfig.Config = input
+
+  expectTypeOf(config).toEqualTypeOf<MultisigConfig.Config>()
+})
+
+test('sign payloads take the version from config', () => {
+  MultisigConfig.getSignPayload({
+    account: '0x2222222222222222222222222222222222222222',
+    config: { version: 1n },
+    payload: '0x1234',
+  })
+
+  MultisigConfig.getSignPayload({
+    account: '0x2222222222222222222222222222222222222222',
+    // @ts-expect-error A configuration version is required.
+    config: {},
+    payload: '0x1234',
+  })
+})

--- a/src/tempo/MultisigConfig.test-d.ts
+++ b/src/tempo/MultisigConfig.test-d.ts
@@ -13,9 +13,13 @@ const input = {
 
 test('from returns a complete configuration', () => {
   const config = MultisigConfig.from(input)
+  const numeric = MultisigConfig.from({ ...input, version: 1 })
+  const zero = MultisigConfig.from({ ...input, version: 0 })
 
   expectTypeOf(config).toMatchTypeOf<MultisigConfig.Config>()
   expectTypeOf(config.version).toEqualTypeOf<0n>()
+  expectTypeOf(numeric.version).toEqualTypeOf<bigint>()
+  expectTypeOf(zero.version).toEqualTypeOf<0n>()
 })
 
 test('RPC configurations use hexadecimal versions', () => {
@@ -35,7 +39,7 @@ test('complete configurations require a version', () => {
 test('sign payloads take the version from config', () => {
   MultisigConfig.getSignPayload({
     account: '0x2222222222222222222222222222222222222222',
-    config: { version: 1n },
+    config: { version: 1 },
     payload: '0x1234',
   })
 

--- a/src/tempo/MultisigConfig.test.ts
+++ b/src/tempo/MultisigConfig.test.ts
@@ -1,339 +1,341 @@
+import { Hash, Hex, Rlp } from 'ox'
 import { MultisigConfig } from 'ox/tempo'
 import { describe, expect, test } from 'vitest'
 
-// Ground-truth vectors independently computed via `cast keccak` over the exact
-// preimages defined by TIP-1061 / the Tempo reference implementation.
-const owner1 = '0x1111111111111111111111111111111111111111'
-const owner2 = '0x2222222222222222222222222222222222222222'
-
-const singleOwnerConfig = {
+const owner_1 = '0x1111111111111111111111111111111111111111'
+const owner_2 = '0x2222222222222222222222222222222222222222'
+const payload = `0x${'42'.repeat(32)}` as const
+const config = MultisigConfig.from({
+  owners: [{ owner: owner_1, weight: 1 }],
   threshold: 1,
-  owners: [{ owner: owner1, weight: 1 }],
-} as const
+})
+const account = MultisigConfig.getAddress(config)
 
 describe('from', () => {
-  test('sorts owners ascending by address', () => {
-    const config = MultisigConfig.from({
-      threshold: 2,
-      owners: [
-        { owner: owner2, weight: 1 },
-        { owner: owner1, weight: 1 },
-      ],
-    })
-    expect(config.owners.map((o) => o.owner)).toEqual([owner1, owner2])
+  test('behavior: normalizes an initial configuration', () => {
+    expect(
+      MultisigConfig.from({
+        owners: [
+          { owner: owner_2, weight: 1 },
+          { owner: owner_1, weight: 1 },
+        ],
+        threshold: 2,
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "owners": [
+          {
+            "owner": "0x1111111111111111111111111111111111111111",
+            "weight": 1,
+          },
+          {
+            "owner": "0x2222222222222222222222222222222222222222",
+            "weight": 1,
+          },
+        ],
+        "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "threshold": 2,
+        "version": 0n,
+      }
+    `)
   })
 
-  test('asserts validity', () => {
+  test('behavior: preserves a current configuration version', () => {
+    expect(
+      MultisigConfig.from({ ...config, version: 1n }),
+    ).toMatchInlineSnapshot(`
+      {
+        "owners": [
+          {
+            "owner": "0x1111111111111111111111111111111111111111",
+            "weight": 1,
+          },
+        ],
+        "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "threshold": 1,
+        "version": 1n,
+      }
+    `)
+  })
+
+  test('error: rejects an invalid configuration', () => {
     expect(() =>
-      MultisigConfig.from({ threshold: 0, owners: [] }),
-    ).toThrowError()
+      MultisigConfig.from({ owners: [], threshold: 0 }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[MultisigConfig.InvalidConfigError: Invalid native multisig config: owners cannot be empty.]`,
+    )
+  })
+})
+
+describe('fromRpc/toRpc', () => {
+  test('behavior: round trips a configuration', () => {
+    const rpc = MultisigConfig.toRpc({ ...config, version: 1n })
+    expect(rpc).toMatchInlineSnapshot(`
+      {
+        "owners": [
+          {
+            "owner": "0x1111111111111111111111111111111111111111",
+            "weight": 1,
+          },
+        ],
+        "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "threshold": 1,
+        "version": "0x1",
+      }
+    `)
+    expect(MultisigConfig.fromRpc(rpc)).toStrictEqual({
+      ...config,
+      version: 1n,
+    })
   })
 })
 
 describe('getAddress', () => {
-  test('matches independent ground truth', () => {
-    expect(MultisigConfig.getAddress(singleOwnerConfig)).toMatchInlineSnapshot(
+  test('example: matches the frozen version-0 vector', () => {
+    expect(account).toMatchInlineSnapshot(
       `"0x8820d1497eeaf4f68e00b2cfc00a2f3b1dbb00da"`,
     )
   })
 
-  test('matches independent ground truth (salt + weights)', () => {
+  test('behavior: includes salt, threshold, and owners', () => {
     expect(
       MultisigConfig.getAddress({
+        owners: [
+          { owner: owner_1, weight: 1 },
+          { owner: owner_2, weight: 2 },
+        ],
         salt: `0x${'42'.repeat(32)}`,
         threshold: 2,
-        owners: [
-          { owner: owner1, weight: 1 },
-          { owner: owner2, weight: 2 },
-        ],
       }),
     ).toMatchInlineSnapshot(`"0x0773e28146400643e42cb28f6659b74e7c0b451d"`)
   })
 
-  test('is stable across calls', () => {
-    expect(MultisigConfig.getAddress(singleOwnerConfig)).toBe(
-      MultisigConfig.getAddress(singleOwnerConfig),
-    )
-  })
-
-  test('differs for a different salt', () => {
-    expect(MultisigConfig.getAddress(singleOwnerConfig)).not.toBe(
-      MultisigConfig.getAddress({
-        ...singleOwnerConfig,
-        salt: `0x${'42'.repeat(32)}`,
-      }),
-    )
-  })
-
-  test('address is chain-independent', () => {
-    // Derivation does not include chain ID; identical config → identical address.
-    const a = MultisigConfig.getAddress(singleOwnerConfig)
-    const b = MultisigConfig.getAddress(MultisigConfig.from(singleOwnerConfig))
-    expect(a).toBe(b)
-  })
-
-  test('throws on invalid config', () => {
+  test('error: rejects a current configuration', () => {
     expect(() =>
-      MultisigConfig.getAddress({
-        threshold: 5,
-        owners: singleOwnerConfig.owners,
-      }),
-    ).toThrowError()
+      MultisigConfig.getAddress({ ...config, version: 1n }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[MultisigConfig.InvalidConfigError: Invalid native multisig config: account address requires version zero.]`,
+    )
+  })
+})
+
+describe('getCommitment', () => {
+  test('example: matches the frozen initial and current vectors', () => {
+    expect({
+      current: MultisigConfig.getCommitment({ ...config, version: 1n }),
+      initial: MultisigConfig.getCommitment(config),
+    }).toMatchInlineSnapshot(`
+      {
+        "current": "0x6237ca5930f2265d4fb70a0305dd6ceea4df227053b4a62c304489ede946a2f8",
+        "initial": "0xa9e7d1e2ad25e227a4de5f38f3bba31d854ffc8efec46aaa8649097a516bb4ee",
+      }
+    `)
   })
 })
 
 describe('getSignPayload', () => {
-  test('matches independent ground truth', () => {
+  test('example: matches the frozen version-0 vector', () => {
     expect(
-      MultisigConfig.getSignPayload({
-        payload: `0x${'42'.repeat(32)}`,
-        initialConfig: singleOwnerConfig,
-      }),
+      MultisigConfig.getSignPayload({ account, config, payload }),
     ).toMatchInlineSnapshot(
       `"0xbf944a7a752b2cfab0418d5fb4591c5a7ff62976488edce11794d7f35fb34f41"`,
     )
   })
 
-  test('behavior: `initialConfig` and `{ account }` produce identical digests', () => {
-    const account = MultisigConfig.getAddress(singleOwnerConfig)
-    const payload = `0x${'42'.repeat(32)}` as const
+  test('behavior: binds the configuration version', () => {
     expect(
       MultisigConfig.getSignPayload({
+        account,
+        config: { version: 1n },
         payload,
-        initialConfig: singleOwnerConfig,
       }),
-    ).toBe(MultisigConfig.getSignPayload({ payload, account }))
-  })
-
-  test('differs for a different config version', () => {
-    const value = {
-      payload: `0x${'42'.repeat(32)}` as const,
-      initialConfig: singleOwnerConfig,
-    }
-    expect(MultisigConfig.getSignPayload(value)).not.toBe(
-      MultisigConfig.getSignPayload({ ...value, version: 1n }),
-    )
-  })
-
-  test('defaults the config version to zero', () => {
-    const value = {
-      payload: `0x${'42'.repeat(32)}` as const,
-      initialConfig: singleOwnerConfig,
-    }
-    expect(MultisigConfig.getSignPayload(value)).toBe(
-      MultisigConfig.getSignPayload({ ...value, version: 0n }),
-    )
+    ).not.toBe(MultisigConfig.getSignPayload({ account, config, payload }))
   })
 })
 
-describe('toTuple / fromTuple', () => {
-  test('round-trips', () => {
-    const config = MultisigConfig.from({
-      threshold: 3,
+describe('toTuple/fromTuple', () => {
+  test('example: matches the frozen initial and current RLP vectors', () => {
+    expect({
+      current: Rlp.fromHex(MultisigConfig.toTuple({ ...config, version: 1n })),
+      initial: Rlp.fromHex(MultisigConfig.toTuple(config)),
+    }).toMatchInlineSnapshot(`
+      {
+        "current": "0xf83ba000000000000000000000000000000000000000000000000000000000000000000101d7d694111111111111111111111111111111111111111101",
+        "initial": "0xf83ba000000000000000000000000000000000000000000000000000000000000000008001d7d694111111111111111111111111111111111111111101",
+      }
+    `)
+  })
+
+  test('behavior: round trips the complete witness', () => {
+    const current = MultisigConfig.from({
       owners: [
-        { owner: owner1, weight: 1 },
-        { owner: owner2, weight: 2 },
+        { owner: owner_1, weight: 1 },
+        { owner: owner_2, weight: 2 },
       ],
-    })
-    const tuple = MultisigConfig.toTuple(config)
-    expect(MultisigConfig.fromTuple(tuple)).toEqual(config)
-  })
-
-  test('encodes each owner as `[owner, weight]`', () => {
-    const [, , owners] = MultisigConfig.toTuple(singleOwnerConfig)
-    expect(owners[0]).toEqual([owner1, '0x1'])
-  })
-
-  test('encodes salt as a full 32-byte string (first element)', () => {
-    const [salt] = MultisigConfig.toTuple(singleOwnerConfig)
-    expect(salt).toBe(MultisigConfig.zeroSalt)
-  })
-
-  test('round-trips a non-zero salt', () => {
-    const config = MultisigConfig.from({
-      ...singleOwnerConfig,
       salt: `0x${'42'.repeat(32)}`,
+      threshold: 3,
+      version: 1n,
     })
-    const tuple = MultisigConfig.toTuple(config)
-    expect(tuple[0]).toBe(`0x${'42'.repeat(32)}`)
-    expect(MultisigConfig.fromTuple(tuple)).toEqual(config)
+    expect(
+      MultisigConfig.fromTuple(MultisigConfig.toTuple(current)),
+    ).toStrictEqual(current)
   })
 })
 
-describe('assert / validate', () => {
-  test('valid config', () => {
-    expect(MultisigConfig.validate(singleOwnerConfig)).toBe(true)
+describe('assert/validate', () => {
+  test('example: matches the frozen 48-owner boundary vector', () => {
+    const boundary = MultisigConfig.from({
+      owners: Array.from({ length: 48 }, (_, index) => ({
+        owner: `0x${(index + 1).toString(16).padStart(40, '0')}` as const,
+        weight: 1,
+      })),
+      threshold: 8,
+    })
+    const rlp = Rlp.fromHex(MultisigConfig.toTuple(boundary))
+    expect({
+      account: MultisigConfig.getAddress(boundary),
+      commitment: MultisigConfig.getCommitment(boundary),
+      rlpHash: Hash.keccak256(rlp),
+      rlpLength: Hex.size(rlp),
+      valid: MultisigConfig.validate(boundary),
+    }).toMatchInlineSnapshot(`
+      {
+        "account": "0x6c67c57e0eed05341137dbf88e4e7a90dc46ef50",
+        "commitment": "0x0dc47a7ab45ffa21a01bfd115427e26617b5a57d7ccbea57db2fd4537ba96f56",
+        "rlpHash": "0xbaf0d030add91caaa10815d2e99c942f1e39b0d199216973781adb4fc1af6955",
+        "rlpLength": 1145,
+        "valid": true,
+      }
+    `)
   })
 
-  test('empty owners', () => {
-    expect(MultisigConfig.validate({ threshold: 1, owners: [] })).toBe(false)
-  })
-
-  test('accepts 48 owners', () => {
-    const owners = Array.from({ length: 48 }, (_, i) => ({
-      owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
-      weight: 1,
-    }))
+  test('behavior: accepts the uint8 weight boundary', () => {
     expect(
       MultisigConfig.validate({
-        threshold: MultisigConfig.maxSignatures,
-        owners,
-      }),
-    ).toBe(true)
-  })
-
-  test('too many owners', () => {
-    const owners = Array.from({ length: 49 }, (_, i) => ({
-      owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
-      weight: 1,
-    }))
-    expect(MultisigConfig.validate({ threshold: 1, owners })).toBe(false)
-  })
-
-  test('zero threshold', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: 0,
-        owners: singleOwnerConfig.owners,
-      }),
-    ).toBe(false)
-  })
-
-  test('accepts a uint8 threshold above the signature limit', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: 9,
-        owners: [{ owner: owner1, weight: 9 }],
-      }),
-    ).toBe(true)
-  })
-
-  test('accepts the maximum uint8 threshold', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: MultisigConfig.maxThreshold,
-        owners: [{ owner: owner1, weight: MultisigConfig.maxThreshold }],
-      }),
-    ).toBe(true)
-  })
-
-  test('threshold exceeds uint8 maximum', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: MultisigConfig.maxThreshold + 1,
-        owners: [{ owner: owner1, weight: MultisigConfig.maxThreshold }],
-      }),
-    ).toBe(false)
-  })
-
-  test('fractional threshold', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: 1.5,
-        owners: [{ owner: owner1, weight: 2 }],
-      }),
-    ).toBe(false)
-  })
-
-  test('threshold exceeds total weight', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: 2,
-        owners: singleOwnerConfig.owners,
-      }),
-    ).toBe(false)
-  })
-
-  test('threshold cannot require more than eight owners', () => {
-    const owners = Array.from({ length: 9 }, (_, i) => ({
-      owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
-      weight: 1,
-    }))
-    expect(MultisigConfig.validate({ threshold: 9, owners })).toBe(false)
-  })
-
-  test('threshold can be reached by eight of more than eight owners', () => {
-    const owners = Array.from({ length: 9 }, (_, i) => ({
-      owner: `0x${(i + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
-      weight: i === 0 ? 2 : 1,
-    }))
-    expect(MultisigConfig.validate({ threshold: 9, owners })).toBe(true)
-  })
-
-  test('total weight exceeds u8 max', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: MultisigConfig.maxThreshold,
         owners: [
-          { owner: owner1, weight: 128 },
-          { owner: owner2, weight: 128 },
+          { owner: owner_1, weight: 128 },
+          { owner: owner_2, weight: 127 },
         ],
+        threshold: 255,
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
-  test('zero owner weight', () => {
-    expect(
-      MultisigConfig.validate({
+  test.each([
+    { config: { owners: [], threshold: 1 }, name: 'empty owners' },
+    {
+      config: {
+        owners: Array.from({ length: 49 }, (_, index) => ({
+          owner: `0x${(index + 1).toString(16).padStart(40, '0')}` as const,
+          weight: 1,
+        })),
         threshold: 1,
-        owners: [{ owner: owner1, weight: 0 }],
-      }),
-    ).toBe(false)
-  })
-
-  test('fractional owner weight', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: 1,
-        owners: [{ owner: owner1, weight: 1.5 }],
-      }),
-    ).toBe(false)
-  })
-
-  test('zero owner address', () => {
-    expect(
-      MultisigConfig.validate({
-        threshold: 1,
+      },
+      name: '49 owners',
+    },
+    {
+      config: { owners: config.owners, threshold: 0 },
+      name: 'zero threshold',
+    },
+    {
+      config: {
         owners: [
           {
-            owner: '0x0000000000000000000000000000000000000000',
+            owner: '0x0000000000000000000000000000000000000000' as const,
             weight: 1,
           },
         ],
-      }),
-    ).toBe(false)
-  })
-
-  test('unsorted owners', () => {
-    expect(
-      MultisigConfig.validate({
         threshold: 1,
-        owners: [
-          { owner: owner2, weight: 1 },
-          { owner: owner1, weight: 1 },
-        ],
-      }),
-    ).toBe(false)
-  })
-
-  test('duplicate owners', () => {
-    expect(
-      MultisigConfig.validate({
+      },
+      name: 'zero owner',
+    },
+    {
+      config: {
+        owners: [{ owner: owner_1, weight: 0 }],
         threshold: 1,
+      },
+      name: 'zero weight',
+    },
+    {
+      config: {
         owners: [
-          { owner: owner1, weight: 1 },
-          { owner: owner1, weight: 1 },
+          { owner: owner_1, weight: 1 },
+          { owner: owner_1, weight: 1 },
         ],
-      }),
-    ).toBe(false)
+        threshold: 1,
+      },
+      name: 'duplicate owner',
+    },
+    {
+      config: {
+        owners: [
+          { owner: owner_2, weight: 1 },
+          { owner: owner_1, weight: 1 },
+        ],
+        threshold: 1,
+      },
+      name: 'unsorted owners',
+    },
+    {
+      config: {
+        owners: [
+          { owner: owner_1, weight: 128 },
+          { owner: owner_2, weight: 128 },
+        ],
+        threshold: 255,
+      },
+      name: 'weight overflow',
+    },
+    {
+      config: {
+        owners: Array.from({ length: 9 }, (_, index) => ({
+          owner:
+            `0x${(index + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
+          weight: 1,
+        })),
+        threshold: 9,
+      },
+      name: 'unreachable threshold',
+    },
+    {
+      config: { ...config, salt: '0x42' as const },
+      name: 'short salt',
+    },
+    {
+      config: { ...config, version: -1n },
+      name: 'negative version',
+    },
+    {
+      config: { ...config, version: MultisigConfig.maxVersion + 1n },
+      name: 'version overflow',
+    },
+  ])('error: rejects $name', ({ config }) => {
+    expect(MultisigConfig.validate(config as MultisigConfig.Input)).toBe(false)
   })
+})
 
-  test('invalid salt size', () => {
-    expect(
-      MultisigConfig.validate({
-        ...singleOwnerConfig,
-        salt: '0x42',
-      }),
-    ).toBe(false)
-  })
+test('exports', () => {
+  expect(Object.keys(MultisigConfig)).toMatchInlineSnapshot(`
+    [
+      "maxNestingDepth",
+      "maxOwnerSignatureBytes",
+      "maxOwners",
+      "maxSignatures",
+      "maxThreshold",
+      "maxVersion",
+      "signatureTypeByte",
+      "zeroSalt",
+      "assert",
+      "from",
+      "fromRpc",
+      "fromTuple",
+      "getAddress",
+      "getCommitment",
+      "getSignPayload",
+      "toRpc",
+      "toTuple",
+      "validate",
+      "InvalidConfigError",
+    ]
+  `)
 })

--- a/src/tempo/MultisigConfig.test.ts
+++ b/src/tempo/MultisigConfig.test.ts
@@ -40,9 +40,9 @@ describe('from', () => {
     `)
   })
 
-  test('behavior: preserves a current configuration version', () => {
+  test('behavior: normalizes a numeric configuration version', () => {
     expect(
-      MultisigConfig.from({ ...config, version: 1n }),
+      MultisigConfig.from({ ...config, version: 1 }),
     ).toMatchInlineSnapshot(`
       {
         "owners": [
@@ -63,6 +63,14 @@ describe('from', () => {
       MultisigConfig.from({ owners: [], threshold: 0 }),
     ).toThrowErrorMatchingInlineSnapshot(
       `[MultisigConfig.InvalidConfigError: Invalid native multisig config: owners cannot be empty.]`,
+    )
+  })
+
+  test('error: rejects an invalid numeric version', () => {
+    expect(() =>
+      MultisigConfig.from({ ...config, version: 1.5 }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[MultisigConfig.InvalidConfigError: Invalid native multisig config: version must be an unsigned 64-bit integer.]`,
     )
   })
 })
@@ -117,16 +125,22 @@ describe('getAddress', () => {
       `[MultisigConfig.InvalidConfigError: Invalid native multisig config: account address requires version zero.]`,
     )
   })
+
+  test('behavior: accepts numeric zero for an initial configuration', () => {
+    expect(MultisigConfig.getAddress({ ...config, version: 0 })).toBe(account)
+  })
 })
 
 describe('getCommitment', () => {
   test('example: matches the frozen initial and current vectors', () => {
     expect({
       current: MultisigConfig.getCommitment({ ...config, version: 1n }),
+      currentNumber: MultisigConfig.getCommitment({ ...config, version: 1 }),
       initial: MultisigConfig.getCommitment(config),
     }).toMatchInlineSnapshot(`
       {
         "current": "0x6237ca5930f2265d4fb70a0305dd6ceea4df227053b4a62c304489ede946a2f8",
+        "currentNumber": "0x6237ca5930f2265d4fb70a0305dd6ceea4df227053b4a62c304489ede946a2f8",
         "initial": "0xa9e7d1e2ad25e227a4de5f38f3bba31d854ffc8efec46aaa8649097a516bb4ee",
       }
     `)
@@ -146,7 +160,7 @@ describe('getSignPayload', () => {
     expect(
       MultisigConfig.getSignPayload({
         account,
-        config: { version: 1n },
+        config: { version: 1 },
         payload,
       }),
     ).not.toBe(MultisigConfig.getSignPayload({ account, config, payload }))
@@ -306,8 +320,20 @@ describe('assert/validate', () => {
       name: 'negative version',
     },
     {
+      config: { ...config, version: -1 },
+      name: 'negative numeric version',
+    },
+    {
       config: { ...config, version: MultisigConfig.maxVersion + 1n },
       name: 'version overflow',
+    },
+    {
+      config: { ...config, version: 1.5 },
+      name: 'fractional numeric version',
+    },
+    {
+      config: { ...config, version: Number.MAX_SAFE_INTEGER + 1 },
+      name: 'unsafe numeric version',
     },
   ])('error: rejects $name', ({ config }) => {
     expect(MultisigConfig.validate(config as MultisigConfig.Input)).toBe(false)

--- a/src/tempo/MultisigConfig.ts
+++ b/src/tempo/MultisigConfig.ts
@@ -56,7 +56,10 @@ export type Config<bigintType = bigint, numberType = number> = Compute<{
 }>
 
 /** Input accepted when constructing a native multisig configuration. */
-export type Input<bigintType = bigint, numberType = number> = Compute<{
+export type Input<
+  versionType extends bigint | number = bigint | number,
+  numberType = number,
+> = Compute<{
   /** Weighted owner list (strictly ascending by `owner` address). */
   owners: readonly Owner<numberType>[]
   /**
@@ -66,8 +69,8 @@ export type Input<bigintType = bigint, numberType = number> = Compute<{
   salt?: Hex.Hex | undefined
   /** Minimum total owner weight required to authorize a transaction. */
   threshold: numberType
-  /** Configuration version. Defaults to `0n` for an initial configuration. */
-  version?: bigintType | undefined
+  /** Configuration version as a safe integer or bigint. Defaults to `0n`. */
+  version?: versionType | undefined
 }>
 
 /** Native multisig owner entry. */
@@ -112,9 +115,10 @@ export type Tuple = readonly [
  *
  * @param config - The multisig config.
  */
-export function assert<bigintType = bigint, numberType = number>(
-  config: Input<bigintType, numberType>,
-): void {
+export function assert<
+  versionType extends bigint | number = bigint | number,
+  numberType = number,
+>(config: Input<versionType, numberType>): void {
   const { owners, salt, threshold, version = 0n } = config
 
   if (typeof salt !== 'undefined' && Hex.size(salt) !== 32)
@@ -203,17 +207,22 @@ export declare namespace assert {
  * @returns The normalized multisig config.
  */
 export function from<numberType = number>(
-  config: Input<0n, numberType>,
+  config: Input<0 | 0n, numberType> & { version?: 0 | 0n | undefined },
 ): Config<0n, numberType>
 export function from<bigintType extends bigint, numberType = number>(
   config: Input<bigintType, numberType> & { version: bigintType },
 ): Config<bigintType, numberType>
-export function from<bigintType extends bigint = bigint, numberType = number>(
-  config: Input<bigintType, numberType>,
-): Config<bigintType, numberType>
-export function from<bigintType extends bigint = bigint, numberType = number>(
-  config: Input<bigintType, numberType>,
-): Config<bigintType, numberType> {
+export function from<numberType = number>(
+  config: Input<number, numberType> & { version: number },
+): Config<bigint, numberType>
+export function from<numberType = number>(
+  config: Input<bigint | number, numberType>,
+): Config<bigint, numberType>
+export function from<numberType = number>(
+  config: Input<bigint | number, numberType>,
+): Config<bigint, numberType> {
+  const version = config.version ?? 0n
+  assertVersion(version)
   const owners = [...config.owners].sort((a, b) =>
     Hex.toBigInt(a.owner) < Hex.toBigInt(b.owner) ? -1 : 1,
   )
@@ -221,8 +230,8 @@ export function from<bigintType extends bigint = bigint, numberType = number>(
     owners,
     salt: config.salt ? Hex.padLeft(config.salt, 32) : zeroSalt,
     threshold: config.threshold,
-    version: (config.version ?? 0n) as bigintType,
-  } as Config<bigintType, numberType>
+    version: BigInt(version),
+  } as Config<bigint, numberType>
   assert(normalized)
   return normalized
 }
@@ -324,7 +333,7 @@ export function fromTuple(tuple: Tuple): Config {
  */
 export function getAddress(config: Input): Address.Address {
   assert(config)
-  if ((config.version ?? 0n) !== 0n)
+  if (BigInt(config.version ?? 0) !== 0n)
     throw new InvalidConfigError({
       reason: 'account address requires version zero',
     })
@@ -469,7 +478,7 @@ export declare namespace getSignPayload {
     /** The native multisig account address. */
     account: Address.Address
     /** Configuration whose version applies to the approval. */
-    config: Pick<Config, 'version'>
+    config: Pick<Config<bigint | number>, 'version'>
     /** The inner transaction sign payload (`tx.signature_hash()`). */
     payload: Hex.Hex | Bytes.Bytes
   }
@@ -551,9 +560,10 @@ export function toTuple(config: Input): Tuple {
   // `salt` is a fixed 32-byte value: it RLP-encodes as a full 32-byte string
   // (including the zero salt), never trimmed like an integer.
   const salt = config.salt ? Hex.padLeft(config.salt, 32) : zeroSalt
+  const version = BigInt(config.version ?? 0)
   return [
     salt,
-    (config.version ?? 0n) === 0n ? '0x' : Hex.fromNumber(config.version ?? 0n),
+    version === 0n ? '0x' : Hex.fromNumber(version),
     Hex.fromNumber(config.threshold),
     owners,
   ] as const
@@ -597,8 +607,13 @@ export class InvalidConfigError extends Errors.BaseError {
 }
 
 /** Asserts that a configuration version fits the protocol's `uint64`. */
-function assertVersion(version: unknown): asserts version is bigint {
-  if (typeof version !== 'bigint' || version < 0n || version > maxVersion)
+function assertVersion(version: unknown): asserts version is bigint | number {
+  if (
+    (typeof version !== 'bigint' && typeof version !== 'number') ||
+    (typeof version === 'number' && !Number.isSafeInteger(version)) ||
+    BigInt(version) < 0n ||
+    BigInt(version) > maxVersion
+  )
     throw new InvalidConfigError({
       reason: 'version must be an unsigned 64-bit integer',
     })

--- a/src/tempo/MultisigConfig.ts
+++ b/src/tempo/MultisigConfig.ts
@@ -218,6 +218,7 @@ export function from<numberType = number>(
 export function from<numberType = number>(
   config: Input<bigint | number, numberType>,
 ): Config<bigint, numberType>
+// eslint-disable-next-line jsdoc/require-jsdoc
 export function from<numberType = number>(
   config: Input<bigint | number, numberType>,
 ): Config<bigint, numberType> {
@@ -606,7 +607,7 @@ export class InvalidConfigError extends Errors.BaseError {
   }
 }
 
-/** Asserts that a configuration version fits the protocol's `uint64`. */
+/** @internal */
 function assertVersion(version: unknown): asserts version is bigint | number {
   if (
     (typeof version !== 'bigint' && typeof version !== 'number') ||

--- a/src/tempo/MultisigConfig.ts
+++ b/src/tempo/MultisigConfig.ts
@@ -3,16 +3,7 @@ import type * as Bytes from '../core/Bytes.js'
 import * as Errors from '../core/Errors.js'
 import * as Hash from '../core/Hash.js'
 import * as Hex from '../core/Hex.js'
-import type { Compute, OneOf } from '../core/internal/types.js'
-
-/** Maximum number of owners allowed in a native multisig config. */
-export const maxOwners = 48
-
-/** Maximum threshold accepted by a native multisig config. */
-export const maxThreshold = 0xff
-
-/** Maximum number of owner approvals in a native multisig signature. */
-export const maxSignatures = 8
+import type { Compute } from '../core/internal/types.js'
 
 /**
  * Maximum number of native multisig signatures in one nested authorization
@@ -23,6 +14,18 @@ export const maxNestingDepth = 2
 /** Maximum encoded byte length for one primitive owner approval. */
 export const maxOwnerSignatureBytes = 2049
 
+/** Maximum number of owners allowed in a native multisig config. */
+export const maxOwners = 48
+
+/** Maximum number of owner approvals in a native multisig signature. */
+export const maxSignatures = 8
+
+/** Maximum threshold accepted by a native multisig config. */
+export const maxThreshold = 0xff
+
+/** Maximum version accepted by a native multisig config. */
+export const maxVersion = 2n ** 64n - 1n
+
 /** Tempo signature type byte for native multisig signatures. */
 export const signatureTypeByte = '0x05' as const
 
@@ -32,14 +35,30 @@ export const zeroSalt = `0x${'00'.repeat(32)}` as const
 /** Domain prefix for the native multisig account address derivation. */
 const accountDomain = 'tempo:multisig:account'
 
+/** Domain prefix for native multisig configuration commitments. */
+const configDomain = 'tempo:multisig:config'
+
 /** Domain prefix for native multisig owner approvals. */
 const signatureDomain = 'tempo:multisig:signature'
 
 /**
- * Native multisig configuration. Determines the stable multisig account
- * address.
+ * Complete native multisig configuration witness.
  */
-export type Config<numberType = number> = Compute<{
+export type Config<bigintType = bigint, numberType = number> = Compute<{
+  /** Weighted owner list, strictly ascending by owner address. */
+  owners: readonly Owner<numberType>[]
+  /** Caller-chosen 32-byte salt. */
+  salt: Hex.Hex
+  /** Minimum total owner weight required for authorization. */
+  threshold: numberType
+  /** Configuration version. Zero identifies the initial configuration. */
+  version: bigintType
+}>
+
+/** Input accepted when constructing a native multisig configuration. */
+export type Input<bigintType = bigint, numberType = number> = Compute<{
+  /** Weighted owner list (strictly ascending by `owner` address). */
+  owners: readonly Owner<numberType>[]
   /**
    * Caller-chosen 32-byte salt mixed into the derived account address.
    * Defaults to the zero salt (`MultisigConfig.zeroSalt`) when omitted.
@@ -47,8 +66,8 @@ export type Config<numberType = number> = Compute<{
   salt?: Hex.Hex | undefined
   /** Minimum total owner weight required to authorize a transaction. */
   threshold: numberType
-  /** Weighted owner list (strictly ascending by `owner` address). */
-  owners: readonly Owner<numberType>[]
+  /** Configuration version. Defaults to `0n` for an initial configuration. */
+  version?: bigintType | undefined
 }>
 
 /** Native multisig owner entry. */
@@ -59,9 +78,13 @@ export type Owner<numberType = number> = {
   weight: numberType
 }
 
+/** JSON-RPC representation of a native multisig configuration. */
+export type Rpc = Config<Hex.Hex, number>
+
 /** RLP tuple representation of a {@link ox#MultisigConfig.Config}. */
 export type Tuple = readonly [
   salt: Hex.Hex,
+  version: Hex.Hex,
   threshold: Hex.Hex,
   owners: readonly Hex.Hex[][],
 ]
@@ -69,7 +92,7 @@ export type Tuple = readonly [
 /**
  * Asserts that a native multisig {@link ox#MultisigConfig.Config} is valid.
  *
- * Mirrors the Tempo `InitMultisig::validate` rules: owners non-empty and
+ * Mirrors the Tempo configuration rules: owners non-empty and
  * `<= maxOwners`, strictly ascending unique nonzero owner addresses, nonzero
  * integer owner weights, integer `threshold` between `1` and `maxThreshold`,
  * total weight `<= 255` (u8 max), and a threshold reachable by at most
@@ -89,11 +112,14 @@ export type Tuple = readonly [
  *
  * @param config - The multisig config.
  */
-export function assert<numberType = number>(config: Config<numberType>): void {
-  const { salt, threshold, owners } = config
+export function assert<bigintType = bigint, numberType = number>(
+  config: Input<bigintType, numberType>,
+): void {
+  const { owners, salt, threshold, version = 0n } = config
 
   if (typeof salt !== 'undefined' && Hex.size(salt) !== 32)
     throw new InvalidConfigError({ reason: 'salt must be 32 bytes' })
+  assertVersion(version)
   if (owners.length === 0)
     throw new InvalidConfigError({ reason: 'owners cannot be empty' })
   if (owners.length > maxOwners)
@@ -164,11 +190,11 @@ export declare namespace assert {
  * import { MultisigConfig } from 'ox/tempo'
  *
  * const config = MultisigConfig.from({
- *   threshold: 2,
  *   owners: [
  *     { owner: '0x2222222222222222222222222222222222222222', weight: 1 },
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
+ *   threshold: 2,
  * })
  * // owners are now sorted ascending by address
  * ```
@@ -177,18 +203,62 @@ export declare namespace assert {
  * @returns The normalized multisig config.
  */
 export function from<numberType = number>(
-  config: Config<numberType>,
-): Config<numberType> {
+  config: Input<0n, numberType>,
+): Config<0n, numberType>
+export function from<bigintType extends bigint, numberType = number>(
+  config: Input<bigintType, numberType> & { version: bigintType },
+): Config<bigintType, numberType>
+export function from<bigintType extends bigint = bigint, numberType = number>(
+  config: Input<bigintType, numberType>,
+): Config<bigintType, numberType>
+export function from<bigintType extends bigint = bigint, numberType = number>(
+  config: Input<bigintType, numberType>,
+): Config<bigintType, numberType> {
   const owners = [...config.owners].sort((a, b) =>
     Hex.toBigInt(a.owner) < Hex.toBigInt(b.owner) ? -1 : 1,
   )
   const normalized = {
+    owners,
     salt: config.salt ? Hex.padLeft(config.salt, 32) : zeroSalt,
     threshold: config.threshold,
-    owners,
-  } as Config<numberType>
+    version: (config.version ?? 0n) as bigintType,
+  } as Config<bigintType, numberType>
   assert(normalized)
   return normalized
+}
+
+/**
+ * Converts a JSON-RPC multisig configuration to its domain representation.
+ *
+ * @example
+ * ```ts twoslash
+ * import { MultisigConfig } from 'ox/tempo'
+ *
+ * const config = MultisigConfig.fromRpc({
+ *   owners: [
+ *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
+ *   ],
+ *   salt: `0x${'00'.repeat(32)}`,
+ *   threshold: 1,
+ *   version: '0x0',
+ * })
+ * ```
+ *
+ * @param config - The JSON-RPC multisig configuration.
+ * @returns The normalized multisig configuration.
+ */
+export function fromRpc(config: Rpc): Config {
+  return from({
+    ...config,
+    version: Hex.toBigInt(config.version),
+  })
+}
+
+export declare namespace fromRpc {
+  type ErrorType =
+    | assert.ErrorType
+    | Hex.toBigInt.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -201,6 +271,7 @@ export function from<numberType = number>(
  *
  * const config = MultisigConfig.fromTuple([
  *   `0x${'00'.repeat(32)}`,
+ *   '0x',
  *   '0x01',
  *   [['0x1111111111111111111111111111111111111111', '0x01']],
  * ])
@@ -210,10 +281,8 @@ export function from<numberType = number>(
  * @returns The multisig config.
  */
 export function fromTuple(tuple: Tuple): Config {
-  const [salt, threshold, owners] = tuple
+  const [salt, version, threshold, owners] = tuple
   return {
-    salt: salt && salt !== '0x' ? Hex.padLeft(salt, 32) : zeroSalt,
-    threshold: threshold === '0x' ? 0 : Hex.toNumber(threshold),
     owners: owners.map((owner) => {
       const [ownerAddress, weight] = owner as readonly Hex.Hex[]
       return {
@@ -221,6 +290,9 @@ export function fromTuple(tuple: Tuple): Config {
         weight: !weight || weight === '0x' ? 0 : Hex.toNumber(weight),
       }
     }),
+    salt: salt && salt !== '0x' ? Hex.padLeft(salt, 32) : zeroSalt,
+    threshold: threshold === '0x' ? 0 : Hex.toNumber(threshold),
+    version: version === '0x' ? 0n : Hex.toBigInt(version),
   }
 }
 
@@ -230,28 +302,32 @@ export function fromTuple(tuple: Tuple): Config {
  * Preimage (fixed-width big-endian, **not** RLP):
  * `keccak256("tempo:multisig:account" || salt || u8(threshold) || u8(owners.length) || (owner || u8(weight)) for each owner)[12:32]`.
  *
- * The address is derived once from the initial (bootstrap) config and never
- * changes — config updates do not affect it.
+ * The address is derived once from the initial version-0 config. Config
+ * updates do not change it.
  *
  * @example
  * ```ts twoslash
  * import { MultisigConfig } from 'ox/tempo'
  *
  * const initialConfig = MultisigConfig.from({
- *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
+ *   threshold: 1,
  * })
  *
  * const address = MultisigConfig.getAddress(initialConfig)
  * ```
  *
- * @param config - The initial (bootstrap) multisig config.
+ * @param config - The initial multisig config.
  * @returns The multisig account address.
  */
-export function getAddress(config: Config): Address.Address {
+export function getAddress(config: Input): Address.Address {
   assert(config)
+  if ((config.version ?? 0n) !== 0n)
+    throw new InvalidConfigError({
+      reason: 'account address requires version zero',
+    })
   const hash = Hash.keccak256(
     Hex.concat(
       Hex.fromString(accountDomain),
@@ -267,6 +343,10 @@ export function getAddress(config: Config): Address.Address {
   const account = Address.from(Hex.slice(hash, 12, 32))
   if (Hex.toBigInt(account) === 0n)
     throw new InvalidConfigError({ reason: 'derived account cannot be zero' })
+  if (config.owners.some((owner) => Address.isEqual(owner.owner, account)))
+    throw new InvalidConfigError({
+      reason: 'derived account cannot be an owner',
+    })
   return account
 }
 
@@ -283,15 +363,64 @@ export declare namespace getAddress {
 }
 
 /**
+ * Computes the commitment for a native multisig configuration.
+ *
+ * The commitment uses raw fixed-width fields, not RLP or ABI encoding:
+ * `keccak256("tempo:multisig:config" || salt || uint64be(version) || uint8(threshold) || uint8(owners.length) || owners)`.
+ *
+ * @example
+ * ```ts twoslash
+ * import { MultisigConfig } from 'ox/tempo'
+ *
+ * const commitment = MultisigConfig.getCommitment({
+ *   owners: [
+ *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
+ *   ],
+ *   threshold: 1,
+ *   version: 1n,
+ * })
+ * ```
+ *
+ * @param config - The complete multisig configuration.
+ * @returns The configuration commitment.
+ */
+export function getCommitment(config: Input): Hex.Hex {
+  assert(config)
+  return Hash.keccak256(
+    Hex.concat(
+      Hex.fromString(configDomain),
+      Hex.padLeft(config.salt ?? zeroSalt, 32),
+      Hex.fromNumber(config.version ?? 0n, { size: 8 }),
+      Hex.fromNumber(config.threshold, { size: 1 }),
+      Hex.fromNumber(config.owners.length, { size: 1 }),
+      ...config.owners.flatMap((owner) => [
+        owner.owner,
+        Hex.fromNumber(owner.weight, { size: 1 }),
+      ]),
+    ),
+  )
+}
+
+export declare namespace getCommitment {
+  type ErrorType =
+    | assert.ErrorType
+    | Hash.keccak256.ErrorType
+    | Hex.concat.ErrorType
+    | Hex.fromNumber.ErrorType
+    | Hex.fromString.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Computes the digest a native multisig owner approves (signs).
  *
  * `keccak256("tempo:multisig:signature" || inner_digest || account || uint64be(version))`,
  * where `inner_digest` is the transaction sign payload
  * ({@link ox#TxEnvelopeTempo.(getSignPayload:function)}).
  *
- * The digest is keyed on the permanent `account` derived from the initial
- * (bootstrap) config and the current config `version`. Bootstrap approvals use
- * version `0n`, which is also the default; each config update increments it.
+ * The digest is keyed on the permanent `account` and the supplied config
+ * version. Initial approvals use version `0n`; each config update increments
+ * it.
  *
  * For a nested multisig owner approval, the parent digest becomes the nested
  * approval's `payload`, with the nested multisig `account`.
@@ -300,11 +429,11 @@ export declare namespace getAddress {
  * ```ts twoslash
  * import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
  *
- * const initialConfig = MultisigConfig.from({
- *   threshold: 1,
+ * const config = MultisigConfig.from({
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
+ *   threshold: 1,
  * })
  *
  * const envelope = TxEnvelopeTempo.from({
@@ -313,34 +442,9 @@ export declare namespace getAddress {
  * })
  *
  * const digest = MultisigConfig.getSignPayload({
+ *   account: MultisigConfig.getAddress(config),
+ *   config,
  *   payload: TxEnvelopeTempo.getSignPayload(envelope),
- *   initialConfig,
- * })
- * ```
- *
- * @example
- * ### From `account`
- *
- * If you already have the permanent `account` (for example, recovered from a
- * stored envelope), pass it directly:
- *
- * ```ts twoslash
- * import { MultisigConfig, TxEnvelopeTempo } from 'ox/tempo'
- *
- * const initialConfig = MultisigConfig.from({
- *   threshold: 1,
- *   owners: [
- *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
- *   ],
- * })
- * const account = MultisigConfig.getAddress(initialConfig)
- *
- * const envelope = TxEnvelopeTempo.from({ chainId: 1, calls: [] })
- *
- * const digest = MultisigConfig.getSignPayload({
- *   payload: TxEnvelopeTempo.getSignPayload(envelope),
- *   account,
- *   version: 1n
  * })
  * ```
  *
@@ -348,45 +452,30 @@ export declare namespace getAddress {
  * @returns The owner approval digest.
  */
 export function getSignPayload(value: getSignPayload.Value): Hex.Hex {
-  const { payload, version = 0n } = value
-  const account =
-    'account' in value && value.account
-      ? value.account
-      : getAddress((value as { initialConfig: Config }).initialConfig)
+  const { account, config, payload } = value
+  assertVersion(config.version)
   return Hash.keccak256(
     Hex.concat(
       Hex.fromString(signatureDomain),
       Hex.from(payload),
       account,
-      Hex.fromNumber(version, { size: 8 }),
+      Hex.fromNumber(config.version ?? 0n, { size: 8 }),
     ),
   )
 }
 
 export declare namespace getSignPayload {
   type Value = {
+    /** The native multisig account address. */
+    account: Address.Address
+    /** Configuration whose version applies to the approval. */
+    config: Pick<Config, 'version'>
     /** The inner transaction sign payload (`tx.signature_hash()`). */
     payload: Hex.Hex | Bytes.Bytes
-    /** Current multisig config version. Defaults to `0n`. */
-    version?: bigint | undefined
-  } & OneOf<
-    | {
-        /** The native multisig account address. */
-        account: Address.Address
-      }
-    | {
-        /**
-         * The initial multisig config (the bootstrap config that derived the
-         * permanent `account`). Used to derive the account automatically.
-         * Config updates never change `account`, so the initial config can
-         * continue deriving the account for post-update transactions.
-         */
-        initialConfig: Config
-      }
-  >
+  }
 
   type ErrorType =
-    | getAddress.ErrorType
+    | assert.ErrorType
     | Hash.keccak256.ErrorType
     | Hex.concat.ErrorType
     | Hex.from.ErrorType
@@ -395,10 +484,47 @@ export declare namespace getSignPayload {
 }
 
 /**
- * Converts a {@link ox#MultisigConfig.Config} to its RLP tuple form (carried
- * by the multisig signature `init`).
+ * Converts a multisig configuration to its JSON-RPC representation.
  *
- * Tuple shape: `[salt, threshold, [[owner, weight], ...]]`. The
+ * @example
+ * ```ts twoslash
+ * import { MultisigConfig } from 'ox/tempo'
+ *
+ * const config = MultisigConfig.toRpc({
+ *   owners: [
+ *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
+ *   ],
+ *   threshold: 1,
+ * })
+ * ```
+ *
+ * @param config - The multisig configuration.
+ * @returns The JSON-RPC multisig configuration.
+ */
+export function toRpc(config: Input): Rpc {
+  const value = from(config)
+  return {
+    owners: value.owners.map((owner) => ({
+      owner: owner.owner,
+      weight: Number(owner.weight),
+    })),
+    salt: value.salt,
+    threshold: Number(value.threshold),
+    version: Hex.fromNumber(value.version),
+  }
+}
+
+export declare namespace toRpc {
+  type ErrorType =
+    | assert.ErrorType
+    | Hex.fromNumber.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Converts a {@link ox#MultisigConfig.Config} to its RLP tuple form.
+ *
+ * Tuple shape: `[salt, version, threshold, [[owner, weight], ...]]`. The
  * 32-byte `salt` encodes as a full fixed-width string; other integers use
  * canonical RLP encoding (zero values encode as `0x`).
  *
@@ -407,17 +533,17 @@ export declare namespace getSignPayload {
  * import { MultisigConfig } from 'ox/tempo'
  *
  * const tuple = MultisigConfig.toTuple({
- *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
+ *   threshold: 1,
  * })
  * ```
  *
  * @param config - The multisig config.
  * @returns The RLP tuple.
  */
-export function toTuple(config: Config): Tuple {
+export function toTuple(config: Input): Tuple {
   assert(config)
   const owners = config.owners.map(
     (owner) => [owner.owner, Hex.fromNumber(owner.weight)] as Hex.Hex[],
@@ -425,7 +551,12 @@ export function toTuple(config: Config): Tuple {
   // `salt` is a fixed 32-byte value: it RLP-encodes as a full 32-byte string
   // (including the zero salt), never trimmed like an integer.
   const salt = config.salt ? Hex.padLeft(config.salt, 32) : zeroSalt
-  return [salt, Hex.fromNumber(config.threshold), owners] as const
+  return [
+    salt,
+    (config.version ?? 0n) === 0n ? '0x' : Hex.fromNumber(config.version ?? 0n),
+    Hex.fromNumber(config.threshold),
+    owners,
+  ] as const
 }
 
 /**
@@ -437,10 +568,10 @@ export function toTuple(config: Config): Tuple {
  * import { MultisigConfig } from 'ox/tempo'
  *
  * const valid = MultisigConfig.validate({
- *   threshold: 1,
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
+ *   threshold: 1,
  * })
  * // @log: true
  * ```
@@ -448,7 +579,7 @@ export function toTuple(config: Config): Tuple {
  * @param config - The multisig config.
  * @returns Whether the config is valid.
  */
-export function validate(config: Config): boolean {
+export function validate(config: Input): boolean {
   try {
     assert(config)
     return true
@@ -463,4 +594,12 @@ export class InvalidConfigError extends Errors.BaseError {
   constructor({ reason }: { reason: string }) {
     super(`Invalid native multisig config: ${reason}.`)
   }
+}
+
+/** Asserts that a configuration version fits the protocol's `uint64`. */
+function assertVersion(version: unknown): asserts version is bigint {
+  if (typeof version !== 'bigint' || version < 0n || version > maxVersion)
+    throw new InvalidConfigError({
+      reason: 'version must be an unsigned 64-bit integer',
+    })
 }

--- a/src/tempo/MultisigOperation.test-d.ts
+++ b/src/tempo/MultisigOperation.test-d.ts
@@ -48,8 +48,14 @@ test('preserves operation kinds during RPC conversion', () => {
 
 test('uses JSON-RPC quantities only in RPC operations', () => {
   expectTypeOf<
+    MultisigOperation.Operation['config']['version']
+  >().toEqualTypeOf<bigint>()
+  expectTypeOf<
     MultisigOperation.Operation['configVersion']
   >().toEqualTypeOf<bigint>()
+  expectTypeOf<
+    MultisigOperation.Rpc['config']['version']
+  >().toEqualTypeOf<Hex.Hex>()
   expectTypeOf<
     MultisigOperation.Rpc['configVersion']
   >().toEqualTypeOf<Hex.Hex>()

--- a/src/tempo/MultisigOperation.test.ts
+++ b/src/tempo/MultisigOperation.test.ts
@@ -1269,6 +1269,9 @@ describe('RPC conversion', () => {
     const transactionRpc = MultisigOperation.toRpc(transactionPending)
     const keyAuthorizationRpc = MultisigOperation.toRpc(keyAuthorizationPending)
 
+    expect(() =>
+      JSON.stringify({ keyAuthorizationRpc, transactionRpc }),
+    ).not.toThrow()
     expect({ keyAuthorizationRpc, transactionRpc }).toMatchInlineSnapshot(`
       {
         "keyAuthorizationRpc": {
@@ -1289,7 +1292,7 @@ describe('RPC conversion', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
-            "version": 1n,
+            "version": "0x1",
           },
           "configVersion": "0x1",
           "createdAt": 1,
@@ -1321,7 +1324,7 @@ describe('RPC conversion', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
-            "version": 1n,
+            "version": "0x1",
           },
           "configVersion": "0x1",
           "createdAt": 1,

--- a/src/tempo/MultisigOperation.test.ts
+++ b/src/tempo/MultisigOperation.test.ts
@@ -36,6 +36,7 @@ const config = MultisigConfig.from({
   ],
   threshold: 2,
 })
+const initializedConfig = MultisigConfig.from({ ...config, version: 1n })
 const account = MultisigConfig.getAddress(config)
 const ownerSignature_1 = owners[0]!.signature
 const approval_1 = SignatureEnvelope.serialize(ownerSignature_1)
@@ -62,23 +63,23 @@ const keyAuthorization = KeyAuthorization.serialize(
 
 const transactionHash_ = MultisigConfig.getSignPayload({
   account,
+  config: initializedConfig,
   payload: TxEnvelopeTempo.getSignPayload(
     TxEnvelopeTempo.deserialize(transaction),
   ),
-  version: 1n,
 })
 const keyAuthorizationHash = MultisigConfig.getSignPayload({
   account,
+  config: initializedConfig,
   payload: KeyAuthorization.getSignPayload(
     KeyAuthorization.deserialize(keyAuthorization),
   ),
-  version: 1n,
 })
 
 const base = {
   account,
   approvals: [approval_1],
-  config,
+  config: initializedConfig,
   configVersion: 1n,
   createdAt: 1,
   init: false,
@@ -249,8 +250,8 @@ describe('selectApprovals', () => {
     })
     const childHash = MultisigConfig.getSignPayload({
       account: child,
+      config: { version: 2n },
       payload: hash,
-      version: 2n,
     })
     const childApprovals = [
       signApproval(owners[1]!, childHash),
@@ -269,6 +270,7 @@ describe('selectApprovals', () => {
         rootApproval,
         SignatureEnvelope.serialize({
           account: child,
+          config: MultisigConfig.from({ ...childConfig, version: 2n }),
           signatures: [SignatureEnvelope.deserialize(childApprovals[0]!)],
           type: 'multisig',
         }),
@@ -283,6 +285,7 @@ describe('selectApprovals', () => {
         rootApproval,
         SignatureEnvelope.serialize({
           account: child,
+          config: MultisigConfig.from({ ...childConfig, version: 2n }),
           signatures: childApprovals.map((approval) =>
             SignatureEnvelope.deserialize(approval),
           ),
@@ -389,8 +392,8 @@ describe('selectApprovals', () => {
     })
     const childHash = MultisigConfig.getSignPayload({
       account: child,
+      config: { version: 1n },
       payload: hash,
-      version: 1n,
     })
 
     await expect(
@@ -399,6 +402,7 @@ describe('selectApprovals', () => {
         approvals: [
           SignatureEnvelope.serialize({
             account: child,
+            config: MultisigConfig.from({ ...childConfig, version: 1n }),
             signatures: [
               SignatureEnvelope.deserialize(
                 signApproval(owners[1]!, childHash),
@@ -415,7 +419,7 @@ describe('selectApprovals', () => {
     )
   })
 
-  test('rejects keychain and bootstrap nested approvals', async () => {
+  test('rejects keychain and accepts initial nested approvals', async () => {
     const childConfig = MultisigConfig.from({
       owners: [{ owner: owners[1]!.address, weight: 1 }],
       threshold: 1,
@@ -437,8 +441,8 @@ describe('selectApprovals', () => {
     })
     const childHash = MultisigConfig.getSignPayload({
       account: child,
+      config: childConfig,
       payload: hash,
-      version: 0n,
     })
 
     await expect(
@@ -459,31 +463,36 @@ describe('selectApprovals', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: keychain signatures cannot approve a multisig operation.]`,
     )
-    await expect(
-      MultisigOperation.selectApprovals({
-        account,
-        approvals: [
-          SignatureEnvelope.serialize({
-            account: child,
-            init: childConfig,
-            signatures: [
-              SignatureEnvelope.deserialize(
-                signApproval(owners[1]!, childHash),
-              ),
-            ],
-            type: 'multisig',
-          }),
-        ],
-        config,
-        hash,
-        resolveConfig: () => ({ config: childConfig, version: 0n }),
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0x7888d60e9cc26c8569d394fce435c248f1e49c3b cannot carry init.]`,
-    )
+    const selection = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [
+        SignatureEnvelope.serialize({
+          account: child,
+          config: childConfig,
+          signatures: [
+            SignatureEnvelope.deserialize(signApproval(owners[1]!, childHash)),
+          ],
+          type: 'multisig',
+        }),
+      ],
+      config,
+      hash,
+      resolveConfig: () => ({ config: childConfig, version: 0n }),
+    })
+    expect({
+      signatureCount: selection.signatureCount,
+      threshold: selection.threshold,
+      weight: selection.weight,
+    }).toMatchInlineSnapshot(`
+      {
+        "signatureCount": 1,
+        "threshold": 1,
+        "weight": 1,
+      }
+    `)
   })
 
-  test('rejects nested account cycles', async () => {
+  test('rejects nested account cycles while serializing', () => {
     const config = MultisigConfig.from({
       owners: [{ owner: account, weight: 1 }],
       threshold: 1,
@@ -496,30 +505,21 @@ describe('selectApprovals', () => {
     })
     const nestedHash = MultisigConfig.getSignPayload({
       account,
+      config: { version: 2n },
       payload: hash,
-      version: 2n,
     })
 
-    await expect(
-      MultisigOperation.selectApprovals({
+    expect(() =>
+      SignatureEnvelope.serialize({
         account,
-        approvals: [
-          SignatureEnvelope.serialize({
-            account,
-            signatures: [
-              SignatureEnvelope.deserialize(
-                signApproval(owners[0]!, nestedHash),
-              ),
-            ],
-            type: 'multisig',
-          }),
+        config: MultisigConfig.from({ ...config, version: 2n }),
+        signatures: [
+          SignatureEnvelope.deserialize(signApproval(owners[0]!, nestedHash)),
         ],
-        config,
-        hash,
-        resolveConfig: () => ({ config, version: 2n }),
+        type: 'multisig',
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0xf81b7763d3a6876195d780865bd783dbd97dd36e is invalid.]`,
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig account cannot be an owner.]`,
     )
   })
 
@@ -547,13 +547,13 @@ describe('selectApprovals', () => {
     })
     const childHash = MultisigConfig.getSignPayload({
       account: child,
+      config: { version: 1n },
       payload: hash,
-      version: 1n,
     })
     const grandchildHash = MultisigConfig.getSignPayload({
       account: grandchild,
+      config: { version: 1n },
       payload: childHash,
-      version: 1n,
     })
 
     await expect(
@@ -562,9 +562,14 @@ describe('selectApprovals', () => {
         approvals: [
           SignatureEnvelope.serialize({
             account: child,
+            config: MultisigConfig.from({ ...childConfig, version: 1n }),
             signatures: [
               {
                 account: grandchild,
+                config: MultisigConfig.from({
+                  ...grandchildConfig,
+                  version: 1n,
+                }),
                 signatures: [
                   SignatureEnvelope.deserialize(
                     signApproval(owners[2]!, grandchildHash),
@@ -632,8 +637,11 @@ describe('serializeTransaction', () => {
       const value = TxEnvelopeTempo.deserialize(serialized)
       results.push({
         account: value.signature?.account,
+        configVersion:
+          value.signature?.type === 'multisig'
+            ? value.signature.config.version
+            : undefined,
         hash: Hash.keccak256(serialized),
-        init: value.signature?.type === 'multisig' && !!value.signature.init,
         signatureCount:
           value.signature?.type === 'multisig'
             ? value.signature.signatures.length
@@ -646,15 +654,15 @@ describe('serializeTransaction', () => {
       [
         {
           "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
-          "hash": "0x704768725a4e798e2656f0f355f99507522c97b2947f551a5ee696216a2ba6fe",
-          "init": false,
+          "configVersion": 1n,
+          "hash": "0x8309740edaf304284186f7bcfe4527745cd4eb48e7441795ebdd970798091f8f",
           "signatureCount": 2,
           "type": "0x76",
         },
         {
           "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
-          "hash": "0x08131922349c385f9112fefc617fa6f6258a71df1125ec243bb3ee7cff59b700",
-          "init": true,
+          "configVersion": 0n,
+          "hash": "0x636af84d8445d87cbcd33039d5a3a2274a5911036b1b7ceb740ac41e2f638611",
           "signatureCount": 2,
           "type": "0x76",
         },
@@ -833,6 +841,7 @@ describe('from', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
+            "version": 1n,
           },
           "configVersion": 1n,
           "createdAt": 1,
@@ -865,6 +874,7 @@ describe('from', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
+            "version": 1n,
           },
           "configVersion": 1n,
           "createdAt": 1,
@@ -899,6 +909,7 @@ describe('from', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
+            "version": 1n,
           },
           "configVersion": 1n,
           "createdAt": 1,
@@ -929,10 +940,10 @@ describe('from', () => {
       ...transactionPending,
       hash: MultisigConfig.getSignPayload({
         account,
+        config: initializedConfig,
         payload: TxEnvelopeTempo.getSignPayload(
           TxEnvelopeTempo.deserialize(transaction),
         ),
-        version: 1n,
       }),
       transaction,
     })
@@ -961,6 +972,7 @@ describe('from', () => {
           ],
           "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "threshold": 2,
+          "version": 1n,
         },
         "configVersion": 1n,
         "createdAt": 1,
@@ -991,10 +1003,10 @@ describe('from', () => {
       ...transactionPending,
       hash: MultisigConfig.getSignPayload({
         account,
+        config: initializedConfig,
         payload: TxEnvelopeTempo.getSignPayload(
           TxEnvelopeTempo.deserialize(transaction),
         ),
-        version: 1n,
       }),
       transaction,
     })
@@ -1008,10 +1020,10 @@ describe('from', () => {
       configVersion: 0n,
       hash: MultisigConfig.getSignPayload({
         account,
+        config,
         payload: TxEnvelopeTempo.getSignPayload(
           TxEnvelopeTempo.deserialize(transaction),
         ),
-        version: 0n,
       }),
       init: true,
     })
@@ -1040,6 +1052,7 @@ describe('from', () => {
           ],
           "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "threshold": 2,
+          "version": 0n,
         },
         "configVersion": 0n,
         "createdAt": 1,
@@ -1063,10 +1076,10 @@ describe('from', () => {
       configVersion: 0n,
       hash: MultisigConfig.getSignPayload({
         account,
+        config,
         payload: TxEnvelopeTempo.getSignPayload(
           TxEnvelopeTempo.deserialize(transaction),
         ),
-        version: 0n,
       }),
     })
 
@@ -1091,6 +1104,7 @@ describe('from', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
+            config: initializedConfig,
             signatures: [
               SignatureEnvelope.deserialize(approval_1),
               SignatureEnvelope.deserialize(approval_2),
@@ -1124,6 +1138,7 @@ describe('from', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
+            "version": 1n,
           },
           "configVersion": 1n,
           "createdAt": 1,
@@ -1156,12 +1171,13 @@ describe('from', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
+            "version": 1n,
           },
           "configVersion": 1n,
           "createdAt": 1,
           "hash": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
           "init": false,
-          "keyAuthorization": "0xf9015ff782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36eb9012405f9012094f81b7763d3a6876195d780865bd783dbd97dd36ef90108b88201000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200b88201000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
+          "keyAuthorization": "0xf901b3f782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36eb9017805f9017494f81b7763d3a6876195d780865bd783dbd97dd36ef852a000000000000000000000000000000000000000000000000000000000000000000102eed69407e1ed8ea0e9601e5546b0a03aed683df360140701d694288f0cd85005f34168f731a468aef268c2f9456f01f90108b88201000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200b88201000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
           "signatureCount": 2,
           "status": "success",
           "threshold": 2,
@@ -1179,7 +1195,7 @@ describe('from', () => {
       KeyAuthorization.from(authorization, {
         signature: {
           account,
-          init: config,
+          config,
           signatures: [
             SignatureEnvelope.deserialize(approval_1),
             SignatureEnvelope.deserialize(approval_2),
@@ -1194,8 +1210,8 @@ describe('from', () => {
       configVersion: 0n,
       hash: MultisigConfig.getSignPayload({
         account,
+        config,
         payload: KeyAuthorization.getSignPayload(authorization),
-        version: 0n,
       }),
       init: true,
       keyAuthorization: keyAuthorization_,
@@ -1229,6 +1245,7 @@ describe('from', () => {
           ],
           "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "threshold": 2,
+          "version": 0n,
         },
         "configVersion": 0n,
         "createdAt": 1,
@@ -1272,6 +1289,7 @@ describe('RPC conversion', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
+            "version": 1n,
           },
           "configVersion": "0x1",
           "createdAt": 1,
@@ -1303,6 +1321,7 @@ describe('RPC conversion', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 2,
+            "version": 1n,
           },
           "configVersion": "0x1",
           "createdAt": 1,
@@ -1440,10 +1459,10 @@ describe('validation', () => {
         account: '0x0000000000000000000000000000000000000000',
         hash: MultisigConfig.getSignPayload({
           account: '0x0000000000000000000000000000000000000000',
+          config: initializedConfig,
           payload: TxEnvelopeTempo.getSignPayload(
             TxEnvelopeTempo.deserialize(transaction),
           ),
-          version: 1n,
         }),
       },
     },
@@ -1513,7 +1532,7 @@ describe('validation', () => {
         approvals: [
           SignatureEnvelope.serialize({
             account,
-            init: config,
+            config,
             signatures: [ownerSignature_1],
             type: 'multisig',
           }),
@@ -1550,6 +1569,7 @@ describe('validation', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
+            config: initializedConfig,
             signatures: [
               SignatureEnvelope.deserialize(approval_1),
               SignatureEnvelope.deserialize(approval_3),
@@ -1573,12 +1593,12 @@ describe('validation', () => {
     const signatures = [
       ...SignatureEnvelope.sortMultisigApprovals({
         account,
+        config: initializedConfig,
         payload: KeyAuthorization.getSignPayload(authorization),
         signatures: [
           SignatureEnvelope.deserialize(approval_1),
           SignatureEnvelope.deserialize(approval_2),
         ],
-        version: 1n,
       }),
     ].reverse()
     const operation = {
@@ -1586,7 +1606,12 @@ describe('validation', () => {
       approvals: [approval_1, approval_2],
       keyAuthorization: KeyAuthorization.serialize(
         KeyAuthorization.from(authorization, {
-          signature: { account, signatures, type: 'multisig' },
+          signature: {
+            account,
+            config: initializedConfig,
+            signatures,
+            type: 'multisig',
+          },
         }),
       ),
       signatureCount: 2,
@@ -1608,6 +1633,7 @@ describe('validation', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
+            config: initializedConfig,
             signatures: [
               SignatureEnvelope.deserialize(approval_1),
               SignatureEnvelope.deserialize(approval_1),
@@ -1628,37 +1654,49 @@ describe('validation', () => {
 
   test('rejects reordered nested key authorization approvals', () => {
     const authorization = KeyAuthorization.deserialize(keyAuthorization)
+    const nestedConfig = MultisigConfig.from({
+      owners: [{ owner: owner_2, weight: 1 }],
+      threshold: 1,
+      version: 1n,
+    })
     const childSignatures = SignatureEnvelope.sortMultisigApprovals({
       account: owner_1,
+      config: nestedConfig,
       payload: keyAuthorizationHash,
       signatures: [
         SignatureEnvelope.deserialize(approval_1),
         SignatureEnvelope.deserialize(approval_2),
       ],
-      version: 1n,
     })
     const retainedNested = SignatureEnvelope.from({
       account: owner_1,
+      config: nestedConfig,
       signatures: childSignatures,
       type: 'multisig',
     })
     const selectedNested = SignatureEnvelope.from({
       account: owner_1,
+      config: nestedConfig,
       signatures: [...childSignatures].reverse(),
       type: 'multisig',
     })
     const selected = SignatureEnvelope.sortMultisigApprovals({
       account,
+      config: initializedConfig,
       payload: KeyAuthorization.getSignPayload(authorization),
       signatures: [selectedNested, SignatureEnvelope.deserialize(approval_2)],
-      version: 1n,
     })
     const operation = {
       ...keyAuthorizationPending,
       approvals: [SignatureEnvelope.serialize(retainedNested), approval_2],
       keyAuthorization: KeyAuthorization.serialize(
         KeyAuthorization.from(authorization, {
-          signature: { account, signatures: selected, type: 'multisig' },
+          signature: {
+            account,
+            config: initializedConfig,
+            signatures: selected,
+            type: 'multisig',
+          },
         }),
       ),
       signatureCount: 2,
@@ -1697,12 +1735,12 @@ describe('validation', () => {
     })
     const signatures = SignatureEnvelope.sortMultisigApprovals({
       account,
+      config,
       payload: KeyAuthorization.getSignPayload(authorization),
       signatures: [
         SignatureEnvelope.deserialize(approval_1),
         SignatureEnvelope.deserialize(approval_2),
       ],
-      version: 0n,
     })
     const approvals = signatures.map((signature) =>
       SignatureEnvelope.serialize(signature),
@@ -1716,15 +1754,15 @@ describe('validation', () => {
       createdAt: 1,
       hash: MultisigConfig.getSignPayload({
         account,
+        config,
         payload: KeyAuthorization.getSignPayload(authorization),
-        version: 0n,
       }),
       init: true,
       keyAuthorization: KeyAuthorization.serialize(
         KeyAuthorization.from(authorization, {
           signature: {
             account,
-            init: config,
+            config,
             signatures,
             type: 'multisig',
           },

--- a/src/tempo/MultisigOperation.ts
+++ b/src/tempo/MultisigOperation.ts
@@ -109,8 +109,8 @@ export function getHash(options: getHash.Options): Hex.Hex {
         )
   return MultisigConfig.getSignPayload({
     account,
+    config: { version: configVersion },
     payload,
-    version: configVersion,
   })
 }
 
@@ -281,20 +281,15 @@ export function serializeTransaction(
   assertRetainedApprovals(value, approvals)
   const signatures = SignatureEnvelope.sortMultisigApprovals({
     account: value.account,
+    config: value.config,
     payload: TxEnvelopeTempo.getSignPayload(envelope),
     signatures: approvals,
-    version: value.configVersion,
   })
-  const signature = value.init
-    ? SignatureEnvelope.from({
-        init: true,
-        initialConfig: value.config,
-        signatures,
-      })
-    : SignatureEnvelope.from({
-        account: value.account,
-        signatures,
-      })
+  const signature = SignatureEnvelope.from({
+    account: value.account,
+    config: value.config,
+    signatures,
+  })
   return TxEnvelopeTempo.serialize(
     envelope,
     value.transaction.startsWith(TxEnvelopeTempo.feePayerMagic)
@@ -343,7 +338,10 @@ export function from<const operation extends Operation>(
   operation: operation,
 ): from.ReturnValue<operation> {
   try {
-    const config = MultisigConfig.from(operation.config)
+    const config = MultisigConfig.from({
+      ...operation.config,
+      version: operation.configVersion,
+    })
     if (
       typeof config.threshold !== 'number' ||
       config.owners.some((owner) => typeof owner.weight !== 'number')
@@ -351,12 +349,13 @@ export function from<const operation extends Operation>(
       throw new InvalidOperationError({
         reason: 'config threshold and owner weights must be numbers',
       })
-    assertBase(operation, config)
-    if (operation.type === 'transaction') assertTransaction(operation)
-    else if (operation.type === 'keyAuthorization')
-      assertKeyAuthorization(operation, config)
+    const value = { ...operation, config } as Operation
+    assertBase(value, config)
+    if (value.type === 'transaction') assertTransaction(value)
+    else if (value.type === 'keyAuthorization')
+      assertKeyAuthorization(value, config)
     else throw new InvalidOperationError({ reason: 'unknown operation type' })
-    return { ...operation, config } as never
+    return value as never
   } catch (cause) {
     if (cause instanceof InvalidOperationError) throw cause
     throw new InvalidOperationError({ cause })
@@ -513,10 +512,6 @@ async function selectApprovals_internal(
         throw new InvalidApprovalError({
           reason: `owner ${group.address} has conflicting signature types`,
         })
-      if (nested.some((signature) => signature.init))
-        throw new InvalidApprovalError({
-          reason: `nested multisig owner ${group.address} cannot carry init`,
-        })
       if (
         path.length >= MultisigConfig.maxNestingDepth ||
         path.includes(group.address.toLowerCase())
@@ -529,6 +524,10 @@ async function selectApprovals_internal(
           reason: `nested multisig owner ${group.address} requires a config resolver`,
         })
       const resolved = await options.resolveConfig({ account: group.address })
+      const config = MultisigConfig.from({
+        ...resolved.config,
+        version: resolved.version,
+      })
       const selected = await selectApprovals_internal(
         {
           account: group.address,
@@ -537,11 +536,11 @@ async function selectApprovals_internal(
               SignatureEnvelope.serialize(approval),
             ),
           ),
-          config: MultisigConfig.from(resolved.config),
+          config,
           hash: MultisigConfig.getSignPayload({
             account: group.address,
+            config,
             payload: options.hash,
-            version: resolved.version,
           }),
           resolveConfig: options.resolveConfig,
         },
@@ -552,6 +551,7 @@ async function selectApprovals_internal(
         signature: SignatureEnvelope.serialize(
           SignatureEnvelope.from({
             account: group.address,
+            config,
             signatures: selected.approvals.map((approval) =>
               SignatureEnvelope.from(approval),
             ),
@@ -564,6 +564,7 @@ async function selectApprovals_internal(
           signature: SignatureEnvelope.serialize(
             SignatureEnvelope.from({
               account: group.address,
+              config,
               signatures: selected.selectedApprovals.map((approval) =>
                 SignatureEnvelope.from(approval),
               ),
@@ -739,6 +740,7 @@ function assertBase(operation: Operation, config: MultisigConfig.Config): void {
     const signature = assertApproval(
       operation.account,
       approval as SignatureEnvelope.Serialized,
+      config,
     )
     const address = SignatureEnvelope.extractAddress({
       payload: operation.hash,
@@ -944,13 +946,9 @@ function assertKeyAuthorization(
         reason: 'key authorization signatureCount does not match its signature',
       })
     assertSelectedApprovals(operation, signature.signatures, authorization)
-    if (!!signature.init !== operation.init)
+    if (!sameConfig(signature.config, config))
       throw new InvalidOperationError({
-        reason: 'key authorization bootstrap state does not match',
-      })
-    if (signature.init && !sameConfig(signature.init, config))
-      throw new InvalidOperationError({
-        reason: 'key authorization bootstrap config does not match',
+        reason: 'key authorization config does not match',
       })
   }
   assertOperationHash(
@@ -974,10 +972,12 @@ function assertKeyAuthorization(
 function assertApproval(
   account: Address.Address,
   serialized: SignatureEnvelope.Serialized,
+  config: MultisigConfig.Config,
 ): SignatureEnvelope.SignatureEnvelope {
   const approval = SignatureEnvelope.deserialize(serialized)
   SignatureEnvelope.assert({
     account,
+    config,
     signatures: [approval],
     type: 'multisig',
   })
@@ -1039,8 +1039,8 @@ function assertSelectedApprovals(
 
   const digest = MultisigConfig.getSignPayload({
     account: operation.account,
+    config: operation.config,
     payload: KeyAuthorization_.getSignPayload(authorization),
-    version: operation.configVersion,
   })
   const addresses = selected.map((signature) =>
     SignatureEnvelope.extractAddress({ payload: digest, signature }),
@@ -1075,7 +1075,7 @@ function includesApproval(
     )
   if (retained.account.toLowerCase() !== selected.account.toLowerCase())
     return false
-  // Nested versions are not serialized, so selected child approvals must preserve the validated retained order.
+  if (!sameConfig(retained.config, selected.config)) return false
   let index = 0
   for (const approval of selected.signatures) {
     while (
@@ -1119,8 +1119,8 @@ function isWeightReachable(
 function assertOperationHash(operation: Operation, payload: Hex.Hex): void {
   const hash = MultisigConfig.getSignPayload({
     account: operation.account,
+    config: operation.config,
     payload,
-    version: operation.configVersion,
   })
   if (hash.toLowerCase() !== operation.hash.toLowerCase())
     throw new InvalidOperationError({
@@ -1157,6 +1157,7 @@ function sameConfig(
       configB.salt ?? MultisigConfig.zeroSalt,
     ) &&
     configA.threshold === configB.threshold &&
+    configA.version === configB.version &&
     configA.owners.length === configB.owners.length &&
     configA.owners.every((owner, index) => {
       const other = configB.owners[index]!

--- a/src/tempo/MultisigOperation.ts
+++ b/src/tempo/MultisigOperation.ts
@@ -14,7 +14,7 @@ export type Base<quantity = bigint> = {
   /** Every retained serialized owner approval. */
   approvals: readonly Hex.Hex[]
   /** Root configuration used to verify approvals. */
-  config: MultisigConfig.Config
+  config: MultisigConfig.Config<quantity>
   /** Root configuration version. */
   configVersion: quantity
   /** Unix creation time in milliseconds. */
@@ -403,7 +403,11 @@ export function fromRpc<const operation extends Rpc>(
       throw new InvalidOperationError({
         reason: 'configVersion must use canonical quantity encoding',
       })
-    return from({ ...operation, configVersion } as Operation) as never
+    return from({
+      ...operation,
+      config: MultisigConfig.fromRpc(operation.config),
+      configVersion,
+    } as Operation) as never
   } catch (cause) {
     if (cause instanceof InvalidOperationError) throw cause
     throw new InvalidOperationError({ cause })
@@ -441,6 +445,7 @@ export function toRpc<const operation extends Operation>(
   const value = from(operation)
   return {
     ...value,
+    config: MultisigConfig.toRpc(value.config),
     configVersion: Hex.fromNumber(value.configVersion),
   } as never
 }

--- a/src/tempo/SignatureEnvelope.test-d.ts
+++ b/src/tempo/SignatureEnvelope.test-d.ts
@@ -63,13 +63,13 @@ test('from derives an initial account', () => {
 test('from requires an account for a current config', () => {
   // @ts-expect-error Current configurations require an explicit account.
   SignatureEnvelope.from({
-    config: { ...config, version: 1n },
+    config: { ...config, version: 1 },
     signatures: [signature],
   })
 
   const multisig = SignatureEnvelope.from({
     account: '0x2222222222222222222222222222222222222222',
-    config: { ...config, version: 1n },
+    config: { ...config, version: 1 },
     signatures: [signature],
   })
   expectTypeOf(multisig).toMatchTypeOf<SignatureEnvelope.Multisig>()

--- a/src/tempo/SignatureEnvelope.test-d.ts
+++ b/src/tempo/SignatureEnvelope.test-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf, test } from 'vitest'
+import * as MultisigConfig from './MultisigConfig.js'
 import * as SignatureEnvelope from './SignatureEnvelope.js'
 
 const signatureRpc = {
@@ -17,67 +18,81 @@ const signature = {
   type: 'secp256k1',
 } as const satisfies SignatureEnvelope.Secp256k1
 
+const config = MultisigConfig.from({
+  owners: [
+    {
+      owner: '0x1111111111111111111111111111111111111111',
+      weight: 1,
+    },
+  ],
+  threshold: 1,
+})
+
 test('toRpc preserves the signature type', () => {
   expectTypeOf(
     SignatureEnvelope.toRpc(signature),
   ).toEqualTypeOf<SignatureEnvelope.Secp256k1Rpc>()
 })
 
-test('MultisigRpc uses static initialized and bootstrap shapes', () => {
-  const initialized = {
+test('MultisigRpc carries one complete witness shape', () => {
+  const rpc = {
     account: '0x1111111111111111111111111111111111111111',
+    config: MultisigConfig.toRpc(config),
     signatures: [signatureRpc],
   } as const satisfies SignatureEnvelope.MultisigRpc
-  const bootstrap = {
-    init: {
-      owners: [
-        {
-          owner: '0x1111111111111111111111111111111111111111',
-          weight: 1,
-        },
-      ],
-      threshold: 1,
-    },
-    signatures: [signatureRpc],
-  } as const satisfies SignatureEnvelope.MultisigRpc
-  const bootstrapWithAccountUndefined: SignatureEnvelope.MultisigRpc = {
-    ...bootstrap,
-    account: undefined,
-  }
 
-  expectTypeOf(initialized.signatures).toMatchTypeOf<
+  expectTypeOf(rpc.config).toMatchTypeOf<MultisigConfig.Rpc>()
+  expectTypeOf(rpc.signatures).toMatchTypeOf<
     readonly SignatureEnvelope.SignatureEnvelopeRpc[]
   >()
-  expectTypeOf(bootstrap.signatures).toMatchTypeOf<
-    readonly SignatureEnvelope.SignatureEnvelopeRpc[]
-  >()
-  expectTypeOf(
-    bootstrapWithAccountUndefined,
-  ).toMatchTypeOf<SignatureEnvelope.MultisigRpc>()
   expectTypeOf<
-    SignatureEnvelope.GetType<typeof bootstrap>
+    SignatureEnvelope.GetType<typeof rpc>
   >().toEqualTypeOf<'multisig'>()
 })
 
-test('MultisigRpc rejects legacy shapes', () => {
-  const combined = {
+test('from derives an initial account', () => {
+  const multisig = SignatureEnvelope.from({
+    config,
+    signatures: [signature],
+  })
+
+  expectTypeOf(multisig).toMatchTypeOf<SignatureEnvelope.Multisig>()
+  expectTypeOf(multisig.config.version).toEqualTypeOf<bigint>()
+})
+
+test('from requires an account for a current config', () => {
+  // @ts-expect-error Current configurations require an explicit account.
+  SignatureEnvelope.from({
+    config: { ...config, version: 1n },
+    signatures: [signature],
+  })
+
+  const multisig = SignatureEnvelope.from({
+    account: '0x2222222222222222222222222222222222222222',
+    config: { ...config, version: 1n },
+    signatures: [signature],
+  })
+  expectTypeOf(multisig).toMatchTypeOf<SignatureEnvelope.Multisig>()
+})
+
+test('MultisigRpc rejects old witness shapes', () => {
+  const accountOnly = {
     account: '0x1111111111111111111111111111111111111111',
-    init: {
-      owners: [
-        {
-          owner: '0x1111111111111111111111111111111111111111',
-          weight: 1,
-        },
-      ],
-      threshold: 1,
-    },
     signatures: [signatureRpc],
   } as const
-  // @ts-expect-error Bootstrap RPC signatures omit `account`.
-  const combinedRpc: SignatureEnvelope.MultisigRpc = combined
+  // @ts-expect-error Multisig RPC signatures require config.
+  const accountOnlyRpc: SignatureEnvelope.MultisigRpc = accountOnly
+
+  const init = {
+    init: config,
+    signatures: [signatureRpc],
+  } as const
+  // @ts-expect-error Multisig RPC signatures no longer accept init.
+  const initRpc: SignatureEnvelope.MultisigRpc = init
 
   const serialized = {
     account: '0x1111111111111111111111111111111111111111',
+    config: MultisigConfig.toRpc(config),
     signatures: ['0x1234'],
   } as const
   // @ts-expect-error Owner approvals use structured RPC envelopes.
@@ -85,13 +100,15 @@ test('MultisigRpc rejects legacy shapes', () => {
 
   const tagged = {
     account: '0x1111111111111111111111111111111111111111',
+    config: MultisigConfig.toRpc(config),
     signatures: [signatureRpc],
     type: 'multisig',
   } as const
   // @ts-expect-error Multisig RPC signatures are untagged.
   const taggedRpc: SignatureEnvelope.MultisigRpc = tagged
 
-  expectTypeOf(combinedRpc).toEqualTypeOf<SignatureEnvelope.MultisigRpc>()
+  expectTypeOf(accountOnlyRpc).toEqualTypeOf<SignatureEnvelope.MultisigRpc>()
+  expectTypeOf(initRpc).toEqualTypeOf<SignatureEnvelope.MultisigRpc>()
   expectTypeOf(serializedRpc).toEqualTypeOf<SignatureEnvelope.MultisigRpc>()
   expectTypeOf(taggedRpc).toEqualTypeOf<SignatureEnvelope.MultisigRpc>()
 })

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -3322,10 +3322,28 @@ describe('multisig', () => {
       ],
     },
     {
-      field: 'version',
+      field: 'oversized version',
       value: [
         ('0x' + '00'.repeat(32)) as Hex.Hex,
         ('0x' + '01'.repeat(9)) as Hex.Hex,
+        '0x01',
+        [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x01']],
+      ],
+    },
+    {
+      field: 'zero version',
+      value: [
+        ('0x' + '00'.repeat(32)) as Hex.Hex,
+        '0x00',
+        '0x01',
+        [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x01']],
+      ],
+    },
+    {
+      field: 'zero-prefixed version',
+      value: [
+        ('0x' + '00'.repeat(32)) as Hex.Hex,
+        '0x0001',
         '0x01',
         [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x01']],
       ],
@@ -3348,7 +3366,7 @@ describe('multisig', () => {
         [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x0001']],
       ],
     },
-  ])('error: rejects a noncanonical $field width', ({ value }) => {
+  ])('error: rejects a noncanonical $field', ({ value }) => {
     const malformed = Hex.concat(
       '0x05',
       Rlp.fromHex([

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -1,5 +1,6 @@
 import {
   Address,
+  Hash,
   Hex,
   P256,
   PublicKey,
@@ -1100,72 +1101,86 @@ describe('from', () => {
   })
 
   describe('multisig', () => {
-    const initialConfig = MultisigConfig.from({
-      threshold: 1,
+    const config = MultisigConfig.from({
       owners: [
         {
           owner: '0x1111111111111111111111111111111111111111',
           weight: 1,
         },
       ],
+      threshold: 1,
     })
 
-    test('behavior: derives `account` from `initialConfig`', () => {
+    test('behavior: derives an initial account from config', () => {
       const envelope = SignatureEnvelope.from({
-        initialConfig,
+        config,
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
       })
 
-      expect(envelope).toMatchObject({
-        type: 'multisig',
-        account: MultisigConfig.getAddress(initialConfig),
-      })
-      expect('initialConfig' in envelope).toBe(false)
-      expect((envelope as SignatureEnvelope.Multisig).init).toBeUndefined()
-    })
-
-    test('behavior: `init: true` opts into bootstrap (uses `initialConfig` as `init`)', () => {
-      const envelope = SignatureEnvelope.from({
-        initialConfig,
-        signatures: [SignatureEnvelope.from(signature_secp256k1)],
-        init: true,
-      })
-
-      expect((envelope as SignatureEnvelope.Multisig).init).toEqual(
-        initialConfig,
+      expect(envelope).toMatchInlineSnapshot(
+        {
+          signatures: [
+            {
+              signature: {
+                r: expect.anything(),
+                s: expect.anything(),
+                yParity: expect.any(Number),
+              },
+            },
+          ],
+        },
+        `
+        {
+          "account": "0x8820d1497eeaf4f68e00b2cfc00a2f3b1dbb00da",
+          "config": {
+            "owners": [
+              {
+                "owner": "0x1111111111111111111111111111111111111111",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 1,
+            "version": 0n,
+          },
+          "signatures": [
+            {
+              "signature": {
+                "r": Anything,
+                "s": Anything,
+                "yParity": Any<Number>,
+              },
+              "type": "secp256k1",
+            },
+          ],
+          "type": "multisig",
+        }
+      `,
       )
     })
 
-    test('behavior: `init` accepts an explicit config', () => {
-      const otherConfig = MultisigConfig.from({
-        threshold: 1,
-        owners: [
-          {
-            owner: '0x2222222222222222222222222222222222222222',
-            weight: 1,
-          },
-        ],
-      })
+    test('behavior: accepts an explicit account for a current config', () => {
       const envelope = SignatureEnvelope.from({
-        initialConfig,
+        account: '0x2222222222222222222222222222222222222222',
+        config: { ...config, version: 1n },
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
-        init: otherConfig,
       })
 
-      expect((envelope as SignatureEnvelope.Multisig).init).toEqual(otherConfig)
+      expect(envelope.account).toBe(
+        '0x2222222222222222222222222222222222222222',
+      )
+      expect(envelope.config.version).toBe(1n)
     })
 
-    test('behavior: `{ account }` form still works', () => {
-      const account = MultisigConfig.getAddress(initialConfig)
-      const envelope = SignatureEnvelope.from({
-        account,
-        signatures: [SignatureEnvelope.from(signature_secp256k1)],
-      })
-
-      expect(envelope).toMatchObject({
-        type: 'multisig',
-        account,
-      })
+    test('error: requires an account for a current config', () => {
+      expect(() =>
+        SignatureEnvelope.from({
+          config: { ...config, version: 1n },
+          signatures: [SignatureEnvelope.from(signature_secp256k1)],
+        } as never),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[MultisigConfig.InvalidConfigError: Invalid native multisig config: account address requires version zero.]`,
+      )
     })
   })
 })
@@ -1769,8 +1784,6 @@ describe('serialize', () => {
 })
 
 describe('sortMultisigApprovals', () => {
-  // Build owner key pairs first so we can construct a real initial config
-  // whose owner set matches the keys that produce the approvals below.
   const ownerKeys = Array.from({ length: 3 }, () => {
     const privateKey = Secp256k1.randomPrivateKey()
     const address = Address.fromPublicKey(
@@ -1782,14 +1795,16 @@ describe('sortMultisigApprovals', () => {
     Hex.toBigInt(a.address) < Hex.toBigInt(b.address) ? -1 : 1,
   )
 
-  const initialConfig = MultisigConfig.from({
-    threshold: 2,
+  const config = MultisigConfig.from({
     owners: ascendingOwners.map((o) => ({ owner: o.address, weight: 1 })),
+    threshold: 2,
   })
+  const account = MultisigConfig.getAddress(config)
   const payload = `0x${'42'.repeat(32)}` as const
   const digest = MultisigConfig.getSignPayload({
+    account,
+    config,
     payload,
-    initialConfig,
   })
 
   const owners = ownerKeys.map((owner) => ({
@@ -1805,7 +1820,8 @@ describe('sortMultisigApprovals', () => {
 
   test('behavior: orders approvals ascending by recovered owner address', () => {
     const ordered = SignatureEnvelope.sortMultisigApprovals({
-      initialConfig,
+      account,
+      config,
       payload,
       // Provide approvals in reverse of the canonical order.
       signatures: [...ascending].reverse().map((owner) => owner.signature),
@@ -1817,7 +1833,8 @@ describe('sortMultisigApprovals', () => {
     const signatures = ascending.map((owner) => owner.signature)
     expect(
       SignatureEnvelope.sortMultisigApprovals({
-        initialConfig,
+        account,
+        config,
         payload,
         signatures,
       }),
@@ -1826,7 +1843,8 @@ describe('sortMultisigApprovals', () => {
 
   test('behavior: recovered order matches the config owner order', () => {
     const ordered = SignatureEnvelope.sortMultisigApprovals({
-      initialConfig,
+      account,
+      config,
       payload,
       signatures: owners.map((owner) => owner.signature),
     })
@@ -1834,23 +1852,6 @@ describe('sortMultisigApprovals', () => {
       SignatureEnvelope.extractAddress({ payload: digest, signature }),
     )
     expect(recovered).toEqual(ascending.map((owner) => owner.address))
-  })
-
-  test('behavior: `initialConfig` and `{ account }` produce identical ordering', () => {
-    const account = MultisigConfig.getAddress(initialConfig)
-    const signatures = owners.map((owner) => owner.signature)
-
-    const fromConfig = SignatureEnvelope.sortMultisigApprovals({
-      initialConfig,
-      payload,
-      signatures,
-    })
-    const fromAccount = SignatureEnvelope.sortMultisigApprovals({
-      account,
-      payload,
-      signatures,
-    })
-    expect(fromConfig).toEqual(fromAccount)
   })
 })
 
@@ -2852,146 +2853,371 @@ describe('CoercionError', () => {
 })
 
 describe('multisig', () => {
-  const account = '0x8ba6d26ff5c4e82ba0c8caf8c8ca794e1489a7ae'
+  const initial =
+    '0x05f897949dba7f426b711d4893c11611eacf7cc334e7146bf83ba000000000000000000000000000000000000000000000000000000000000000008001d7d6947e5f4552091a69125d5dfcb7b8c2659029395bdf01f843b841869437e01f64bebeb78a8a6b30bfd3a993819c8cad82c807515d9b9e9b36f98535dfaa5eebc597715d05f6ce4927747f14fa4cd2acc717fdcd3877146437f8f41b' as const
+  const current =
+    '0x05f897949dba7f426b711d4893c11611eacf7cc334e7146bf83ba000000000000000000000000000000000000000000000000000000000000000000101d7d6942b5ad5c4795c026514f8317c7a215e218dccd6cf01f843b8414a0e5b5b4a90f08e6e8d676a73a22dc2cf022ffdcc9299512b5d9a6daf66e0504a395a2ef6f6c0f173910b875c45d01aa66d928e56ba6f49bbc8186f80268bf51b' as const
+  const nested =
+    '0x05f8f0949969e2243075b27a8eab61009c59b77ab13b83f6f83ba033333333333333333333333333333333333333333333333333333333333333338001d7d6944f9f5b162a7464bcc260ce44d7ae0d935f9c583701f89cb89a05f897944f9f5b162a7464bcc260ce44d7ae0d935f9c5837f83ba022222222222222222222222222222222222222222222222222222222222222228001d7d6946813eb9362372eef6200f3b1dbc3f819671cba6901f843b841032aa6f3ea7b0b7069720d0f3891983c493d149326c5c957d864ed7371b8475e3e95325079b24491f4b6d68920e4b3bacd7c6094df6ed88b8674864ab559c8fb1b' as const
 
-  // P256 signatures do not carry `yParity` in the wire format, so use a clean
-  // inner signature for round-trip equality checks.
-  const innerP256 = SignatureEnvelope.from({
-    signature: { r: p256Signature.r, s: p256Signature.s },
-    publicKey,
-    prehash: true,
+  test('example: decodes and re-encodes the frozen initial witness', () => {
+    const envelope = SignatureEnvelope.deserialize(initial)
+
+    expect(envelope).toMatchInlineSnapshot(`
+      {
+        "account": "0x9dba7f426b711d4893c11611eacf7cc334e7146b",
+        "config": {
+          "owners": [
+            {
+              "owner": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "threshold": 1,
+          "version": 0n,
+        },
+        "signatures": [
+          {
+            "signature": {
+              "r": 60871800714128149016591846789173983752390955456021923556141688418770269698437n,
+              "s": 24367763726302312398084372528434045669788111037623467391175388828437596076276n,
+              "yParity": 0,
+            },
+            "type": "secp256k1",
+          },
+        ],
+        "type": "multisig",
+      }
+    `)
+    expect(SignatureEnvelope.serialize(envelope)).toBe(initial)
   })
 
-  const envelope = SignatureEnvelope.from({
-    type: 'multisig',
-    account,
-    signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
+  test('example: decodes and re-encodes the frozen current witness', () => {
+    const envelope = SignatureEnvelope.deserialize(current)
+
+    expect(envelope).toMatchInlineSnapshot(`
+      {
+        "account": "0x9dba7f426b711d4893c11611eacf7cc334e7146b",
+        "config": {
+          "owners": [
+            {
+              "owner": "0x2b5ad5c4795c026514f8317c7a215e218dccd6cf",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "threshold": 1,
+          "version": 1n,
+        },
+        "signatures": [
+          {
+            "signature": {
+              "r": 33496517174194049078979631673636743206216482049680398378774155205635729711184n,
+              "s": 33572483501191170814542557897380275621900207658854593170435098846326627404789n,
+              "yParity": 0,
+            },
+            "type": "secp256k1",
+          },
+        ],
+        "type": "multisig",
+      }
+    `)
+    expect(SignatureEnvelope.serialize(envelope)).toBe(current)
   })
 
-  test('serialize: type byte 0x05 prefix', () => {
+  test('example: decodes and re-encodes the frozen nested witness', () => {
+    const envelope = SignatureEnvelope.deserialize(nested)
+
+    expect(envelope).toMatchInlineSnapshot(`
+      {
+        "account": "0x9969e2243075b27a8eab61009c59b77ab13b83f6",
+        "config": {
+          "owners": [
+            {
+              "owner": "0x4f9f5b162a7464bcc260ce44d7ae0d935f9c5837",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x3333333333333333333333333333333333333333333333333333333333333333",
+          "threshold": 1,
+          "version": 0n,
+        },
+        "signatures": [
+          {
+            "account": "0x4f9f5b162a7464bcc260ce44d7ae0d935f9c5837",
+            "config": {
+              "owners": [
+                {
+                  "owner": "0x6813eb9362372eef6200f3b1dbc3f819671cba69",
+                  "weight": 1,
+                },
+              ],
+              "salt": "0x2222222222222222222222222222222222222222222222222222222222222222",
+              "threshold": 1,
+              "version": 0n,
+            },
+            "signatures": [
+              {
+                "signature": {
+                  "r": 1432298388324792555676061659976215111517531547814803085200940835913455912798n,
+                  "s": 28307004081743690677157914067925034813425317008577473150162358055484664695035n,
+                  "yParity": 0,
+                },
+                "type": "secp256k1",
+              },
+            ],
+            "type": "multisig",
+          },
+        ],
+        "type": "multisig",
+      }
+    `)
+    expect(SignatureEnvelope.serialize(envelope)).toBe(nested)
+  })
+
+  test('behavior: preserves exact 65-byte secp256k1 precedence', () => {
+    const serialized = ('0x05' +
+      '00'.repeat(31) +
+      '00'.repeat(31) +
+      '01' +
+      '00') as Hex.Hex
+
+    expect(Hex.size(serialized)).toBe(65)
+    expect(SignatureEnvelope.deserialize(serialized).type).toBe('secp256k1')
+  })
+
+  test('behavior: serializes account, config, and approvals in wire order', () => {
+    const envelope = SignatureEnvelope.deserialize(initial)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
     const serialized = SignatureEnvelope.serialize(envelope)
-    expect(serialized.startsWith('0x05')).toBe(true)
+    const decoded = Rlp.toHex(Hex.slice(serialized, 1))
+
+    expect(decoded).toMatchInlineSnapshot(`
+      [
+        "0x9dba7f426b711d4893c11611eacf7cc334e7146b",
+        [
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x",
+          "0x01",
+          [
+            [
+              "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+              "0x01",
+            ],
+          ],
+        ],
+        [
+          "0x869437e01f64bebeb78a8a6b30bfd3a993819c8cad82c807515d9b9e9b36f98535dfaa5eebc597715d05f6ce4927747f14fa4cd2acc717fdcd3877146437f8f41b",
+        ],
+      ]
+    `)
   })
 
-  test('serialize: wire shape is `0x05 || rlp([account, signatures])`', () => {
-    const deterministic = SignatureEnvelope.from({
-      type: 'multisig',
-      account,
-      signatures: [innerP256],
-    })
-    expect(SignatureEnvelope.serialize(deterministic)).toMatchInlineSnapshot(
-      `"0x05f89b948ba6d26ff5c4e82ba0c8caf8c8ca794e1489a7aef884b88201ccbb3485d4726235f13cb15ef394fb7158179fb7b1925eccec0147671090c52e77c3c53373cc1e3b05e7c23f609deb17cea8fe097300c45411237e9fe4166b35ad8ac16e167d6992c3e120d7f17d2376bc1cbcf30c46ba6dd00ce07303e742f511edf6ce1c32de66846f56afa7be1cbd729bc35750b6d0cdcf3ec9d75461aba001"`,
-    )
-  })
+  test('behavior: round trips initial and current RPC witnesses', () => {
+    const initialEnvelope = SignatureEnvelope.deserialize(initial)
+    const currentEnvelope = SignatureEnvelope.deserialize(current)
+    const rpc = {
+      current: SignatureEnvelope.toRpc(currentEnvelope),
+      initial: SignatureEnvelope.toRpc(initialEnvelope),
+    }
 
-  test('serialize/deserialize round-trip', () => {
-    const serialized = SignatureEnvelope.serialize(envelope)
-    expect(SignatureEnvelope.deserialize(serialized)).toEqual(envelope)
-  })
-
-  test('deserialize: rejects the legacy three-field wire shape', () => {
-    const init = MultisigConfig.toTuple({
-      threshold: 1,
-      owners: [
-        { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
-      ],
-    })
-    const legacy = Hex.concat(
-      '0x05',
-      Rlp.fromHex([account, [SignatureEnvelope.serialize(innerP256)], init]),
-    )
-    expect(() => SignatureEnvelope.deserialize(legacy)).toThrowError(
-      SignatureEnvelope.InvalidSerializedError,
-    )
-  })
-
-  test('deserialize: rejects an invalid initialized account', () => {
-    const malformed = Hex.concat(
-      '0x05',
-      Rlp.fromHex(['0x11', [SignatureEnvelope.serialize(innerP256)]]),
-    )
-    expect(() => SignatureEnvelope.deserialize(malformed)).toThrowError(
-      SignatureEnvelope.InvalidSerializedError,
-    )
-  })
-
-  test('getType', () => {
-    expect(SignatureEnvelope.getType(envelope)).toBe('multisig')
-    expect(
-      SignatureEnvelope.getType({
-        init: {
-          threshold: 1,
-          owners: [
-            { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
+    expect(rpc).toMatchInlineSnapshot(`
+      {
+        "current": {
+          "account": "0x9dba7f426b711d4893c11611eacf7cc334e7146b",
+          "config": {
+            "owners": [
+              {
+                "owner": "0x2b5ad5c4795c026514f8317c7a215e218dccd6cf",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 1,
+            "version": "0x1",
+          },
+          "signatures": [
+            {
+              "r": "0x4a0e5b5b4a90f08e6e8d676a73a22dc2cf022ffdcc9299512b5d9a6daf66e050",
+              "s": "0x4a395a2ef6f6c0f173910b875c45d01aa66d928e56ba6f49bbc8186f80268bf5",
+              "type": "secp256k1",
+              "yParity": "0x0",
+            },
           ],
         },
-        signatures: [innerP256],
-      } as never),
-    ).toBe('multisig')
+        "initial": {
+          "account": "0x9dba7f426b711d4893c11611eacf7cc334e7146b",
+          "config": {
+            "owners": [
+              {
+                "owner": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+                "weight": 1,
+              },
+            ],
+            "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "threshold": 1,
+            "version": "0x0",
+          },
+          "signatures": [
+            {
+              "r": "0x869437e01f64bebeb78a8a6b30bfd3a993819c8cad82c807515d9b9e9b36f985",
+              "s": "0x35dfaa5eebc597715d05f6ce4927747f14fa4cd2acc717fdcd3877146437f8f4",
+              "type": "secp256k1",
+              "yParity": "0x0",
+            },
+          ],
+        },
+      }
+    `)
+    expect(SignatureEnvelope.fromRpc(rpc.initial)).toStrictEqual(
+      initialEnvelope,
+    )
+    expect(SignatureEnvelope.fromRpc(rpc.current)).toStrictEqual(
+      currentEnvelope,
+    )
   })
 
-  test('extractAddress returns the multisig account', () => {
+  test('behavior: derives the account only for an initial witness', () => {
+    const initialEnvelope = SignatureEnvelope.deserialize(initial)
+    if (initialEnvelope.type !== 'multisig') throw new Error('unreachable')
+    if (initialEnvelope.config.version !== 0n) throw new Error('unreachable')
+    const derived = SignatureEnvelope.from({
+      config: initialEnvelope.config as MultisigConfig.Config<0n>,
+      signatures: initialEnvelope.signatures,
+    })
+    const currentEnvelope = SignatureEnvelope.deserialize(current)
+    if (currentEnvelope.type !== 'multisig') throw new Error('unreachable')
+
+    expect(derived.account).toBe(initialEnvelope.account)
+    expect(() =>
+      SignatureEnvelope.from({
+        config: currentEnvelope.config,
+        signatures: currentEnvelope.signatures,
+      } as never),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[MultisigConfig.InvalidConfigError: Invalid native multisig config: account address requires version zero.]`,
+    )
+  })
+
+  test('behavior: extracts the multisig account', () => {
+    const envelope = SignatureEnvelope.deserialize(initial)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
+
     expect(
       SignatureEnvelope.extractAddress({
         payload: '0xdeadbeef',
         signature: envelope,
       }),
-    ).toBe(account)
+    ).toBe(envelope.account)
   })
 
-  test('toRpc/fromRpc round-trip', () => {
-    const rpc = SignatureEnvelope.toRpc(
-      envelope,
-    ) as SignatureEnvelope.MultisigRpc
-    expect(rpc).toMatchObject({
-      account,
-      signatures: [{ type: 'secp256k1' }, { type: 'p256' }],
+  test('example: matches the frozen eight-approval boundary vector', () => {
+    const config = MultisigConfig.from({
+      owners: Array.from({ length: 8 }, (_, index) => ({
+        owner:
+          `0x${(index + 1).toString(16).padStart(40, '0')}` as `0x${string}`,
+        weight: 1,
+      })),
+      salt: `0x${'66'.repeat(32)}`,
+      threshold: 8,
     })
-    expect(rpc.init).toBeUndefined()
-    expect('type' in rpc).toBe(false)
-    expect(SignatureEnvelope.fromRpc(rpc)).toEqual(envelope)
-    expect(
-      SignatureEnvelope.fromRpc({ ...rpc, type: 'multisig' } as never),
-    ).toEqual(envelope)
+    const approval = SignatureEnvelope.from({
+      r: 0x840cfc572845f5786e702984c2a582528cad4b49b2a10b9db1be7fca90058565n,
+      s: 0x25e7109ceb98168d95b09b18bbf6b685130e0562f233877d492b94eee0c5b6d1n,
+      yParity: 0,
+    })
+    const envelope = SignatureEnvelope.from({
+      config,
+      signatures: Array.from(
+        { length: MultisigConfig.maxSignatures },
+        () => approval,
+      ),
+    })
+    const serialized = SignatureEnvelope.serialize(envelope)
+
+    expect({
+      hash: Hash.keccak256(serialized),
+      length: Hex.size(serialized),
+      signatureCount: envelope.signatures.length,
+    }).toMatchInlineSnapshot(`
+      {
+        "hash": "0x1cb47fcf31fb1ebb3177ec1744eeda195e4d789920d1214af32baaa6150ad5e2",
+        "length": 787,
+        "signatureCount": 8,
+      }
+    `)
   })
 
-  test('assert: missing properties', () => {
-    expect(() =>
-      SignatureEnvelope.assert({ type: 'multisig', account } as never),
-    ).toThrowError()
+  test('behavior: accepts initial and current nested witnesses', () => {
+    const initialEnvelope = SignatureEnvelope.deserialize(initial)
+    const currentEnvelope = SignatureEnvelope.deserialize(current)
+    if (
+      initialEnvelope.type !== 'multisig' ||
+      currentEnvelope.type !== 'multisig'
+    )
+      throw new Error('unreachable')
+
+    for (const signature of [initialEnvelope, currentEnvelope]) {
+      const config = MultisigConfig.from({
+        owners: [{ owner: signature.account, weight: 1 }],
+        salt: ('0x' + 'ff'.repeat(32)) as Hex.Hex,
+        threshold: 1,
+        version: 1n,
+      })
+      const envelope = SignatureEnvelope.from({
+        account: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        config,
+        signatures: [signature],
+      })
+
+      expect(
+        SignatureEnvelope.deserialize(SignatureEnvelope.serialize(envelope)),
+      ).toStrictEqual(envelope)
+    }
   })
 
-  test('assert: rejects empty owner approvals', () => {
+  test('error: rejects an initial account mismatch', () => {
+    const envelope = SignatureEnvelope.deserialize(initial)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
+
     expect(() =>
       SignatureEnvelope.assert({
-        type: 'multisig',
-        account,
-        signatures: [],
+        ...envelope,
+        account: '0x1111111111111111111111111111111111111111',
       }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig signatures cannot be empty.]`,
+      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: initial multisig config does not derive account.]`,
     )
   })
 
-  test('assert: accepts at most eight owner approvals', () => {
-    expect(() =>
-      SignatureEnvelope.assert({
-        type: 'multisig',
-        account,
-        signatures: Array.from(
-          { length: MultisigConfig.maxSignatures },
-          () => innerP256,
-        ),
-      }),
-    ).not.toThrow()
+  test('error: rejects a self-owned current witness', () => {
+    const envelope = SignatureEnvelope.deserialize(current)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
+    const account = envelope.config.owners[0]!.owner
 
     expect(() =>
+      SignatureEnvelope.assert({ ...envelope, account }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig account cannot be an owner.]`,
+    )
+  })
+
+  test('error: rejects empty and excess approvals', () => {
+    const envelope = SignatureEnvelope.deserialize(current)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
+
+    expect(() =>
+      SignatureEnvelope.assert({ ...envelope, signatures: [] }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig signatures cannot be empty.]`,
+    )
+    expect(() =>
       SignatureEnvelope.assert({
-        type: 'multisig',
-        account,
+        ...envelope,
         signatures: Array.from(
           { length: MultisigConfig.maxSignatures + 1 },
-          () => innerP256,
+          () => envelope.signatures[0]!,
         ),
       }),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -2999,38 +3225,13 @@ describe('multisig', () => {
     )
   })
 
-  test('assert: rejects oversized owner approvals', () => {
-    const oversized = {
-      ...signature_webauthn,
-      metadata: {
-        ...signature_webauthn.metadata,
-        clientDataJSON: JSON.stringify({ value: 'x'.repeat(2048) }),
-      },
-    }
+  test('error: rejects keychain owner approvals', () => {
+    const envelope = SignatureEnvelope.deserialize(current)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
+
     expect(() =>
       SignatureEnvelope.assert({
-        type: 'multisig',
-        account,
-        signatures: [oversized],
-      }),
-    ).toThrowErrorMatchingInlineSnapshot(
-      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig owner signature exceeds 2049 bytes.]`,
-    )
-
-    const serialized = Hex.concat(
-      '0x05',
-      Rlp.fromHex([account, [SignatureEnvelope.serialize(oversized)]]),
-    )
-    expect(() => SignatureEnvelope.deserialize(serialized)).toThrowError(
-      SignatureEnvelope.InvalidSerializedError,
-    )
-  })
-
-  test('assert: rejects keychain owner approvals', () => {
-    expect(() =>
-      SignatureEnvelope.assert({
-        type: 'multisig',
-        account,
+        ...envelope,
         signatures: [signature_keychain_secp256k1],
       } as never),
     ).toThrowErrorMatchingInlineSnapshot(
@@ -3038,303 +3239,127 @@ describe('multisig', () => {
     )
   })
 
-  describe('nested approvals', () => {
-    const nestedAccount = '0x1111111111111111111111111111111111111111'
-    const nested = SignatureEnvelope.from({
-      type: 'multisig',
-      account: nestedAccount,
-      signatures: [innerP256],
-    })
+  test('error: rejects oversized primitive approvals', () => {
+    const envelope = SignatureEnvelope.deserialize(current)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
+    const oversized = {
+      ...signature_webauthn,
+      metadata: {
+        ...signature_webauthn.metadata,
+        clientDataJSON: JSON.stringify({ value: 'x'.repeat(2048) }),
+      },
+    }
 
-    test('serialize/deserialize round-trip with a nested multisig approval', () => {
-      const parent = SignatureEnvelope.from({
-        type: 'multisig',
-        account,
-        signatures: [innerP256, nested],
-      })
-      const serialized = SignatureEnvelope.serialize(parent)
-      expect(SignatureEnvelope.deserialize(serialized)).toEqual(parent)
-    })
-
-    test('assert: accepts the maximum nesting depth', () => {
-      const depth2 = SignatureEnvelope.from({
-        type: 'multisig',
-        account,
-        signatures: [nested],
-      })
-      expect(() => SignatureEnvelope.assert(depth2)).not.toThrowError()
-    })
-
-    test('accepts a nested approval above the primitive byte limit', () => {
-      const primitive = SignatureEnvelope.from({
-        ...signature_webauthn,
-        metadata: {
-          ...signature_webauthn.metadata,
-          clientDataJSON: JSON.stringify({ value: 'x'.repeat(1_050) }),
-        },
-        signature: {
-          r: signature_webauthn.signature.r,
-          s: signature_webauthn.signature.s,
-        },
-      })
-      const largeNested = SignatureEnvelope.from({
-        type: 'multisig',
-        account: nestedAccount,
-        signatures: [primitive, primitive],
-      })
-      expect(Hex.size(SignatureEnvelope.serialize(primitive))).toBeLessThan(
-        MultisigConfig.maxOwnerSignatureBytes,
-      )
-      expect(
-        Hex.size(SignatureEnvelope.serialize(largeNested)),
-      ).toBeGreaterThan(MultisigConfig.maxOwnerSignatureBytes)
-
-      const parent = SignatureEnvelope.from({
-        type: 'multisig',
-        account,
-        signatures: [largeNested],
-      })
-      expect(
-        SignatureEnvelope.deserialize(SignatureEnvelope.serialize(parent)),
-      ).toEqual(parent)
-    })
-
-    test('assert: rejects nesting deeper than the maximum', () => {
-      const depth3 = SignatureEnvelope.from({
-        type: 'multisig',
-        account,
-        signatures: [
-          SignatureEnvelope.from({
-            type: 'multisig',
-            account: nestedAccount,
-            signatures: [nested],
-          }),
-        ],
-      })
-      expect(() =>
-        SignatureEnvelope.assert(depth3),
-      ).toThrowErrorMatchingInlineSnapshot(
-        `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig nesting depth exceeds 2.]`,
-      )
-    })
-
-    test('deserialize: rejects nesting deeper than the maximum during decode', () => {
-      const primitive = SignatureEnvelope.serialize(innerP256)
-      const depth1 = Hex.concat(
-        '0x05',
-        Rlp.fromHex([nestedAccount, [primitive]]),
-      )
-      const depth2 = Hex.concat('0x05', Rlp.fromHex([nestedAccount, [depth1]]))
-      const depth3 = Hex.concat('0x05', Rlp.fromHex([account, [depth2]]))
-
-      expect(() => SignatureEnvelope.deserialize(depth3)).toThrowError(
-        SignatureEnvelope.InvalidSerializedError,
-      )
-    })
-
-    test('assert: rejects nested approvals carrying `init`', () => {
-      expect(() =>
-        SignatureEnvelope.assert({
-          type: 'multisig',
-          account,
-          signatures: [
-            {
-              ...nested,
-              init: {
-                threshold: 1,
-                owners: [{ owner: nestedAccount, weight: 1 }],
-              },
-            },
-          ],
-        } as never),
-      ).toThrowErrorMatchingInlineSnapshot(
-        `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: nested multisig owner approvals cannot carry \`init\`.]`,
-      )
-    })
+    expect(() =>
+      SignatureEnvelope.assert({
+        ...envelope,
+        signatures: [oversized],
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig owner signature exceeds 2049 bytes.]`,
+    )
   })
 
-  describe('init (bootstrap)', () => {
-    const init = {
-      salt: `0x${'00'.repeat(32)}` as const,
-      threshold: 1,
-      owners: [
-        {
-          owner: '0x1111111111111111111111111111111111111111' as const,
-          weight: 1,
-        },
-      ],
-    }
-    const bootstrapAccount = MultisigConfig.getAddress(init)
-
-    const bootstrapEnvelope = SignatureEnvelope.from({
-      type: 'multisig',
-      account: bootstrapAccount,
-      signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
-      init,
+  test('error: rejects nesting deeper than two nodes', () => {
+    const envelope = SignatureEnvelope.deserialize(initial)
+    if (envelope.type !== 'multisig') throw new Error('unreachable')
+    const depth2 = SignatureEnvelope.from({
+      ...envelope,
+      signatures: [envelope],
     })
 
-    test('serialize/deserialize round-trip with init', () => {
-      const serialized = SignatureEnvelope.serialize(bootstrapEnvelope)
-      expect(SignatureEnvelope.deserialize(serialized)).toEqual(
-        bootstrapEnvelope,
-      )
-    })
+    expect(() =>
+      SignatureEnvelope.assert({
+        ...envelope,
+        signatures: [depth2],
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig nesting depth exceeds 2.]`,
+    )
+  })
 
-    test('deserialize: validates bootstrap init semantics', () => {
-      const invalid = Hex.concat(
-        '0x05',
-        Rlp.fromHex([
-          [MultisigConfig.zeroSalt, '0x01', []],
-          [SignatureEnvelope.serialize(innerP256)],
-        ]),
-      )
-      expect(() => SignatureEnvelope.deserialize(invalid)).toThrowError(
-        MultisigConfig.InvalidConfigError,
-      )
-    })
-
-    test('deserialize: rejects noncanonical bootstrap field widths', () => {
-      const signatures = [SignatureEnvelope.serialize(innerP256)]
-      const shortSalt = Hex.concat(
-        '0x05',
-        Rlp.fromHex([
-          [`0x${'00'.repeat(31)}`, '0x01', [[init.owners[0]!.owner, '0x01']]],
-          signatures,
-        ]),
-      )
-      const wideThreshold = Hex.concat(
-        '0x05',
-        Rlp.fromHex([
-          [init.salt, '0x0001', [[init.owners[0]!.owner, '0x01']]],
-          signatures,
-        ]),
-      )
-      const wideWeight = Hex.concat(
-        '0x05',
-        Rlp.fromHex([
-          [init.salt, '0x01', [[init.owners[0]!.owner, '0x0001']]],
-          signatures,
-        ]),
-      )
-
-      for (const serialized of [shortSalt, wideThreshold, wideWeight])
-        expect(() => SignatureEnvelope.deserialize(serialized)).toThrowError(
-          SignatureEnvelope.InvalidSerializedError,
-        )
-    })
-
-    test('serialize: wire shape is `0x05 || rlp([init, signatures])`', () => {
-      const serialized = SignatureEnvelope.serialize(bootstrapEnvelope)
-      const [address] = Rlp.toHex(Hex.slice(serialized, 1)) as readonly [
-        MultisigConfig.Tuple,
-        readonly Hex.Hex[],
-      ]
-      expect(MultisigConfig.fromTuple(address)).toEqual(init)
-    })
-
-    test('serialize/deserialize round-trip preserves non-zero salt', () => {
-      const saltedInit = {
-        ...init,
-        salt: `0x${'42'.repeat(32)}` as const,
-      }
-      const salted = SignatureEnvelope.from({
-        type: 'multisig',
-        account: MultisigConfig.getAddress(saltedInit),
-        signatures: [SignatureEnvelope.from(signature_secp256k1), innerP256],
-        init: saltedInit,
-      })
-      const serialized = SignatureEnvelope.serialize(salted)
-      const deserialized = SignatureEnvelope.deserialize(
-        serialized,
-      ) as SignatureEnvelope.Multisig
-      expect(deserialized.init?.salt).toBe(`0x${'42'.repeat(32)}`)
-      expect(deserialized).toEqual(salted)
-    })
-
-    test('absent init has no `init` key after deserialize', () => {
-      const serialized = SignatureEnvelope.serialize(envelope)
-      const deserialized = SignatureEnvelope.deserialize(serialized)
-      expect('init' in deserialized).toBe(false)
-    })
-
-    test('init absent vs present produce different serializations', () => {
-      expect(SignatureEnvelope.serialize(envelope)).not.toBe(
-        SignatureEnvelope.serialize(bootstrapEnvelope),
-      )
-    })
-
-    test('toRpc/fromRpc round-trip with init', () => {
-      const rpc = SignatureEnvelope.toRpc(
-        bootstrapEnvelope,
-      ) as SignatureEnvelope.MultisigRpc
-      expect(rpc.init).toEqual(init)
-      expect(rpc.account).toBeUndefined()
-      expect('type' in rpc).toBe(false)
-      expect(SignatureEnvelope.fromRpc(rpc)).toEqual(bootstrapEnvelope)
-    })
-
-    test('toRpc encodes owner approvals as structured RPC envelopes', () => {
-      const multisig = bootstrapEnvelope as SignatureEnvelope.Multisig
-      const rpc = SignatureEnvelope.toRpc(
-        multisig,
-      ) as SignatureEnvelope.MultisigRpc
-      expect(rpc.signatures).toEqual(
-        multisig.signatures.map((signature) =>
-          SignatureEnvelope.toRpc(signature),
+  test.each([
+    {
+      name: 'two fields',
+      value: Rlp.fromHex([
+        '0x9dba7f426b711d4893c11611eacf7cc334e7146b',
+        [Hex.slice(initial, -65)],
+      ]),
+    },
+    {
+      name: 'trailing field',
+      value: Rlp.fromHex([
+        '0x9dba7f426b711d4893c11611eacf7cc334e7146b',
+        MultisigConfig.toTuple(
+          MultisigConfig.from({
+            owners: [
+              {
+                owner: '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf',
+                weight: 1,
+              },
+            ],
+            threshold: 1,
+          }),
         ),
-      )
-    })
+        [Hex.slice(initial, -65)],
+        '0x',
+      ]),
+    },
+  ])('error: rejects malformed $name wire shape', ({ value }) => {
+    expect(() =>
+      SignatureEnvelope.deserialize(Hex.concat('0x05', value)),
+    ).toThrowError(SignatureEnvelope.InvalidSerializedError)
+  })
 
-    test('fromRpc detects multisig by shape (no `type` field)', () => {
-      const rpc = SignatureEnvelope.toRpc(bootstrapEnvelope)
-      expect(SignatureEnvelope.fromRpc(rpc)).toEqual(bootstrapEnvelope)
-    })
+  test.each([
+    {
+      field: 'salt',
+      value: [
+        ('0x' + '00'.repeat(31)) as Hex.Hex,
+        '0x',
+        '0x01',
+        [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x01']],
+      ],
+    },
+    {
+      field: 'version',
+      value: [
+        ('0x' + '00'.repeat(32)) as Hex.Hex,
+        ('0x' + '01'.repeat(9)) as Hex.Hex,
+        '0x01',
+        [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x01']],
+      ],
+    },
+    {
+      field: 'threshold',
+      value: [
+        ('0x' + '00'.repeat(32)) as Hex.Hex,
+        '0x',
+        '0x0001',
+        [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x01']],
+      ],
+    },
+    {
+      field: 'weight',
+      value: [
+        ('0x' + '00'.repeat(32)) as Hex.Hex,
+        '0x',
+        '0x01',
+        [['0x7e5f4552091a69125d5dfcb7b8c2659029395bdf', '0x0001']],
+      ],
+    },
+  ])('error: rejects a noncanonical $field width', ({ value }) => {
+    const malformed = Hex.concat(
+      '0x05',
+      Rlp.fromHex([
+        '0x9dba7f426b711d4893c11611eacf7cc334e7146b',
+        value as never,
+        [Hex.slice(initial, -65)],
+      ]),
+    )
 
-    test('fromRpc accepts the opposite static property as undefined', () => {
-      const rpc = SignatureEnvelope.toRpc(
-        bootstrapEnvelope,
-      ) as SignatureEnvelope.MultisigRpc
-      expect(
-        SignatureEnvelope.fromRpc({ ...rpc, account: undefined } as never),
-      ).toEqual(bootstrapEnvelope)
-    })
-
-    test('fromRpc rejects the legacy combined account and init shape', () => {
-      const rpc = SignatureEnvelope.toRpc(
-        bootstrapEnvelope,
-      ) as SignatureEnvelope.MultisigRpc
-      expect(() =>
-        SignatureEnvelope.fromRpc({
-          ...rpc,
-          account: bootstrapAccount,
-        } as never),
-      ).toThrowErrorMatchingInlineSnapshot(
-        `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: RPC multisig must contain exactly one of \`account\` or \`init\`.]`,
-      )
-    })
-
-    test('assert: invalid init config throws', () => {
-      expect(() =>
-        SignatureEnvelope.assert({
-          type: 'multisig',
-          account: bootstrapAccount,
-          signatures: [innerP256],
-          init: { threshold: 1, owners: [] },
-        } as never),
-      ).toThrowError()
-    })
-
-    test('assert: init must derive the supplied account', () => {
-      expect(() =>
-        SignatureEnvelope.assert({
-          type: 'multisig',
-          account,
-          signatures: [innerP256],
-          init,
-        }),
-      ).toThrowErrorMatchingInlineSnapshot(
-        `[SignatureEnvelope.InvalidMultisigApprovalError: Invalid native multisig owner approval: multisig init does not derive account.]`,
-      )
-    })
+    expect(() => SignatureEnvelope.deserialize(malformed)).toThrowError(
+      SignatureEnvelope.InvalidSerializedError,
+    )
   })
 })

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -1162,7 +1162,7 @@ describe('from', () => {
     test('behavior: accepts an explicit account for a current config', () => {
       const envelope = SignatureEnvelope.from({
         account: '0x2222222222222222222222222222222222222222',
-        config: { ...config, version: 1n },
+        config: { ...config, version: 1 },
         signatures: [SignatureEnvelope.from(signature_secp256k1)],
       })
 

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -799,6 +799,7 @@ function deserialize_(
       Hex.size(salt) !== 32 ||
       Array.isArray(version) ||
       Hex.size(version) > 8 ||
+      (version !== '0x' && Hex.slice(version, 0, 1) === '0x00') ||
       Array.isArray(threshold) ||
       Hex.size(threshold) > 1 ||
       !Array.isArray(owners) ||

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -27,6 +27,50 @@ const serializedKeychainType = '0x03'
 const serializedKeychainV2Type = '0x04'
 const serializedMultisigType = '0x05'
 
+type EnvelopeOneOf<
+  union extends object,
+  keys extends PropertyKey,
+> = union extends union
+  ? Compute<
+      union & {
+        [key in Exclude<keys, keyof union>]?: undefined
+      }
+    >
+  : never
+
+type SignatureEnvelopeKey =
+  | 'account'
+  | 'config'
+  | 'inner'
+  | 'keyId'
+  | 'metadata'
+  | 'prehash'
+  | 'publicKey'
+  | 'signature'
+  | 'signatures'
+  | 'type'
+  | 'userAddress'
+  | 'version'
+
+type SignatureEnvelopeRpcKey =
+  | 'account'
+  | 'config'
+  | 'keyId'
+  | 'metadata'
+  | 'preHash'
+  | 'pubKeyX'
+  | 'pubKeyY'
+  | 'r'
+  | 's'
+  | 'signature'
+  | 'signatures'
+  | 'type'
+  | 'userAddress'
+  | 'v'
+  | 'version'
+  | 'webauthnData'
+  | 'yParity'
+
 /** Serialized magic identifier for Tempo signature envelopes. */
 export const magicBytes =
   '0x7777777777777777777777777777777777777777777777777777777777777777' // 32 "T"s
@@ -72,15 +116,7 @@ export type GetType<
                   userAddress: Address.Address
                 }
               ? 'keychain'
-              : envelope extends
-                    | {
-                        account: Address.Address
-                        signatures: any
-                      }
-                    | {
-                        init: MultisigConfig.Config
-                        signatures: any
-                      }
+              : envelope extends { config: unknown; signatures: any }
                 ? 'multisig'
                 : never
 
@@ -107,20 +143,25 @@ export type GetType<
  *
  * [Signature Types Specification](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#signature-types)
  */
-export type SignatureEnvelope<bigintType = bigint, numberType = number> = OneOf<
-  | Secp256k1<bigintType, numberType>
-  | P256<bigintType, numberType>
-  | WebAuthn<bigintType, numberType>
-  | Keychain<bigintType, numberType>
-  | Multisig<bigintType, numberType>
->
+export type SignatureEnvelope<bigintType = bigint, numberType = number> =
+  | EnvelopeOneOf<
+      | Secp256k1<bigintType, numberType>
+      | P256<bigintType, numberType>
+      | WebAuthn<bigintType, numberType>
+      | Keychain<bigintType, numberType>,
+      SignatureEnvelopeKey
+    >
+  | MultisigOneOf<bigintType, numberType>
 
 /**
  * RPC-formatted signature envelope.
  */
-export type SignatureEnvelopeRpc = OneOf<
-  Secp256k1Rpc | P256Rpc | WebAuthnRpc | KeychainRpc | MultisigRpc
->
+export type SignatureEnvelopeRpc =
+  | EnvelopeOneOf<
+      Secp256k1Rpc | P256Rpc | WebAuthnRpc | KeychainRpc,
+      SignatureEnvelopeRpcKey
+    >
+  | MultisigRpcOneOf
 
 /** Primitive signature envelope accepted by protocol sidecars. */
 export type Primitive<bigintType = bigint, numberType = number> = OneOf<
@@ -171,43 +212,61 @@ export type KeychainRpc = {
  *
  * [TIP-1061](https://tips.sh/1061)
  */
-export type Multisig<bigintType = bigint, numberType = number> = {
-  type: 'multisig'
+export interface Multisig<bigintType = bigint, numberType = number> {
   /** Native multisig account address. */
   account: Address.Address
+  /** Complete applicable multisig configuration witness. */
+  config: MultisigConfig.Config<bigintType, numberType>
   /**
    * Owner approvals over the multisig owner approval digest. Each approval is
    * either a primitive signature or a nested multisig signature (keychain
    * approvals are invalid).
    */
   signatures: readonly SignatureEnvelope<bigintType, numberType>[]
-  /**
-   * Initial native multisig config for bootstrapping this account. Present only on
-   * the first (bootstrap) transaction from the derived account; absent on every
-   * subsequent transaction.
-   */
-  init?: MultisigConfig.Config<numberType> | undefined
+  type: 'multisig'
+}
+
+type MultisigOneOf<bigintType = bigint, numberType = number> = Multisig<
+  bigintType,
+  numberType
+> & {
+  inner?: undefined
+  keyId?: undefined
+  metadata?: undefined
+  prehash?: undefined
+  publicKey?: undefined
+  signature?: undefined
+  userAddress?: undefined
+  version?: undefined
 }
 
 /** RPC-formatted native multisig signature. */
-export type MultisigRpc = OneOf<
-  | {
-      /** Existing native multisig account. */
-      account: Address.Address
-      /** Structured owner approvals. */
-      signatures: readonly SignatureEnvelopeRpc[]
-      /** Multisig RPC signatures are untagged. */
-      type?: undefined
-    }
-  | {
-      /** Initial config for bootstrapping a native multisig account. */
-      init: MultisigConfig.Config
-      /** Structured owner approvals. */
-      signatures: readonly SignatureEnvelopeRpc[]
-      /** Multisig RPC signatures are untagged. */
-      type?: undefined
-    }
->
+export type MultisigRpc = {
+  /** Native multisig account address. */
+  account: Address.Address
+  /** Complete applicable multisig configuration witness. */
+  config: MultisigConfig.Rpc
+  /** Structured owner approvals. */
+  signatures: readonly SignatureEnvelopeRpc[]
+  /** Multisig RPC signatures are untagged. */
+  type?: undefined
+}
+
+type MultisigRpcOneOf = MultisigRpc & {
+  keyId?: undefined
+  metadata?: undefined
+  preHash?: undefined
+  pubKeyX?: undefined
+  pubKeyY?: undefined
+  r?: undefined
+  s?: undefined
+  signature?: undefined
+  userAddress?: undefined
+  v?: undefined
+  version?: undefined
+  webauthnData?: undefined
+  yParity?: undefined
+}
 
 export type P256<bigintType = bigint, numberType = number> = {
   prehash: boolean
@@ -370,6 +429,7 @@ export declare namespace assert {
 function assertMultisig(envelope: Multisig, depth: number): void {
   const missing: string[] = []
   if (!envelope.account) missing.push('account')
+  if (!envelope.config) missing.push('config')
   if (!Array.isArray(envelope.signatures)) missing.push('signatures')
   if (missing.length > 0)
     throw new MissingPropertiesError({
@@ -389,6 +449,25 @@ function assertMultisig(envelope: Multisig, depth: number): void {
     throw new InvalidMultisigApprovalError({
       reason: 'multisig account cannot be zero',
     })
+  MultisigConfig.assert(envelope.config)
+  if (
+    envelope.config.owners.some((owner) =>
+      Address.isEqual(owner.owner, envelope.account),
+    )
+  )
+    throw new InvalidMultisigApprovalError({
+      reason: 'multisig account cannot be an owner',
+    })
+  if (
+    envelope.config.version === 0n &&
+    !Address.isEqual(
+      MultisigConfig.getAddress(envelope.config),
+      envelope.account,
+    )
+  )
+    throw new InvalidMultisigApprovalError({
+      reason: 'initial multisig config does not derive account',
+    })
   if (envelope.signatures.length === 0)
     throw new InvalidMultisigApprovalError({
       reason: 'multisig signatures cannot be empty',
@@ -398,33 +477,14 @@ function assertMultisig(envelope: Multisig, depth: number): void {
       reason: `multisig signatures exceed ${MultisigConfig.maxSignatures}`,
     })
 
-  if (envelope.init) {
-    MultisigConfig.assert(envelope.init)
-    if (
-      !Address.isEqual(
-        MultisigConfig.getAddress(envelope.init),
-        envelope.account,
-      )
-    )
-      throw new InvalidMultisigApprovalError({
-        reason: 'multisig init does not derive account',
-      })
-  }
-
   for (const inner of envelope.signatures) {
     const type = getType(inner)
     if (type === 'keychain')
       throw new InvalidMultisigApprovalError({
         reason: 'keychain owner approvals are not allowed',
       })
-    if (type === 'multisig') {
-      const multisig = inner as Multisig
-      if (multisig.init)
-        throw new InvalidMultisigApprovalError({
-          reason: 'nested multisig owner approvals cannot carry `init`',
-        })
-      assertMultisig(multisig, depth + 1)
-    } else {
+    if (type === 'multisig') assertMultisig(inner as Multisig, depth + 1)
+    else {
       assert(inner)
       if (Hex.size(serialize(inner)) > MultisigConfig.maxOwnerSignatureBytes)
         throw new InvalidMultisigApprovalError({
@@ -714,16 +774,47 @@ function deserialize_(
         serialized,
       })
 
-    // The first field distinguishes the static wire shapes: a bootstrap init
-    // config is an RLP list, while an initialized account is a 20-byte string.
     const decoded = Rlp.toHex(data)
-    if (!Array.isArray(decoded) || decoded.length !== 2)
+    if (!Array.isArray(decoded) || decoded.length !== 3)
       throw new InvalidSerializedError({
-        reason: 'invalid multisig wire shape: expected exactly two fields',
+        reason: 'invalid multisig wire shape: expected exactly three fields',
         serialized,
       })
 
-    const [address, signatures] = decoded
+    const [account, config, signatures] = decoded
+    if (!Address.validate(account))
+      throw new InvalidSerializedError({
+        reason: 'invalid multisig account',
+        serialized,
+      })
+    if (!Array.isArray(config))
+      throw new InvalidSerializedError({
+        reason: 'invalid multisig config',
+        serialized,
+      })
+    const [salt, version, threshold, owners] = config
+    if (
+      config.length !== 4 ||
+      Array.isArray(salt) ||
+      Hex.size(salt) !== 32 ||
+      Array.isArray(version) ||
+      Hex.size(version) > 8 ||
+      Array.isArray(threshold) ||
+      Hex.size(threshold) > 1 ||
+      !Array.isArray(owners) ||
+      owners.some(
+        (owner) =>
+          !Array.isArray(owner) ||
+          owner.length !== 2 ||
+          owner.some(Array.isArray) ||
+          !Address.validate(owner[0]) ||
+          Hex.size(owner[1] as Hex.Hex) > 1,
+      )
+    )
+      throw new InvalidSerializedError({
+        reason: 'invalid multisig config',
+        serialized,
+      })
     if (!Array.isArray(signatures) || signatures.some(Array.isArray))
       throw new InvalidSerializedError({
         reason: 'invalid multisig signatures list',
@@ -751,47 +842,15 @@ function deserialize_(
           serialized,
         })
 
-    if (!Array.isArray(address) && !Address.validate(address))
-      throw new InvalidSerializedError({
-        reason: 'invalid multisig account',
-        serialized,
-      })
-    if (Array.isArray(address)) {
-      const [salt, threshold, owners] = address
-      if (
-        address.length !== 3 ||
-        Array.isArray(salt) ||
-        Hex.size(salt) !== 32 ||
-        Array.isArray(threshold) ||
-        Hex.size(threshold) > 1 ||
-        !Array.isArray(owners) ||
-        owners.some(
-          (owner) =>
-            !Array.isArray(owner) ||
-            owner.length !== 2 ||
-            owner.some(Array.isArray) ||
-            Hex.size(owner[1] as Hex.Hex) > 1,
-        )
-      )
-        throw new InvalidSerializedError({
-          reason: 'invalid multisig init config',
-          serialized,
-        })
-    }
-
-    const init = Array.isArray(address)
-      ? MultisigConfig.fromTuple(address as unknown as MultisigConfig.Tuple)
-      : undefined
-    const account = init
-      ? MultisigConfig.getAddress(init)
-      : (address as Address.Address)
     const envelope = {
-      type: 'multisig',
-      account,
+      account: account as Address.Address,
+      config: MultisigConfig.fromTuple(
+        config as unknown as MultisigConfig.Tuple,
+      ),
       signatures: signatures.map((signature) =>
         deserialize_(signature as Hex.Hex, depth),
       ),
-      ...(init ? { init } : {}),
+      type: 'multisig',
     } satisfies Multisig
     assertMultisig(envelope, depth)
     return envelope
@@ -916,21 +975,17 @@ function deserialize_(
  * ```
  *
  * @example
- * ### Multisig (from initial config)
- *
- * Pass `initialConfig` to derive `account` automatically. Set `init: true` to
- * opt into bootstrap (uses `initialConfig` as the bootstrap `init`); omit
- * `init` for subsequent (non-bootstrap) transactions.
+ * ### Multisig
  *
  * ```ts twoslash
  * import { Secp256k1 } from 'ox'
  * import { MultisigConfig, SignatureEnvelope } from 'ox/tempo'
  *
- * const initialConfig = MultisigConfig.from({
- *   threshold: 1,
+ * const config = MultisigConfig.from({
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *   ],
+ *   threshold: 1,
  * })
  *
  * const privateKey = Secp256k1.randomPrivateKey()
@@ -938,16 +993,8 @@ function deserialize_(
  *   Secp256k1.sign({ payload: '0xdeadbeef', privateKey }),
  * )
  *
- * // Bootstrap transaction
- * const bootstrap = SignatureEnvelope.from({
- *   initialConfig,
- *   signatures: [signature],
- *   init: true,
- * })
- *
- * // Subsequent (non-bootstrap) transactions
- * const subsequent = SignatureEnvelope.from({
- *   initialConfig,
+ * const multisig = SignatureEnvelope.from({
+ *   config,
  *   signatures: [signature],
  * })
  * ```
@@ -973,30 +1020,17 @@ export function from<const value extends from.Value>(
   const type = getType(value)
 
   if (type === 'multisig') {
-    const multisig = value as Multisig & {
-      initialConfig?: MultisigConfig.Config | undefined
-      init?: MultisigConfig.Config | boolean | undefined
-    }
-    const { initialConfig, init, ...rest } = multisig
-    // Derive `account` from `initialConfig` when not provided explicitly.
-    const account = (() => {
-      if (rest.account) return rest.account
-      if (initialConfig) return MultisigConfig.getAddress(initialConfig)
-      return rest.account
-    })()
-    // `init: true` opts into bootstrap using the supplied `initialConfig`.
-    // Otherwise, `init` is treated as the explicit bootstrap config (or
-    // omitted).
-    const initSource = init === true ? initialConfig : init || undefined
-    return {
-      ...rest,
+    const multisig = value as from.MultisigFromConfig
+    const config = MultisigConfig.from(multisig.config)
+    const account = multisig.account ?? MultisigConfig.getAddress(config)
+    const envelope = {
       account,
-      signatures: rest.signatures.map((signature) => from(signature)),
-      // Normalize the bootstrap config (sorts owners, defaults the salt) so the
-      // in-memory envelope matches what `deserialize` reconstructs.
-      ...(initSource ? { init: MultisigConfig.from(initSource) } : {}),
+      config,
+      signatures: multisig.signatures.map((signature) => from(signature)),
       type,
-    } as never
+    } satisfies Multisig
+    assert(envelope)
+    return envelope as never
   }
 
   return {
@@ -1041,45 +1075,49 @@ export declare namespace from {
     payload?: Hex.Hex | Bytes.Bytes | undefined
   }
 
-  /**
-   * Multisig envelope input variant where `account` is derived from the
-   * supplied `initialConfig`. Pass `init: true` to opt into bootstrap (uses
-   * `initialConfig` as the bootstrap `init`); omit `init` for subsequent
-   * (non-bootstrap) transactions.
-   */
-  type MultisigFromInitialConfig = {
-    type?: 'multisig' | undefined
-    initialConfig: MultisigConfig.Config
-    signatures: readonly SignatureEnvelope[]
-    init?: MultisigConfig.Config | boolean | undefined
-  }
+  /** Multisig signature input with an optional derived initial account. */
+  type MultisigFromConfig =
+    | {
+        /** Initial native multisig account, derived from config when omitted. */
+        account?: Address.Address | undefined
+        /** Initial version-0 multisig configuration witness. */
+        config: MultisigConfig.Input<0n>
+        /** Primitive or nested owner approvals. */
+        signatures: readonly SignatureEnvelope[]
+        type?: 'multisig' | undefined
+      }
+    | {
+        /** Native multisig account. */
+        account: Address.Address
+        /** Complete applicable multisig configuration witness. */
+        config: MultisigConfig.Input
+        /** Primitive or nested owner approvals. */
+        signatures: readonly SignatureEnvelope[]
+        type?: 'multisig' | undefined
+      }
 
   type Value =
     | UnionPartialBy<SignatureEnvelope, 'prehash' | 'type'>
     | Secp256k1Flat
     | Serialized
-    | MultisigFromInitialConfig
+    | MultisigFromConfig
 
-  type ReturnValue<value extends Value> = Compute<
-    OneOf<
-      value extends Serialized
-        ? SignatureEnvelope
-        : value extends Secp256k1Flat
-          ? Secp256k1
-          : value extends MultisigFromInitialConfig
-            ? Multisig
-            : IsNarrowable<value, SignatureEnvelope> extends true
-              ? SignatureEnvelope
-              : Assign<
-                  value,
-                  {
-                    readonly type: GetType<value>
-                  } & (GetType<value> extends 'keychain'
-                    ? { keyId?: Address.Address | undefined }
-                    : {})
-                >
-    >
-  >
+  type ReturnValue<value extends Value> = value extends Serialized
+    ? SignatureEnvelope
+    : value extends Secp256k1Flat
+      ? Secp256k1
+      : value extends MultisigFromConfig
+        ? MultisigOneOf
+        : IsNarrowable<value, SignatureEnvelope> extends true
+          ? SignatureEnvelope
+          : Assign<
+              value,
+              {
+                readonly type: GetType<value>
+              } & (GetType<value> extends 'keychain'
+                ? { keyId?: Address.Address | undefined }
+                : {})
+            >
 }
 
 /**
@@ -1185,24 +1223,14 @@ export function fromRpc(envelope: SignatureEnvelopeRpc): SignatureEnvelope {
 
   if (
     (envelope as { type?: string | undefined }).type === 'multisig' ||
-    ('signatures' in envelope && ('account' in envelope || 'init' in envelope))
+    ('config' in envelope && 'signatures' in envelope)
   ) {
     const multisig = envelope as MultisigRpc
-    const hasAccount = typeof multisig.account !== 'undefined'
-    const hasInit = typeof multisig.init !== 'undefined'
-    if (hasAccount === hasInit)
-      throw new InvalidMultisigApprovalError({
-        reason: 'RPC multisig must contain exactly one of `account` or `init`',
-      })
-    const init = hasInit
-      ? MultisigConfig.from(multisig.init as MultisigConfig.Config)
-      : undefined
-    const account = init ? MultisigConfig.getAddress(init) : multisig.account
     const result = {
-      type: 'multisig',
-      account: account as Address.Address,
+      account: multisig.account,
+      config: MultisigConfig.fromRpc(multisig.config),
       signatures: multisig.signatures.map((signature) => fromRpc(signature)),
-      ...(init ? { init } : {}),
+      type: 'multisig',
     } satisfies Multisig
     assert(result)
     return result
@@ -1216,7 +1244,7 @@ export declare namespace fromRpc {
     | assert.ErrorType
     | CoercionError
     | InvalidSerializedError
-    | MultisigConfig.getAddress.ErrorType
+    | MultisigConfig.fromRpc.ErrorType
     | Signature.fromRpc.ErrorType
     | Errors.GlobalErrorType
 }
@@ -1287,12 +1315,7 @@ export function getType<
     return 'keychain' as never
 
   // Detect Multisig signature
-  if (
-    ('account' in envelope ||
-      'initialConfig' in envelope ||
-      'init' in envelope) &&
-    'signatures' in envelope
-  )
+  if ('config' in envelope && 'signatures' in envelope)
     return 'multisig' as never
 
   throw new CoercionError({
@@ -1309,7 +1332,7 @@ export function getType<
  * - WebAuthn: `0x02` + webauthnData (variable) + r (32) + s (32) + pubKeyX (32) + pubKeyY (32)
  * - Keychain V1: `0x03` + userAddress (20) + inner signature (recursive)
  * - Keychain V2: `0x04` + userAddress (20) + inner signature (recursive)
- * - Multisig: `0x05` + RLP `[account | init, signatures]`
+ * - Multisig: `0x05` + RLP `[account, config, signatures]`
  *
  * [Signature Types](https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#signature-types)
  *
@@ -1392,14 +1415,11 @@ export function serialize(
   if (type === 'multisig') {
     const multisig = envelope as Multisig
     assert(multisig)
-    // The first field is either the initialized account or the bootstrap init
-    // config. Each owner approval is an encoded signature.
     return Hex.concat(
       serializedMultisigType,
       Rlp.fromHex([
-        multisig.init
-          ? MultisigConfig.toTuple(multisig.init)
-          : multisig.account,
+        multisig.account,
+        MultisigConfig.toTuple(multisig.config),
         multisig.signatures.map((signature) => serialize(signature)),
       ]),
       options.magic ? magicBytes : '0x',
@@ -1440,21 +1460,19 @@ export declare namespace serialize {
  * recovered owner address. Works for any owner key type (secp256k1, p256,
  * webAuthn).
  *
- * Config updates never change `account`, so the initial config is the correct
- * input even for post-update transactions.
- *
  * @example
  * ```ts twoslash
  * import { Secp256k1 } from 'ox'
  * import { MultisigConfig, SignatureEnvelope, TxEnvelopeTempo } from 'ox/tempo'
  *
- * const initialConfig = MultisigConfig.from({
- *   threshold: 2,
+ * const config = MultisigConfig.from({
  *   owners: [
  *     { owner: '0x1111111111111111111111111111111111111111', weight: 1 },
  *     { owner: '0x2222222222222222222222222222222222222222', weight: 1 },
  *   ],
+ *   threshold: 2,
  * })
+ * const account = MultisigConfig.getAddress(config)
  *
  * const tx = TxEnvelopeTempo.from({ chainId: 1, calls: [] })
  * const payload = TxEnvelopeTempo.getSignPayload(tx)
@@ -1464,15 +1482,17 @@ export declare namespace serialize {
  *   Secp256k1.randomPrivateKey(),
  * ]
  * const digest = MultisigConfig.getSignPayload({
+ *   account,
+ *   config,
  *   payload,
- *   initialConfig,
  * })
  * const signatures = privateKeys.map((privateKey) =>
  *   SignatureEnvelope.from(Secp256k1.sign({ payload: digest, privateKey })),
  * )
  *
  * const ordered = SignatureEnvelope.sortMultisigApprovals({ // [!code focus]
- *   initialConfig, // [!code focus]
+ *   account, // [!code focus]
+ *   config, // [!code focus]
  *   payload, // [!code focus]
  *   signatures, // [!code focus]
  * }) // [!code focus]
@@ -1484,16 +1504,12 @@ export declare namespace serialize {
 export function sortMultisigApprovals(
   value: sortMultisigApprovals.Value,
 ): readonly SignatureEnvelope[] {
-  const { payload, signatures, version = 0n } = value
-  const digest = MultisigConfig.getSignPayload(
-    'initialConfig' in value && value.initialConfig
-      ? { payload, initialConfig: value.initialConfig, version }
-      : {
-          payload,
-          account: (value as { account: Address.Address }).account,
-          version,
-        },
-  )
+  const { account, config, payload, signatures } = value
+  const digest = MultisigConfig.getSignPayload({
+    account,
+    config: MultisigConfig.from(config),
+    payload,
+  })
   // Recover each signer once (decorate–sort–undecorate) rather than inside the
   // comparator.
   return signatures
@@ -1507,25 +1523,15 @@ export function sortMultisigApprovals(
 
 export declare namespace sortMultisigApprovals {
   type Value = {
+    /** The native multisig account address. */
+    account: Address.Address
+    /** Complete applicable multisig configuration witness. */
+    config: MultisigConfig.Input
     /** The inner transaction sign payload (`tx.signature_hash()`). */
     payload: Hex.Hex | Bytes.Bytes
     /** The owner approvals to order. */
     signatures: readonly SignatureEnvelope[]
-    /** Current multisig config version. Defaults to `0n`. */
-    version?: bigint | undefined
-  } & OneOf<
-    | {
-        /** The native multisig account address. */
-        account: Address.Address
-      }
-    | {
-        /**
-         * The initial multisig config (the bootstrap config that derived the
-         * permanent `account`). Used to derive the account automatically.
-         */
-        initialConfig: MultisigConfig.Config
-      }
-  >
+  }
 
   type ErrorType =
     | MultisigConfig.getSignPayload.ErrorType
@@ -1605,25 +1611,10 @@ export function toRpc<const envelope extends toRpc.Input>(
   if (type === 'multisig') {
     const multisig = envelope as Multisig
     assert(multisig)
-    const signatures = multisig.signatures.map((signature) => toRpc(signature))
-    if (multisig.init) {
-      const init = {
-        ...multisig.init,
-        salt: multisig.init.salt ?? MultisigConfig.zeroSalt,
-        threshold: Number(multisig.init.threshold),
-        owners: multisig.init.owners.map((owner) => ({
-          ...owner,
-          weight: Number(owner.weight),
-        })),
-      }
-      return {
-        init,
-        signatures,
-      } as never
-    }
     return {
       account: multisig.account,
-      signatures,
+      config: MultisigConfig.toRpc(multisig.config),
+      signatures: multisig.signatures.map((signature) => toRpc(signature)),
     } as never
   }
 
@@ -1651,6 +1642,7 @@ export declare namespace toRpc {
   type ErrorType =
     | assert.ErrorType
     | CoercionError
+    | MultisigConfig.toRpc.ErrorType
     | Signature.toRpc.ErrorType
     | Errors.GlobalErrorType
 }

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -1081,7 +1081,7 @@ export declare namespace from {
         /** Initial native multisig account, derived from config when omitted. */
         account?: Address.Address | undefined
         /** Initial version-0 multisig configuration witness. */
-        config: MultisigConfig.Input<0n>
+        config: MultisigConfig.Input<0 | 0n>
         /** Primitive or nested owner approvals. */
         signatures: readonly SignatureEnvelope[]
         type?: 'multisig' | undefined

--- a/src/tempo/multisig.e2e.test.ts
+++ b/src/tempo/multisig.e2e.test.ts
@@ -49,26 +49,19 @@ describe('behavior: multisig (TIP-1061)', () => {
   }
 
   function approve(parameters: {
-    config?: MultisigConfig.Config | undefined
-    initialConfig: MultisigConfig.Config
+    address?: Address.Address | undefined
+    config: MultisigConfig.Config
     payload: Hex.Hex
     signers: readonly { privateKey: Hex.Hex }[]
-    version?: bigint | undefined
   }) {
     const {
-      config: config_,
-      initialConfig,
+      address = MultisigConfig.getAddress(parameters.config),
+      config,
       payload,
       signers,
-      version = 0n,
     } = parameters
-    const account = MultisigConfig.getAddress(initialConfig)
-    const config = MultisigConfig.from({
-      ...(config_ ?? initialConfig),
-      version,
-    })
     const digest = MultisigConfig.getSignPayload({
-      account,
+      account: address,
       config,
       payload,
     })
@@ -79,28 +72,10 @@ describe('behavior: multisig (TIP-1061)', () => {
     )
     // The node requires approvals ordered by recovered owner address.
     return SignatureEnvelope.sortMultisigApprovals({
-      account,
+      account: address,
       config,
       payload,
       signatures,
-    })
-  }
-
-  function multisigSignature(parameters: {
-    config?: MultisigConfig.Config | undefined
-    initialConfig: MultisigConfig.Config
-    payload: Hex.Hex
-    signers: readonly { privateKey: Hex.Hex }[]
-    version?: bigint | undefined
-  }): SignatureEnvelope.Multisig {
-    const config = MultisigConfig.from({
-      ...(parameters.config ?? parameters.initialConfig),
-      version: parameters.version ?? 0n,
-    })
-    return SignatureEnvelope.from({
-      account: MultisigConfig.getAddress(parameters.initialConfig),
-      config,
-      signatures: approve(parameters),
     })
   }
 
@@ -126,10 +101,14 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
     const receipt = await send(
       TxEnvelopeTempo.serialize(transaction, {
-        signature: multisigSignature({
-          initialConfig: multisig.initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(transaction),
-          signers: multisig.ownerKeys,
+        signature: SignatureEnvelope.from({
+          account: multisig.account,
+          config: multisig.initialConfig,
+          signatures: approve({
+            config: multisig.initialConfig,
+            payload: TxEnvelopeTempo.getSignPayload(transaction),
+            signers: multisig.ownerKeys,
+          }),
         }),
       }),
     )
@@ -163,9 +142,10 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
     const replacement = createKey()
     const rotatedConfig = MultisigConfig.from({
+      owners: [{ owner: replacement.address, weight: 1 }],
       salt: initialConfig.salt,
       threshold: 1,
-      owners: [{ owner: replacement.address, weight: 1 }],
+      version: 1,
     })
 
     await fundAddress(client, { address: account })
@@ -181,10 +161,14 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
-      signature: multisigSignature({
-        initialConfig,
-        payload: TxEnvelopeTempo.getSignPayload(bootstrap),
-        signers: [ownerKeys[0]!, ownerKeys[1]!],
+      signature: SignatureEnvelope.from({
+        account,
+        config: initialConfig,
+        signatures: approve({
+          config: initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
+          signers: [ownerKeys[0]!, ownerKeys[1]!],
+        }),
       }),
     })
 
@@ -235,10 +219,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const updateSigned = TxEnvelopeTempo.serialize(update, {
-      signature: multisigSignature({
-        initialConfig,
-        payload: TxEnvelopeTempo.getSignPayload(update),
-        signers: [ownerKeys[0]!, ownerKeys[1]!],
+      signature: SignatureEnvelope.from({
+        account,
+        config: initialConfig,
+        signatures: approve({
+          config: initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(update),
+          signers: [ownerKeys[0]!, ownerKeys[1]!],
+        }),
       }),
     })
     const updateReceipt = (await client
@@ -265,12 +253,15 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const spend_signed = TxEnvelopeTempo.serialize(spend, {
-      signature: multisigSignature({
+      signature: SignatureEnvelope.from({
+        account,
         config: rotatedConfig,
-        initialConfig,
-        payload: TxEnvelopeTempo.getSignPayload(spend),
-        signers: [replacement],
-        version: 1n,
+        signatures: approve({
+          address: account,
+          config: rotatedConfig,
+          payload: TxEnvelopeTempo.getSignPayload(spend),
+          signers: [replacement],
+        }),
       }),
     })
 
@@ -299,10 +290,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const childBootstrapSigned = TxEnvelopeTempo.serialize(childBootstrap, {
-      signature: multisigSignature({
-        initialConfig: child.initialConfig,
-        payload: TxEnvelopeTempo.getSignPayload(childBootstrap),
-        signers: child.ownerKeys,
+      signature: SignatureEnvelope.from({
+        account: child.account,
+        config: child.initialConfig,
+        signatures: approve({
+          config: child.initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(childBootstrap),
+          signers: child.ownerKeys,
+        }),
       }),
     })
     const childReceipt = (await client
@@ -335,10 +330,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       config: initialConfig,
       payload: TxEnvelopeTempo.getSignPayload(bootstrap),
     })
-    const nested = multisigSignature({
-      initialConfig: child.initialConfig,
-      payload: digest,
-      signers: child.ownerKeys,
+    const nested = SignatureEnvelope.from({
+      account: child.account,
+      config: child.initialConfig,
+      signatures: approve({
+        config: child.initialConfig,
+        payload: digest,
+        signers: child.ownerKeys,
+      }),
     })
     const bootstrapSigned = TxEnvelopeTempo.serialize(bootstrap, {
       signature: SignatureEnvelope.from({
@@ -371,10 +370,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       config: initialConfig,
       payload: TxEnvelopeTempo.getSignPayload(transaction),
     })
-    const childSignature = multisigSignature({
-      initialConfig: child.initialConfig,
-      payload: parentDigest,
-      signers: child.ownerKeys,
+    const childSignature = SignatureEnvelope.from({
+      account: child.account,
+      config: child.initialConfig,
+      signatures: approve({
+        config: child.initialConfig,
+        payload: parentDigest,
+        signers: child.ownerKeys,
+      }),
     })
     const serialized = TxEnvelopeTempo.serialize(transaction, {
       signature: SignatureEnvelope.from({
@@ -411,10 +414,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const signedByOwners = TxEnvelopeTempo.from(transaction, {
-      signature: multisigSignature({
-        initialConfig: multisig.initialConfig,
-        payload: TxEnvelopeTempo.getSignPayload(transaction),
-        signers: multisig.ownerKeys,
+      signature: SignatureEnvelope.from({
+        account: multisig.account,
+        config: multisig.initialConfig,
+        signatures: approve({
+          config: multisig.initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(transaction),
+          signers: multisig.ownerKeys,
+        }),
       }),
     })
     const sponsored = TxEnvelopeTempo.from({
@@ -462,10 +469,14 @@ describe('behavior: multisig (TIP-1061)', () => {
     const sponsored = TxEnvelopeTempo.from(transaction, { feePayerSignature })
     const receipt = await send(
       TxEnvelopeTempo.serialize(sponsored, {
-        signature: multisigSignature({
-          initialConfig: multisig.initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(sponsored),
-          signers: multisig.ownerKeys,
+        signature: SignatureEnvelope.from({
+          account: multisig.account,
+          config: multisig.initialConfig,
+          signatures: approve({
+            config: multisig.initialConfig,
+            payload: TxEnvelopeTempo.getSignPayload(sponsored),
+            signers: multisig.ownerKeys,
+          }),
         }),
       }),
     )
@@ -498,10 +509,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       signers: readonly { privateKey: Hex.Hex }[],
     ) =>
       TxEnvelopeTempo.serialize(value, {
-        signature: multisigSignature({
-          initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(value),
-          signers,
+        signature: SignatureEnvelope.from({
+          account,
+          config: initialConfig,
+          signatures: approve({
+            config: initialConfig,
+            payload: TxEnvelopeTempo.getSignPayload(value),
+            signers,
+          }),
         }),
       })
 
@@ -566,10 +581,14 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
-      signature: multisigSignature({
-        initialConfig,
-        payload: TxEnvelopeTempo.getSignPayload(bootstrap),
-        signers: ownerKeys,
+      signature: SignatureEnvelope.from({
+        account,
+        config: initialConfig,
+        signatures: approve({
+          config: initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
+          signers: ownerKeys,
+        }),
       }),
     })
 
@@ -612,10 +631,14 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const authorize_signed = TxEnvelopeTempo.serialize(authorize, {
-      signature: multisigSignature({
-        initialConfig,
-        payload: TxEnvelopeTempo.getSignPayload(authorize),
-        signers: ownerKeys,
+      signature: SignatureEnvelope.from({
+        account,
+        config: initialConfig,
+        signatures: approve({
+          config: initialConfig,
+          payload: TxEnvelopeTempo.getSignPayload(authorize),
+          signers: ownerKeys,
+        }),
       }),
     })
 
@@ -736,10 +759,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       type: 'secp256k1',
     })
     const keyAuthorizationSigned = KeyAuthorization.from(keyAuthorization, {
-      signature: multisigSignature({
-        initialConfig: multisig.initialConfig,
-        payload: KeyAuthorization.getSignPayload(keyAuthorization),
-        signers: multisig.ownerKeys,
+      signature: SignatureEnvelope.from({
+        account: multisig.account,
+        config: multisig.initialConfig,
+        signatures: approve({
+          config: multisig.initialConfig,
+          payload: KeyAuthorization.getSignPayload(keyAuthorization),
+          signers: multisig.ownerKeys,
+        }),
       }),
     })
     const transaction = TxEnvelopeTempo.from({
@@ -778,10 +805,14 @@ describe('behavior: multisig (TIP-1061)', () => {
       type: 'secp256k1',
     })
     const keyAuthorizationSigned = KeyAuthorization.from(keyAuthorization, {
-      signature: multisigSignature({
-        initialConfig: multisig.initialConfig,
-        payload: KeyAuthorization.getSignPayload(keyAuthorization),
-        signers: multisig.ownerKeys,
+      signature: SignatureEnvelope.from({
+        account: multisig.account,
+        config: multisig.initialConfig,
+        signatures: approve({
+          config: multisig.initialConfig,
+          payload: KeyAuthorization.getSignPayload(keyAuthorization),
+          signers: multisig.ownerKeys,
+        }),
       }),
     })
     const bootstrapTransaction = TxEnvelopeTempo.from({
@@ -796,10 +827,14 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
     const bootstrapReceipt = await send(
       TxEnvelopeTempo.serialize(bootstrapTransaction, {
-        signature: multisigSignature({
-          initialConfig: multisig.initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(bootstrapTransaction),
-          signers: multisig.ownerKeys,
+        signature: SignatureEnvelope.from({
+          account: multisig.account,
+          config: multisig.initialConfig,
+          signatures: approve({
+            config: multisig.initialConfig,
+            payload: TxEnvelopeTempo.getSignPayload(bootstrapTransaction),
+            signers: multisig.ownerKeys,
+          }),
         }),
       }),
     )

--- a/src/tempo/multisig.e2e.test.ts
+++ b/src/tempo/multisig.e2e.test.ts
@@ -49,16 +49,28 @@ describe('behavior: multisig (TIP-1061)', () => {
   }
 
   function approve(parameters: {
+    config?: MultisigConfig.Config | undefined
     initialConfig: MultisigConfig.Config
     payload: Hex.Hex
     signers: readonly { privateKey: Hex.Hex }[]
     version?: bigint | undefined
   }) {
-    const { initialConfig, payload, signers, version = 0n } = parameters
-    const digest = MultisigConfig.getSignPayload({
-      payload,
+    const {
+      config: config_,
       initialConfig,
+      payload,
+      signers,
+      version = 0n,
+    } = parameters
+    const account = MultisigConfig.getAddress(initialConfig)
+    const config = MultisigConfig.from({
+      ...(config_ ?? initialConfig),
       version,
+    })
+    const digest = MultisigConfig.getSignPayload({
+      account,
+      config,
+      payload,
     })
     const signatures = signers.map((signer) =>
       SignatureEnvelope.from(
@@ -67,25 +79,28 @@ describe('behavior: multisig (TIP-1061)', () => {
     )
     // The node requires approvals ordered by recovered owner address.
     return SignatureEnvelope.sortMultisigApprovals({
-      initialConfig,
+      account,
+      config,
       payload,
       signatures,
-      version,
     })
   }
 
   function multisigSignature(parameters: {
+    config?: MultisigConfig.Config | undefined
     initialConfig: MultisigConfig.Config
     payload: Hex.Hex
     signers: readonly { privateKey: Hex.Hex }[]
-    init?: boolean | undefined
     version?: bigint | undefined
-  }) {
-    const { init = false, ...approval } = parameters
+  }): SignatureEnvelope.Multisig {
+    const config = MultisigConfig.from({
+      ...(parameters.config ?? parameters.initialConfig),
+      version: parameters.version ?? 0n,
+    })
     return SignatureEnvelope.from({
-      initialConfig: parameters.initialConfig,
-      ...(init ? { init: true } : {}),
-      signatures: approve(approval),
+      account: MultisigConfig.getAddress(parameters.initialConfig),
+      config,
+      signatures: approve(parameters),
     })
   }
 
@@ -113,7 +128,6 @@ describe('behavior: multisig (TIP-1061)', () => {
       TxEnvelopeTempo.serialize(transaction, {
         signature: multisigSignature({
           initialConfig: multisig.initialConfig,
-          init: true,
           payload: TxEnvelopeTempo.getSignPayload(transaction),
           signers: multisig.ownerKeys,
         }),
@@ -167,14 +181,10 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
-      signature: SignatureEnvelope.from({
+      signature: multisigSignature({
         initialConfig,
-        init: true,
-        signatures: approve({
-          initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
-          signers: [ownerKeys[0]!, ownerKeys[1]!],
-        }),
+        payload: TxEnvelopeTempo.getSignPayload(bootstrap),
+        signers: [ownerKeys[0]!, ownerKeys[1]!],
       }),
     })
 
@@ -199,7 +209,7 @@ describe('behavior: multisig (TIP-1061)', () => {
       expect(response.from).toBe(account)
       expect(response.signature?.type).toBe('multisig')
       expect(
-        (response.signature as SignatureEnvelope.Multisig | undefined)?.init,
+        (response.signature as SignatureEnvelope.Multisig | undefined)?.config,
       ).toEqual(initialConfig)
     }
 
@@ -225,13 +235,10 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const updateSigned = TxEnvelopeTempo.serialize(update, {
-      signature: SignatureEnvelope.from({
+      signature: multisigSignature({
         initialConfig,
-        signatures: approve({
-          initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(update),
-          signers: [ownerKeys[0]!, ownerKeys[1]!],
-        }),
+        payload: TxEnvelopeTempo.getSignPayload(update),
+        signers: [ownerKeys[0]!, ownerKeys[1]!],
       }),
     })
     const updateReceipt = (await client
@@ -258,14 +265,12 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const spend_signed = TxEnvelopeTempo.serialize(spend, {
-      signature: SignatureEnvelope.from({
+      signature: multisigSignature({
+        config: rotatedConfig,
         initialConfig,
-        signatures: approve({
-          initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(spend),
-          signers: [replacement],
-          version: 1n,
-        }),
+        payload: TxEnvelopeTempo.getSignPayload(spend),
+        signers: [replacement],
+        version: 1n,
       }),
     })
 
@@ -294,14 +299,10 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const childBootstrapSigned = TxEnvelopeTempo.serialize(childBootstrap, {
-      signature: SignatureEnvelope.from({
+      signature: multisigSignature({
         initialConfig: child.initialConfig,
-        init: true,
-        signatures: approve({
-          initialConfig: child.initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(childBootstrap),
-          signers: child.ownerKeys,
-        }),
+        payload: TxEnvelopeTempo.getSignPayload(childBootstrap),
+        signers: child.ownerKeys,
       }),
     })
     const childReceipt = (await client
@@ -330,21 +331,19 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const digest = MultisigConfig.getSignPayload({
-      initialConfig,
+      account,
+      config: initialConfig,
       payload: TxEnvelopeTempo.getSignPayload(bootstrap),
     })
-    const nested = SignatureEnvelope.from({
+    const nested = multisigSignature({
       initialConfig: child.initialConfig,
-      signatures: approve({
-        initialConfig: child.initialConfig,
-        payload: digest,
-        signers: child.ownerKeys,
-      }),
+      payload: digest,
+      signers: child.ownerKeys,
     })
     const bootstrapSigned = TxEnvelopeTempo.serialize(bootstrap, {
       signature: SignatureEnvelope.from({
-        initialConfig,
-        init: true,
+        account,
+        config: initialConfig,
         signatures: [nested],
       }),
     })
@@ -368,7 +367,8 @@ describe('behavior: multisig (TIP-1061)', () => {
       maxPriorityFeePerGas: Value.fromGwei('10'),
     })
     const parentDigest = MultisigConfig.getSignPayload({
-      initialConfig,
+      account,
+      config: initialConfig,
       payload: TxEnvelopeTempo.getSignPayload(transaction),
     })
     const childSignature = multisigSignature({
@@ -378,7 +378,8 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
     const serialized = TxEnvelopeTempo.serialize(transaction, {
       signature: SignatureEnvelope.from({
-        initialConfig,
+        account,
+        config: initialConfig,
         signatures: [childSignature],
       }),
     })
@@ -495,12 +496,10 @@ describe('behavior: multisig (TIP-1061)', () => {
     const serialize = (
       value: ReturnType<typeof transaction>,
       signers: readonly { privateKey: Hex.Hex }[],
-      init = false,
     ) =>
       TxEnvelopeTempo.serialize(value, {
         signature: multisigSignature({
           initialConfig,
-          init,
           payload: TxEnvelopeTempo.getSignPayload(value),
           signers,
         }),
@@ -510,7 +509,7 @@ describe('behavior: multisig (TIP-1061)', () => {
     const bootstrapReceipt = (await client
       .request({
         method: 'eth_sendRawTransactionSync',
-        params: [serialize(bootstrap, [ownerKeys[0]!, ownerKeys[1]!], true)],
+        params: [serialize(bootstrap, [ownerKeys[0]!, ownerKeys[1]!])],
       })
       .then((tx) => TransactionReceipt.fromRpc(tx as any)))!
     expect(bootstrapReceipt.status).toBe('success')
@@ -567,14 +566,10 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const bootstrap_signed = TxEnvelopeTempo.serialize(bootstrap, {
-      signature: SignatureEnvelope.from({
+      signature: multisigSignature({
         initialConfig,
-        init: true,
-        signatures: approve({
-          initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(bootstrap),
-          signers: ownerKeys,
-        }),
+        payload: TxEnvelopeTempo.getSignPayload(bootstrap),
+        signers: ownerKeys,
       }),
     })
 
@@ -617,13 +612,10 @@ describe('behavior: multisig (TIP-1061)', () => {
     })
 
     const authorize_signed = TxEnvelopeTempo.serialize(authorize, {
-      signature: SignatureEnvelope.from({
+      signature: multisigSignature({
         initialConfig,
-        signatures: approve({
-          initialConfig,
-          payload: TxEnvelopeTempo.getSignPayload(authorize),
-          signers: ownerKeys,
-        }),
+        payload: TxEnvelopeTempo.getSignPayload(authorize),
+        signers: ownerKeys,
       }),
     })
 
@@ -746,7 +738,6 @@ describe('behavior: multisig (TIP-1061)', () => {
     const keyAuthorizationSigned = KeyAuthorization.from(keyAuthorization, {
       signature: multisigSignature({
         initialConfig: multisig.initialConfig,
-        init: true,
         payload: KeyAuthorization.getSignPayload(keyAuthorization),
         signers: multisig.ownerKeys,
       }),
@@ -807,7 +798,6 @@ describe('behavior: multisig (TIP-1061)', () => {
       TxEnvelopeTempo.serialize(bootstrapTransaction, {
         signature: multisigSignature({
           initialConfig: multisig.initialConfig,
-          init: true,
           payload: TxEnvelopeTempo.getSignPayload(bootstrapTransaction),
           signers: multisig.ownerKeys,
         }),

--- a/src/tempo/multisig.e2e.test.ts
+++ b/src/tempo/multisig.e2e.test.ts
@@ -9,7 +9,7 @@ import * as TxEnvelopeTempo from './TxEnvelopeTempo.js'
 
 const chainId = chain.id
 const updateConfig = AbiFunction.from(
-  'function updateConfig(uint8 threshold, (address owner, uint8 weight)[] owners)',
+  'function updateConfig((bytes32 salt, uint64 version, uint8 threshold, (address owner, uint8 weight)[] owners) current, uint8 threshold, (address owner, uint8 weight)[] owners)',
 )
 
 describe('behavior: multisig (TIP-1061)', () => {
@@ -206,6 +206,7 @@ describe('behavior: multisig (TIP-1061)', () => {
         {
           to: '0xaacc000000000000000000000000000000000000',
           data: AbiFunction.encodeData(updateConfig, [
+            initialConfig,
             rotatedConfig.threshold,
             rotatedConfig.owners,
           ]),
@@ -713,6 +714,7 @@ describe('behavior: multisig (TIP-1061)', () => {
         {
           to: '0xaacc000000000000000000000000000000000000',
           data: AbiFunction.encodeData(updateConfig, [
+            initialConfig,
             initialConfig.threshold,
             initialConfig.owners,
           ]),

--- a/test/tempo/multisig.ts
+++ b/test/tempo/multisig.ts
@@ -1,3 +1,3 @@
 export const port = 3001
 
-export const tag = 'sha-4e74a2c'
+export const tag = 'sha-896b990'


### PR DESCRIPTION
Adds complete TIP-1061 configuration witnesses to multisig configs and signatures, including versioned commitments, unified envelope encoding, RPC conversion, nested witnesses, and frozen protocol vectors.

Matches https://github.com/tempoxyz/tempo/pull/7241.
