### PR TITLE
feat(tempo): add multisig simulation witnesses

### DIFF
--- a/.changeset/clean-witnesses-simulate.md
+++ b/.changeset/clean-witnesses-simulate.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Added TIP-1061 configuration witnesses to Tempo transaction simulation requests.

--- a/.changeset/clean-witnesses-simulate.md
+++ b/.changeset/clean-witnesses-simulate.md
@@ -2,4 +2,4 @@
 'ox': patch
 ---
 
-Added TIP-1061 configuration witnesses to Tempo transaction simulation requests.
+Added TIP-1061 configuration witnesses and standalone RPC conversion utilities to Tempo transaction simulation requests.

--- a/src/tempo/MultisigWitness.test-d.ts
+++ b/src/tempo/MultisigWitness.test-d.ts
@@ -1,0 +1,42 @@
+import { expectTypeOf, test } from 'vitest'
+import * as MultisigWitness from './MultisigWitness.js'
+
+const rpc = {
+  account: '0x2222222222222222222222222222222222222222',
+  approvals: [
+    {
+      owner: '0x1111111111111111111111111111111111111111',
+      type: 'primitive',
+    },
+  ],
+  config: {
+    owners: [
+      {
+        owner: '0x1111111111111111111111111111111111111111',
+        weight: 1,
+      },
+    ],
+    salt: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    threshold: 1,
+    version: 0,
+  },
+} as const satisfies MultisigWitness.Rpc
+
+test('fromRpc returns a domain witness', () => {
+  const witness = MultisigWitness.fromRpc(rpc)
+
+  expectTypeOf(witness).toEqualTypeOf<MultisigWitness.MultisigWitness>()
+  expectTypeOf(witness.config.version).toEqualTypeOf<bigint>()
+})
+
+test('RPC witnesses use numeric configuration versions', () => {
+  expectTypeOf<
+    MultisigWitness.Rpc['config']['version']
+  >().toEqualTypeOf<number>()
+})
+
+test('toRpc returns an RPC witness', () => {
+  expectTypeOf(
+    MultisigWitness.toRpc(MultisigWitness.fromRpc(rpc)),
+  ).toEqualTypeOf<MultisigWitness.Rpc>()
+})

--- a/src/tempo/MultisigWitness.test.ts
+++ b/src/tempo/MultisigWitness.test.ts
@@ -1,0 +1,216 @@
+import { MultisigWitness } from 'ox/tempo'
+import { describe, expect, test } from 'vitest'
+
+const rpc = {
+  account: '0xcccccccccccccccccccccccccccccccccccccccc',
+  approvals: [
+    {
+      keyData: '0x0578',
+      keyType: 'webAuthn',
+      owner: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      type: 'primitive',
+    },
+    {
+      type: 'multisig',
+      witness: {
+        account: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        approvals: [
+          {
+            keyType: 'secp256k1',
+            owner: '0xdddddddddddddddddddddddddddddddddddddddd',
+          },
+          {
+            owner: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          },
+        ],
+        config: {
+          owners: [
+            {
+              owner: '0xdddddddddddddddddddddddddddddddddddddddd',
+              weight: 1,
+            },
+            {
+              owner: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+              weight: 1,
+            },
+          ],
+          salt: '0x2222222222222222222222222222222222222222222222222222222222222222',
+          threshold: 2,
+          version: 2,
+        },
+      },
+    },
+  ],
+  config: {
+    owners: [
+      {
+        owner: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        weight: 1,
+      },
+      {
+        owner: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        weight: 1,
+      },
+    ],
+    salt: '0x1111111111111111111111111111111111111111111111111111111111111111',
+    threshold: 2,
+    version: 1,
+  },
+} as const satisfies MultisigWitness.Rpc
+
+describe('fromRpc', () => {
+  test('behavior: converts numeric configuration versions to bigint', () => {
+    expect(MultisigWitness.fromRpc(rpc)).toMatchInlineSnapshot(`
+      {
+        "account": "0xcccccccccccccccccccccccccccccccccccccccc",
+        "approvals": [
+          {
+            "keyData": "0x0578",
+            "keyType": "webAuthn",
+            "owner": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "type": "primitive",
+          },
+          {
+            "type": "multisig",
+            "witness": {
+              "account": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "approvals": [
+                {
+                  "keyType": "secp256k1",
+                  "owner": "0xdddddddddddddddddddddddddddddddddddddddd",
+                },
+                {
+                  "owner": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                },
+              ],
+              "config": {
+                "owners": [
+                  {
+                    "owner": "0xdddddddddddddddddddddddddddddddddddddddd",
+                    "weight": 1,
+                  },
+                  {
+                    "owner": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "weight": 1,
+                  },
+                ],
+                "salt": "0x2222222222222222222222222222222222222222222222222222222222222222",
+                "threshold": 2,
+                "version": 2n,
+              },
+            },
+          },
+        ],
+        "config": {
+          "owners": [
+            {
+              "owner": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "weight": 1,
+            },
+            {
+              "owner": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "threshold": 2,
+          "version": 1n,
+        },
+      }
+    `)
+  })
+
+  test('error: rejects unsafe numeric configuration versions', () => {
+    expect(() =>
+      MultisigWitness.fromRpc({
+        ...rpc,
+        config: {
+          ...rpc.config,
+          version: Number.MAX_SAFE_INTEGER + 1,
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[MultisigConfig.InvalidConfigError: Invalid native multisig config: version must be an unsigned 64-bit integer.]`,
+    )
+  })
+})
+
+describe('toRpc', () => {
+  test('behavior: converts bigint configuration versions to numbers', () => {
+    expect(
+      MultisigWitness.toRpc(MultisigWitness.fromRpc(rpc)),
+    ).toMatchInlineSnapshot(`
+      {
+        "account": "0xcccccccccccccccccccccccccccccccccccccccc",
+        "approvals": [
+          {
+            "keyData": "0x0578",
+            "keyType": "webAuthn",
+            "owner": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "type": "primitive",
+          },
+          {
+            "type": "multisig",
+            "witness": {
+              "account": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "approvals": [
+                {
+                  "keyType": "secp256k1",
+                  "owner": "0xdddddddddddddddddddddddddddddddddddddddd",
+                },
+                {
+                  "owner": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                },
+              ],
+              "config": {
+                "owners": [
+                  {
+                    "owner": "0xdddddddddddddddddddddddddddddddddddddddd",
+                    "weight": 1,
+                  },
+                  {
+                    "owner": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                    "weight": 1,
+                  },
+                ],
+                "salt": "0x2222222222222222222222222222222222222222222222222222222222222222",
+                "threshold": 2,
+                "version": 2,
+              },
+            },
+          },
+        ],
+        "config": {
+          "owners": [
+            {
+              "owner": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "weight": 1,
+            },
+            {
+              "owner": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "weight": 1,
+            },
+          ],
+          "salt": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "threshold": 2,
+          "version": 1,
+        },
+      }
+    `)
+  })
+
+  test('error: rejects versions that JSON cannot represent exactly', () => {
+    const witness = MultisigWitness.fromRpc(rpc)
+    expect(() =>
+      MultisigWitness.toRpc({
+        ...witness,
+        config: {
+          ...witness.config,
+          version: BigInt(Number.MAX_SAFE_INTEGER) + 1n,
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Hex.IntegerOutOfRangeError: Number \`9007199254740992\` is not in safe unsigned integer range (\`0\` to \`9007199254740991\`)]`,
+    )
+  })
+})

--- a/src/tempo/MultisigWitness.ts
+++ b/src/tempo/MultisigWitness.ts
@@ -1,0 +1,157 @@
+import type * as Address from '../core/Address.js'
+import type * as Errors from '../core/Errors.js'
+import * as Hex from '../core/Hex.js'
+import type { Compute } from '../core/internal/types.js'
+import * as MultisigConfig from './MultisigConfig.js'
+import type * as SignatureEnvelope from './SignatureEnvelope.js'
+
+/** Native multisig owner approval used for RPC simulation. */
+export type Approval<versionType = bigint> =
+  | NestedApproval<versionType>
+  | PrimitiveApproval
+
+/** Native multisig witness used to construct an RPC simulation signature. */
+export type MultisigWitness<versionType = bigint> = Compute<{
+  /** Account authorized by this witness. */
+  account: Address.Address
+  /** Owner approvals to model. */
+  approvals: readonly Approval<versionType>[]
+  /** Complete applicable configuration. */
+  config: MultisigConfig.Config<versionType>
+}>
+
+/** Nested native multisig owner approval used for RPC simulation. */
+export type NestedApproval<versionType = bigint> = {
+  /** Approval type. */
+  type: 'multisig'
+  /** Depth-2 multisig witness. */
+  witness: NestedWitness<versionType>
+}
+
+/** Primitive approval in a depth-2 multisig simulation witness. */
+export type NestedPrimitiveApproval = {
+  /** Optional signature-specific gas-estimation data. */
+  keyData?: Hex.Hex | undefined
+  /** Signature type to model. Omission uses a maximum-size WebAuthn signature. */
+  keyType?: SignatureEnvelope.Type | undefined
+  /** Configured owner address. */
+  owner: Address.Address
+}
+
+/** Depth-2 native multisig witness used for RPC simulation. */
+export type NestedWitness<versionType = bigint> = {
+  /** Nested multisig account. */
+  account: Address.Address
+  /** Primitive owner approvals to model. */
+  approvals: readonly NestedPrimitiveApproval[]
+  /** Complete applicable configuration. */
+  config: MultisigConfig.Config<versionType>
+}
+
+/** Primitive owner approval used for RPC simulation. */
+export type PrimitiveApproval = {
+  /** Optional signature-specific gas-estimation data. */
+  keyData?: Hex.Hex | undefined
+  /** Signature type to model. Omission uses a maximum-size WebAuthn signature. */
+  keyType?: SignatureEnvelope.Type | undefined
+  /** Configured owner address. */
+  owner: Address.Address
+  /** Approval type. */
+  type: 'primitive'
+}
+
+/** JSON-RPC representation of a native multisig simulation witness. */
+export type Rpc = MultisigWitness<number>
+
+/**
+ * Converts a JSON-RPC multisig witness to its domain representation.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigWitness } from 'ox/tempo'
+ *
+ * const witness = MultisigWitness.fromRpc(witnessRpc)
+ * ```
+ *
+ * @param witness - JSON-RPC multisig witness.
+ * @returns The multisig witness with bigint configuration versions.
+ */
+export function fromRpc(witness: Rpc): MultisigWitness {
+  const { account, approvals, config } = witness
+  return {
+    account,
+    approvals: approvals.map((approval) => {
+      if (approval.type === 'primitive') return approval
+      return {
+        type: 'multisig',
+        witness: {
+          account: approval.witness.account,
+          approvals: approval.witness.approvals,
+          config: MultisigConfig.from(approval.witness.config),
+        },
+      }
+    }),
+    config: MultisigConfig.from(config),
+  }
+}
+
+export declare namespace fromRpc {
+  /** Error type for `fromRpc`. */
+  export type ErrorType =
+    | MultisigConfig.assert.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
+ * Converts a multisig witness to its JSON-RPC representation.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigWitness } from 'ox/tempo'
+ *
+ * const witnessRpc = MultisigWitness.toRpc(witness)
+ * ```
+ *
+ * @param witness - Multisig witness.
+ * @returns The JSON-RPC multisig witness with numeric configuration versions.
+ */
+export function toRpc(witness: MultisigWitness): Rpc {
+  const { account, approvals, config } = witness
+  return {
+    account,
+    approvals: approvals.map((approval) => {
+      if (approval.type === 'primitive') return approval
+      return {
+        type: 'multisig',
+        witness: {
+          account: approval.witness.account,
+          approvals: approval.witness.approvals,
+          config: configToRpc(approval.witness.config),
+        },
+      }
+    }),
+    config: configToRpc(config),
+  }
+}
+
+export declare namespace toRpc {
+  /** Error type for `toRpc`. */
+  export type ErrorType =
+    | Hex.fromNumber.ErrorType
+    | Hex.toNumber.ErrorType
+    | MultisigConfig.assert.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/** @internal */
+function configToRpc(
+  config: MultisigConfig.Config,
+): MultisigConfig.Config<number> {
+  const value = MultisigConfig.from(config)
+  return {
+    ...value,
+    version: Hex.toNumber(Hex.fromNumber(Number(value.version))),
+  }
+}

--- a/src/tempo/RpcSchemaTempo.test-d.ts
+++ b/src/tempo/RpcSchemaTempo.test-d.ts
@@ -2,8 +2,8 @@ import type { Provider } from 'ox'
 import type {
   KeyAuthorization,
   MultisigOperation,
+  MultisigWitness,
   RpcSchemaTempo,
-  TransactionRequest,
 } from 'ox/tempo'
 import { expectTypeOf, test } from 'vitest'
 import type * as Hex from '../core/Hex.js'
@@ -14,7 +14,7 @@ declare const tempoProvider: Provider.Provider<{
 }>
 declare const hash: Hex.Hex
 declare const keyAuthorization: KeyAuthorization.Rpc
-declare const multisigWitness: TransactionRequest.MultisigWitnessRpc
+declare const multisigWitness: MultisigWitness.Rpc
 declare const serializedTransaction: Hex.Hex
 declare const signature: Hex.Hex
 

--- a/src/tempo/RpcSchemaTempo.test-d.ts
+++ b/src/tempo/RpcSchemaTempo.test-d.ts
@@ -3,13 +3,18 @@ import type {
   KeyAuthorization,
   MultisigOperation,
   RpcSchemaTempo,
+  TransactionRequest,
 } from 'ox/tempo'
 import { expectTypeOf, test } from 'vitest'
 import type * as Hex from '../core/Hex.js'
 
 declare const provider: Provider.Provider<{ schema: RpcSchemaTempo.Multisig }>
+declare const tempoProvider: Provider.Provider<{
+  schema: RpcSchemaTempo.Tempo
+}>
 declare const hash: Hex.Hex
 declare const keyAuthorization: KeyAuthorization.Rpc
+declare const multisigWitness: TransactionRequest.MultisigWitnessRpc
 declare const serializedTransaction: Hex.Hex
 declare const signature: Hex.Hex
 
@@ -53,4 +58,24 @@ test('multisig provider methods', () => {
       params: [hash],
     }),
   ).resolves.toEqualTypeOf<MultisigOperation.Rpc | null>()
+})
+
+test('tempo simulation accepts multisig witnesses', () => {
+  tempoProvider.request({
+    method: 'tempo_simulateV1',
+    params: [
+      {
+        blockStateCalls: [
+          {
+            calls: [
+              {
+                multisigWitness,
+              },
+            ],
+          },
+        ],
+      },
+      'latest',
+    ],
+  })
 })

--- a/src/tempo/TransactionRequest.test-d.ts
+++ b/src/tempo/TransactionRequest.test-d.ts
@@ -1,0 +1,23 @@
+import { expectTypeOf, test } from 'vitest'
+import type * as TransactionRequest from './TransactionRequest.js'
+
+declare const request: TransactionRequest.TransactionRequest
+declare const rpc: TransactionRequest.Rpc
+
+test('transaction requests use domain multisig witnesses', () => {
+  expectTypeOf(request.multisigWitness?.config.version).toEqualTypeOf<
+    bigint | undefined
+  >()
+
+  const approval = request.multisigWitness?.approvals[0]
+  if (approval?.type === 'multisig')
+    expectTypeOf(approval.witness.approvals[0]?.keyType).toEqualTypeOf<
+      TransactionRequest.SignatureType | undefined
+    >()
+})
+
+test('RPC requests use numeric multisig config versions', () => {
+  expectTypeOf(rpc.multisigWitness?.config.version).toEqualTypeOf<
+    number | undefined
+  >()
+})

--- a/src/tempo/TransactionRequest.test-d.ts
+++ b/src/tempo/TransactionRequest.test-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf, test } from 'vitest'
+import type * as MultisigWitness from './MultisigWitness.js'
 import type * as TransactionRequest from './TransactionRequest.js'
 
 declare const request: TransactionRequest.TransactionRequest
@@ -12,7 +13,7 @@ test('transaction requests use domain multisig witnesses', () => {
   const approval = request.multisigWitness?.approvals[0]
   if (approval?.type === 'multisig')
     expectTypeOf(approval.witness.approvals[0]?.keyType).toEqualTypeOf<
-      TransactionRequest.SignatureType | undefined
+      MultisigWitness.NestedPrimitiveApproval['keyType']
     >()
 })
 

--- a/src/tempo/TransactionRequest.test.ts
+++ b/src/tempo/TransactionRequest.test.ts
@@ -1,4 +1,4 @@
-import { TransactionRequest } from 'ox/tempo'
+import { type MultisigWitness, TransactionRequest } from 'ox/tempo'
 import { describe, expect, test } from 'vitest'
 
 const multisigWitnessRpc = {
@@ -49,7 +49,7 @@ const multisigWitnessRpc = {
     threshold: 2,
     version: 0,
   },
-} as const satisfies TransactionRequest.MultisigWitnessRpc
+} as const satisfies MultisigWitness.Rpc
 
 const multisigWitness = {
   ...multisigWitnessRpc,
@@ -67,7 +67,7 @@ const multisigWitness = {
     },
   ],
   config: { ...multisigWitnessRpc.config, version: 0n },
-} as const satisfies TransactionRequest.MultisigWitness
+} as const satisfies MultisigWitness.MultisigWitness
 
 describe('fromRpc', () => {
   test('default', () => {

--- a/src/tempo/TransactionRequest.test.ts
+++ b/src/tempo/TransactionRequest.test.ts
@@ -1,6 +1,74 @@
 import { TransactionRequest } from 'ox/tempo'
 import { describe, expect, test } from 'vitest'
 
+const multisigWitnessRpc = {
+  account: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  approvals: [
+    {
+      keyType: 'secp256k1',
+      owner: '0x1111111111111111111111111111111111111111',
+      type: 'primitive',
+    },
+    {
+      type: 'multisig',
+      witness: {
+        account: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        approvals: [
+          {
+            keyData: '0x0578',
+            keyType: 'webAuthn',
+            owner: '0x2222222222222222222222222222222222222222',
+          },
+        ],
+        config: {
+          owners: [
+            {
+              owner: '0x2222222222222222222222222222222222222222',
+              weight: 1,
+            },
+          ],
+          salt: `0x${'22'.repeat(32)}`,
+          threshold: 1,
+          version: 1,
+        },
+      },
+    },
+  ],
+  config: {
+    owners: [
+      {
+        owner: '0x1111111111111111111111111111111111111111',
+        weight: 1,
+      },
+      {
+        owner: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        weight: 1,
+      },
+    ],
+    salt: `0x${'11'.repeat(32)}`,
+    threshold: 2,
+    version: 0,
+  },
+} as const satisfies TransactionRequest.MultisigWitnessRpc
+
+const multisigWitness = {
+  ...multisigWitnessRpc,
+  approvals: [
+    multisigWitnessRpc.approvals[0],
+    {
+      ...multisigWitnessRpc.approvals[1],
+      witness: {
+        ...multisigWitnessRpc.approvals[1].witness,
+        config: {
+          ...multisigWitnessRpc.approvals[1].witness.config,
+          version: 1n,
+        },
+      },
+    },
+  ],
+  config: { ...multisigWitnessRpc.config, version: 0n },
+} as const satisfies TransactionRequest.MultisigWitness
+
 describe('fromRpc', () => {
   test('default', () => {
     const request = TransactionRequest.fromRpc({
@@ -69,6 +137,21 @@ describe('fromRpc', () => {
     expect(request.nonceKey).toBe(255n)
   })
 
+  test('behavior: multisig witness', () => {
+    const request = TransactionRequest.fromRpc({
+      from: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      multisigWitness: multisigWitnessRpc,
+      type: '0x76',
+    })
+
+    expect(request.multisigWitness?.config.version).toBe(0n)
+    const nested = request.multisigWitness?.approvals[1]
+    expect(nested?.type).toBe('multisig')
+    if (nested?.type !== 'multisig') throw new Error('expected multisig')
+    expect(nested.witness.config.version).toBe(1n)
+    expect(nested.witness.approvals[0]?.keyType).toBe('webAuthn')
+  })
+
   test('behavior: empty', () => {
     const request = TransactionRequest.fromRpc({})
     expect(request).toMatchInlineSnapshot('{}')
@@ -122,6 +205,20 @@ describe('toRpc', () => {
       }
     `)
   })
+
+  test('behavior: multisig witness', () => {
+    const request = TransactionRequest.toRpc({
+      from: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      multisigWitness,
+    })
+
+    expect(request.multisigWitness?.config.version).toBe(0)
+    const nested = request.multisigWitness?.approvals[1]
+    expect(nested?.type).toBe('multisig')
+    if (nested?.type !== 'multisig') throw new Error('expected multisig')
+    expect(nested.witness.config.version).toBe(1)
+    expect(request.type).toBe('0x76')
+  })
 })
 
 describe('roundtrip', () => {
@@ -144,6 +241,7 @@ describe('roundtrip', () => {
       nonceKey: 255n,
       gas: 100000n,
       maxFeePerGas: 1000000000n,
+      multisigWitness,
     }
 
     const rpc = TransactionRequest.toRpc(original)
@@ -164,6 +262,7 @@ describe('roundtrip', () => {
     expect(converted.nonceKey).toBe(original.nonceKey)
     expect(converted.gas).toBe(original.gas)
     expect(converted.maxFeePerGas).toBe(original.maxFeePerGas)
+    expect(converted.multisigWitness).toEqual(original.multisigWitness)
     expect(converted.type).toBe('tempo')
   })
 
@@ -181,6 +280,7 @@ describe('roundtrip', () => {
       validAfter: '0x32',
       nonceKey: '0xff',
       gas: '0x186a0',
+      multisigWitness: multisigWitnessRpc,
       type: '0x76',
     }
 
@@ -193,6 +293,7 @@ describe('roundtrip', () => {
     expect(rpc.validAfter).toBe(original.validAfter)
     expect(rpc.nonceKey).toBe(original.nonceKey)
     expect(rpc.gas).toBe(original.gas)
+    expect(rpc.multisigWitness).toEqual(original.multisigWitness)
     expect(rpc.type).toBe('0x76')
   })
 })

--- a/src/tempo/TransactionRequest.ts
+++ b/src/tempo/TransactionRequest.ts
@@ -1,15 +1,67 @@
+import type * as Address from '../core/Address.js'
 import type * as Errors from '../core/Errors.js'
 import * as Hex from '../core/Hex.js'
 import type { Compute } from '../core/internal/types.js'
 import * as ox_TransactionRequest from '../core/TransactionRequest.js'
 import * as AuthorizationTempo from './AuthorizationTempo.js'
 import * as KeyAuthorization from './KeyAuthorization.js'
+import * as MultisigConfig from './MultisigConfig.js'
 import * as TempoAddress from './TempoAddress.js'
 import * as TokenId from './TokenId.js'
 import * as Transaction from './Transaction.js'
 import type { Call } from './TxEnvelopeTempo.js'
 
-type KeyType = 'secp256k1' | 'p256' | 'webAuthn'
+/** Primitive signature type modeled during transaction simulation. */
+export type SignatureType = 'secp256k1' | 'p256' | 'webAuthn'
+
+/** Primitive owner approval modeled during native multisig simulation. */
+export type MultisigPrimitiveApproval = {
+  /** Optional signature-specific gas-estimation data. */
+  keyData?: Hex.Hex | undefined
+  /** Signature type to model. Omission models a maximum-size WebAuthn signature. */
+  keyType?: SignatureType | undefined
+  /** Configured owner address. */
+  owner: Address.Address
+}
+
+/** Depth-2 native multisig witness used during transaction simulation. */
+export type MultisigNestedWitness<bigintType = bigint> = {
+  /** Nested multisig account. */
+  account: Address.Address
+  /** Primitive owner approvals to model. */
+  approvals: readonly MultisigPrimitiveApproval[]
+  /** Complete applicable configuration. */
+  config: MultisigConfig.Config<bigintType>
+}
+
+/** Native multisig owner approval modeled during transaction simulation. */
+export type MultisigApproval<bigintType = bigint> =
+  | (MultisigPrimitiveApproval & { type: 'primitive' })
+  | {
+      /** Approval type. */
+      type: 'multisig'
+      /** Nested multisig witness. */
+      witness: MultisigNestedWitness<bigintType>
+    }
+
+/** Native multisig witness used during transaction simulation. */
+export type MultisigWitness<bigintType = bigint> = {
+  /** Account authorized by this witness. */
+  account: Address.Address
+  /** Owner approvals to model. */
+  approvals: readonly MultisigApproval<bigintType>[]
+  /** Complete applicable configuration. */
+  config: MultisigConfig.Config<bigintType>
+}
+
+/** JSON-RPC representation of a {@link ox#TransactionRequest.MultisigNestedWitness}. */
+export type MultisigNestedWitnessRpc = MultisigNestedWitness<number>
+
+/** JSON-RPC representation of a {@link ox#TransactionRequest.MultisigApproval}. */
+export type MultisigApprovalRpc = MultisigApproval<number>
+
+/** JSON-RPC representation of a {@link ox#TransactionRequest.MultisigWitness}. */
+export type MultisigWitnessRpc = MultisigWitness<number>
 
 /**
  * A Transaction Request that is generic to all transaction types.
@@ -35,9 +87,10 @@ export type TransactionRequest<
     calls?: readonly Call<bigintType, addressType>[] | undefined
     keyAuthorization?: KeyAuthorization.KeyAuthorization<true> | undefined
     keyData?: Hex.Hex | undefined
-    keyType?: KeyType | undefined
+    keyType?: SignatureType | undefined
     feePayer?: boolean | undefined
     feeToken?: TokenId.TokenIdOrAddress<addressType> | undefined
+    multisigWitness?: MultisigWitness<bigintType> | undefined
     nonceKey?: 'random' | bigintType | undefined
     validBefore?: numberType | undefined
     validAfter?: numberType | undefined
@@ -47,11 +100,12 @@ export type TransactionRequest<
 /** RPC representation of a {@link ox#TransactionRequest.TransactionRequest}. */
 export type Rpc = Omit<
   TransactionRequest<Hex.Hex, Hex.Hex, string, Hex.Hex>,
-  'authorizationList' | 'feeToken' | 'keyAuthorization'
+  'authorizationList' | 'feeToken' | 'keyAuthorization' | 'multisigWitness'
 > & {
   authorizationList?: AuthorizationTempo.ListRpc | undefined
   feeToken?: Hex.Hex | undefined
   keyAuthorization?: KeyAuthorization.Rpc | undefined
+  multisigWitness?: MultisigWitnessRpc | undefined
   nonceKey?: Hex.Hex | undefined
 }
 
@@ -76,7 +130,7 @@ export type Rpc = Omit<
  * @returns A transaction request.
  */
 export function fromRpc(request: Rpc): TransactionRequest {
-  const { authorizationList: _, ...rest } = request
+  const { authorizationList: _, multisigWitness: __, ...rest } = request
   const request_ = ox_TransactionRequest.fromRpc(
     rest as any,
   ) as TransactionRequest
@@ -107,6 +161,8 @@ export function fromRpc(request: Rpc): TransactionRequest {
     request_.keyAuthorization = KeyAuthorization.fromRpc(
       request.keyAuthorization,
     )
+  if (request.multisigWitness)
+    request_.multisigWitness = multisigWitnessFromRpc(request.multisigWitness)
   if (typeof request.validBefore !== 'undefined')
     request_.validBefore = Hex.toNumber(request.validBefore as Hex.Hex)
   if (typeof request.validAfter !== 'undefined')
@@ -120,6 +176,8 @@ export function fromRpc(request: Rpc): TransactionRequest {
 export declare namespace fromRpc {
   export type ErrorType =
     | AuthorizationTempo.fromRpcList.ErrorType
+    | MultisigConfig.fromRpc.ErrorType
+    | Hex.fromNumber.ErrorType
     | Hex.toNumber.ErrorType
     | Hex.toBigInt.ErrorType
     | Errors.GlobalErrorType
@@ -204,6 +262,8 @@ export function toRpc(request: TransactionRequest): Rpc {
     request_rpc.keyAuthorization = KeyAuthorization.toRpc(
       request.keyAuthorization,
     )
+  if (request.multisigWitness)
+    request_rpc.multisigWitness = multisigWitnessToRpc(request.multisigWitness)
   if (typeof request.validBefore !== 'undefined')
     request_rpc.validBefore = Hex.fromNumber(request.validBefore)
   if (typeof request.validAfter !== 'undefined')
@@ -222,6 +282,7 @@ export function toRpc(request: TransactionRequest): Rpc {
     typeof request.feePayer !== 'undefined' ||
     typeof request.feeToken !== 'undefined' ||
     typeof request.keyAuthorization !== 'undefined' ||
+    typeof request.multisigWitness !== 'undefined' ||
     typeof request.nonceKey !== 'undefined' ||
     typeof request.validBefore !== 'undefined' ||
     typeof request.validAfter !== 'undefined' ||
@@ -240,6 +301,65 @@ export function toRpc(request: TransactionRequest): Rpc {
 export declare namespace toRpc {
   export type ErrorType =
     | AuthorizationTempo.toRpcList.ErrorType
+    | MultisigConfig.toRpc.ErrorType
     | Hex.fromNumber.ErrorType
+    | Hex.toNumber.ErrorType
     | Errors.GlobalErrorType
+}
+
+/** @internal */
+function multisigWitnessFromRpc(witness: MultisigWitnessRpc): MultisigWitness {
+  return {
+    account: witness.account,
+    approvals: witness.approvals.map((approval) => {
+      if (approval.type === 'primitive') return approval
+      return {
+        type: 'multisig',
+        witness: {
+          ...approval.witness,
+          config: multisigConfigFromRpc(approval.witness.config),
+        },
+      }
+    }),
+    config: multisigConfigFromRpc(witness.config),
+  }
+}
+
+/** @internal */
+function multisigWitnessToRpc(witness: MultisigWitness): MultisigWitnessRpc {
+  return {
+    account: witness.account,
+    approvals: witness.approvals.map((approval) => {
+      if (approval.type === 'primitive') return approval
+      return {
+        type: 'multisig',
+        witness: {
+          ...approval.witness,
+          config: multisigConfigToRpc(approval.witness.config),
+        },
+      }
+    }),
+    config: multisigConfigToRpc(witness.config),
+  }
+}
+
+/** @internal */
+function multisigConfigFromRpc(
+  config: MultisigConfig.Config<number>,
+): MultisigConfig.Config {
+  return MultisigConfig.fromRpc({
+    ...config,
+    version: Hex.fromNumber(config.version),
+  })
+}
+
+/** @internal */
+function multisigConfigToRpc(
+  config: MultisigConfig.Config,
+): MultisigConfig.Config<number> {
+  const { version, ...rpc } = MultisigConfig.toRpc(config)
+  return {
+    ...rpc,
+    version: Hex.toNumber(version),
+  }
 }

--- a/src/tempo/TransactionRequest.ts
+++ b/src/tempo/TransactionRequest.ts
@@ -1,67 +1,16 @@
-import type * as Address from '../core/Address.js'
 import type * as Errors from '../core/Errors.js'
 import * as Hex from '../core/Hex.js'
 import type { Compute } from '../core/internal/types.js'
 import * as ox_TransactionRequest from '../core/TransactionRequest.js'
 import * as AuthorizationTempo from './AuthorizationTempo.js'
 import * as KeyAuthorization from './KeyAuthorization.js'
-import * as MultisigConfig from './MultisigConfig.js'
+import * as MultisigWitness from './MultisigWitness.js'
 import * as TempoAddress from './TempoAddress.js'
 import * as TokenId from './TokenId.js'
 import * as Transaction from './Transaction.js'
 import type { Call } from './TxEnvelopeTempo.js'
 
-/** Primitive signature type modeled during transaction simulation. */
-export type SignatureType = 'secp256k1' | 'p256' | 'webAuthn'
-
-/** Primitive owner approval modeled during native multisig simulation. */
-export type MultisigPrimitiveApproval = {
-  /** Optional signature-specific gas-estimation data. */
-  keyData?: Hex.Hex | undefined
-  /** Signature type to model. Omission models a maximum-size WebAuthn signature. */
-  keyType?: SignatureType | undefined
-  /** Configured owner address. */
-  owner: Address.Address
-}
-
-/** Depth-2 native multisig witness used during transaction simulation. */
-export type MultisigNestedWitness<bigintType = bigint> = {
-  /** Nested multisig account. */
-  account: Address.Address
-  /** Primitive owner approvals to model. */
-  approvals: readonly MultisigPrimitiveApproval[]
-  /** Complete applicable configuration. */
-  config: MultisigConfig.Config<bigintType>
-}
-
-/** Native multisig owner approval modeled during transaction simulation. */
-export type MultisigApproval<bigintType = bigint> =
-  | (MultisigPrimitiveApproval & { type: 'primitive' })
-  | {
-      /** Approval type. */
-      type: 'multisig'
-      /** Nested multisig witness. */
-      witness: MultisigNestedWitness<bigintType>
-    }
-
-/** Native multisig witness used during transaction simulation. */
-export type MultisigWitness<bigintType = bigint> = {
-  /** Account authorized by this witness. */
-  account: Address.Address
-  /** Owner approvals to model. */
-  approvals: readonly MultisigApproval<bigintType>[]
-  /** Complete applicable configuration. */
-  config: MultisigConfig.Config<bigintType>
-}
-
-/** JSON-RPC representation of a {@link ox#TransactionRequest.MultisigNestedWitness}. */
-export type MultisigNestedWitnessRpc = MultisigNestedWitness<number>
-
-/** JSON-RPC representation of a {@link ox#TransactionRequest.MultisigApproval}. */
-export type MultisigApprovalRpc = MultisigApproval<number>
-
-/** JSON-RPC representation of a {@link ox#TransactionRequest.MultisigWitness}. */
-export type MultisigWitnessRpc = MultisigWitness<number>
+type KeyType = 'secp256k1' | 'p256' | 'webAuthn'
 
 /**
  * A Transaction Request that is generic to all transaction types.
@@ -87,10 +36,10 @@ export type TransactionRequest<
     calls?: readonly Call<bigintType, addressType>[] | undefined
     keyAuthorization?: KeyAuthorization.KeyAuthorization<true> | undefined
     keyData?: Hex.Hex | undefined
-    keyType?: SignatureType | undefined
+    keyType?: KeyType | undefined
     feePayer?: boolean | undefined
     feeToken?: TokenId.TokenIdOrAddress<addressType> | undefined
-    multisigWitness?: MultisigWitness<bigintType> | undefined
+    multisigWitness?: MultisigWitness.MultisigWitness<bigintType> | undefined
     nonceKey?: 'random' | bigintType | undefined
     validBefore?: numberType | undefined
     validAfter?: numberType | undefined
@@ -105,7 +54,7 @@ export type Rpc = Omit<
   authorizationList?: AuthorizationTempo.ListRpc | undefined
   feeToken?: Hex.Hex | undefined
   keyAuthorization?: KeyAuthorization.Rpc | undefined
-  multisigWitness?: MultisigWitnessRpc | undefined
+  multisigWitness?: MultisigWitness.Rpc | undefined
   nonceKey?: Hex.Hex | undefined
 }
 
@@ -162,7 +111,7 @@ export function fromRpc(request: Rpc): TransactionRequest {
       request.keyAuthorization,
     )
   if (request.multisigWitness)
-    request_.multisigWitness = multisigWitnessFromRpc(request.multisigWitness)
+    request_.multisigWitness = MultisigWitness.fromRpc(request.multisigWitness)
   if (typeof request.validBefore !== 'undefined')
     request_.validBefore = Hex.toNumber(request.validBefore as Hex.Hex)
   if (typeof request.validAfter !== 'undefined')
@@ -176,8 +125,7 @@ export function fromRpc(request: Rpc): TransactionRequest {
 export declare namespace fromRpc {
   export type ErrorType =
     | AuthorizationTempo.fromRpcList.ErrorType
-    | MultisigConfig.fromRpc.ErrorType
-    | Hex.fromNumber.ErrorType
+    | MultisigWitness.fromRpc.ErrorType
     | Hex.toNumber.ErrorType
     | Hex.toBigInt.ErrorType
     | Errors.GlobalErrorType
@@ -263,7 +211,7 @@ export function toRpc(request: TransactionRequest): Rpc {
       request.keyAuthorization,
     )
   if (request.multisigWitness)
-    request_rpc.multisigWitness = multisigWitnessToRpc(request.multisigWitness)
+    request_rpc.multisigWitness = MultisigWitness.toRpc(request.multisigWitness)
   if (typeof request.validBefore !== 'undefined')
     request_rpc.validBefore = Hex.fromNumber(request.validBefore)
   if (typeof request.validAfter !== 'undefined')
@@ -301,65 +249,7 @@ export function toRpc(request: TransactionRequest): Rpc {
 export declare namespace toRpc {
   export type ErrorType =
     | AuthorizationTempo.toRpcList.ErrorType
-    | MultisigConfig.toRpc.ErrorType
+    | MultisigWitness.toRpc.ErrorType
     | Hex.fromNumber.ErrorType
-    | Hex.toNumber.ErrorType
     | Errors.GlobalErrorType
-}
-
-/** @internal */
-function multisigWitnessFromRpc(witness: MultisigWitnessRpc): MultisigWitness {
-  return {
-    account: witness.account,
-    approvals: witness.approvals.map((approval) => {
-      if (approval.type === 'primitive') return approval
-      return {
-        type: 'multisig',
-        witness: {
-          ...approval.witness,
-          config: multisigConfigFromRpc(approval.witness.config),
-        },
-      }
-    }),
-    config: multisigConfigFromRpc(witness.config),
-  }
-}
-
-/** @internal */
-function multisigWitnessToRpc(witness: MultisigWitness): MultisigWitnessRpc {
-  return {
-    account: witness.account,
-    approvals: witness.approvals.map((approval) => {
-      if (approval.type === 'primitive') return approval
-      return {
-        type: 'multisig',
-        witness: {
-          ...approval.witness,
-          config: multisigConfigToRpc(approval.witness.config),
-        },
-      }
-    }),
-    config: multisigConfigToRpc(witness.config),
-  }
-}
-
-/** @internal */
-function multisigConfigFromRpc(
-  config: MultisigConfig.Config<number>,
-): MultisigConfig.Config {
-  return MultisigConfig.fromRpc({
-    ...config,
-    version: Hex.fromNumber(config.version),
-  })
-}
-
-/** @internal */
-function multisigConfigToRpc(
-  config: MultisigConfig.Config,
-): MultisigConfig.Config<number> {
-  const { version, ...rpc } = MultisigConfig.toRpc(config)
-  return {
-    ...rpc,
-    version: Hex.toNumber(version),
-  }
 }

--- a/src/tempo/index.ts
+++ b/src/tempo/index.ts
@@ -160,6 +160,15 @@ export * as MultisigConfig from './MultisigConfig.js'
  */
 export * as MultisigOperation from './MultisigOperation.js'
 /**
+ * Native multisig RPC simulation witness utilities.
+ *
+ * Converts complete root and nested owner witnesses between their domain and
+ * Tempo JSON-RPC representations.
+ *
+ * @category Reference
+ */
+export * as MultisigWitness from './MultisigWitness.js'
+/**
  * Utilities for constructing period durations (in seconds) for recurring spending limits.
  *
  * Periods define the reset interval for access key spending limits. A spending limit with a


### PR DESCRIPTION
Adds TIP-1061 `multisigWitness` transaction request types and RPC conversion, including nested approvals and numeric configuration-version mapping for node simulation.
