### PR TITLE
feat(tempo): use config witnesses in multisig operations

### DIFF
--- a/.changeset/quiet-multisig-witnesses.md
+++ b/.changeset/quiet-multisig-witnesses.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Migrated multisig operations to configuration witnesses.

--- a/src/tempo/KeyAuthorization.test-d.ts
+++ b/src/tempo/KeyAuthorization.test-d.ts
@@ -57,7 +57,7 @@ test('accepts multisig signatures', () => {
 
   const multisigRpc = {
     account: multisig.account,
-    config: MultisigConfig.toRpc(multisig.config),
+    config: { ...multisig.config, version: 0 },
     signatures: [
       {
         r: '0x01',

--- a/src/tempo/MultisigOperation.test-d.ts
+++ b/src/tempo/MultisigOperation.test-d.ts
@@ -51,13 +51,7 @@ test('uses JSON-RPC quantities only in RPC operations', () => {
     MultisigOperation.Operation['config']['version']
   >().toEqualTypeOf<bigint>()
   expectTypeOf<
-    MultisigOperation.Operation['configVersion']
-  >().toEqualTypeOf<bigint>()
-  expectTypeOf<
     MultisigOperation.Rpc['config']['version']
-  >().toEqualTypeOf<Hex.Hex>()
-  expectTypeOf<
-    MultisigOperation.Rpc['configVersion']
   >().toEqualTypeOf<Hex.Hex>()
 })
 

--- a/src/tempo/MultisigOperation.test.ts
+++ b/src/tempo/MultisigOperation.test.ts
@@ -36,7 +36,7 @@ const config = MultisigConfig.from({
   ],
   threshold: 2,
 })
-const initializedConfig = MultisigConfig.from({ ...config, version: 1n })
+const currentConfig = MultisigConfig.from({ ...config, version: 1n })
 const account = MultisigConfig.getAddress(config)
 const ownerSignature_1 = owners[0]!.signature
 const approval_1 = SignatureEnvelope.serialize(ownerSignature_1)
@@ -63,14 +63,14 @@ const keyAuthorization = KeyAuthorization.serialize(
 
 const transactionHash_ = MultisigConfig.getSignPayload({
   account,
-  config: initializedConfig,
+  config: currentConfig,
   payload: TxEnvelopeTempo.getSignPayload(
     TxEnvelopeTempo.deserialize(transaction),
   ),
 })
 const keyAuthorizationHash = MultisigConfig.getSignPayload({
   account,
-  config: initializedConfig,
+  config: currentConfig,
   payload: KeyAuthorization.getSignPayload(
     KeyAuthorization.deserialize(keyAuthorization),
   ),
@@ -79,10 +79,8 @@ const keyAuthorizationHash = MultisigConfig.getSignPayload({
 const base = {
   account,
   approvals: [approval_1],
-  config: initializedConfig,
-  configVersion: 1n,
+  config: currentConfig,
   createdAt: 1,
-  init: false,
   signatureCount: 1,
   threshold: 2,
   updatedAt: 2,
@@ -139,13 +137,13 @@ describe('getHash', () => {
     expect({
       keyAuthorization: MultisigOperation.getHash({
         account,
-        configVersion: 1n,
+        config: currentConfig,
         keyAuthorization,
         type: 'keyAuthorization',
       }),
       transaction: MultisigOperation.getHash({
         account,
-        configVersion: 1n,
+        config: currentConfig,
         transaction,
         type: 'transaction',
       }),
@@ -171,7 +169,7 @@ describe('selectApprovals', () => {
     const account = MultisigConfig.getAddress(config)
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: { ...config, version: 1n },
       transaction,
       type: 'transaction',
     })
@@ -244,13 +242,13 @@ describe('selectApprovals', () => {
     const account = MultisigConfig.getAddress(config)
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: { ...config, version: 1n },
       transaction,
       type: 'transaction',
     })
     const childHash = MultisigConfig.getSignPayload({
       account: child,
-      config: { version: 2n },
+      config: { ...childConfig, version: 2n },
       payload: hash,
     })
     const childApprovals = [
@@ -258,15 +256,6 @@ describe('selectApprovals', () => {
       signApproval(owners[2]!, childHash),
     ]
     const rootApproval = signApproval(owners[0]!, hash)
-    const resolveConfig: MultisigOperation.selectApprovals.ResolveConfig = ({
-      account,
-    }) => {
-      if (!Address.isEqual(account, child)) throw new Error('unknown account')
-      return {
-        config: MultisigConfig.from({ ...childConfig, version: 2n }),
-        version: 2n,
-      }
-    }
     const partial = await MultisigOperation.selectApprovals({
       account,
       approvals: [
@@ -280,7 +269,6 @@ describe('selectApprovals', () => {
       ],
       config,
       hash,
-      resolveConfig,
     })
     const complete = await MultisigOperation.selectApprovals({
       account,
@@ -297,7 +285,6 @@ describe('selectApprovals', () => {
       ],
       config,
       hash,
-      resolveConfig,
     })
 
     expect({
@@ -341,7 +328,7 @@ describe('selectApprovals', () => {
     `)
   })
 
-  test('rejects mismatched nested config versions', async () => {
+  test('rejects conflicting nested config witnesses', async () => {
     const childConfig = MultisigConfig.from({
       owners: [{ owner: owners[1]!.address, weight: 1 }],
       threshold: 1,
@@ -354,17 +341,26 @@ describe('selectApprovals', () => {
     const account = MultisigConfig.getAddress(config)
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: { ...config, version: 1n },
       transaction,
       type: 'transaction',
     })
-    const resolvedConfig = MultisigConfig.from({
+    const config_2 = MultisigConfig.from({
       ...childConfig,
       version: 2n,
     })
-    const childHash = MultisigConfig.getSignPayload({
+    const config_3 = MultisigConfig.from({
+      ...childConfig,
+      version: 3n,
+    })
+    const childHash_2 = MultisigConfig.getSignPayload({
       account: child,
-      config: resolvedConfig,
+      config: config_2,
+      payload: hash,
+    })
+    const childHash_3 = MultisigConfig.getSignPayload({
+      account: child,
+      config: config_3,
       payload: hash,
     })
 
@@ -374,10 +370,20 @@ describe('selectApprovals', () => {
         approvals: [
           SignatureEnvelope.serialize({
             account: child,
-            config: resolvedConfig,
+            config: config_2,
             signatures: [
               SignatureEnvelope.deserialize(
-                signApproval(owners[1]!, childHash),
+                signApproval(owners[1]!, childHash_2),
+              ),
+            ],
+            type: 'multisig',
+          }),
+          SignatureEnvelope.serialize({
+            account: child,
+            config: config_3,
+            signatures: [
+              SignatureEnvelope.deserialize(
+                signApproval(owners[1]!, childHash_3),
               ),
             ],
             type: 'multisig',
@@ -385,17 +391,32 @@ describe('selectApprovals', () => {
         ],
         config,
         hash,
-        resolveConfig: () => ({ config: childConfig, version: 2n }),
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: resolved config.version must equal version for nested multisig owner 0x7888d60e9cc26c8569d394fce435c248f1e49c3b.]`,
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0x7888d60e9cc26c8569d394fce435c248f1e49c3b has conflicting config witnesses.]`,
+    )
+  })
+
+  test('rejects an initial root config for another account', async () => {
+    await expect(
+      MultisigOperation.selectApprovals({
+        account,
+        approvals: [],
+        config: MultisigConfig.from({
+          ...config,
+          salt: `0x${'ff'.repeat(32)}`,
+        }),
+        hash: transactionHash_,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: initial config does not derive the root multisig account.]`,
     )
   })
 
   test('rejects invalid and non-owner approvals', async () => {
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: currentConfig,
       transaction,
       type: 'transaction',
     })
@@ -427,7 +448,7 @@ describe('selectApprovals', () => {
     )
   })
 
-  test('requires a resolver for nested owners', async () => {
+  test('reads current nested config witnesses from approvals', async () => {
     const childConfig = MultisigConfig.from({
       owners: [{ owner: owners[1]!.address, weight: 1 }],
       threshold: 1,
@@ -440,36 +461,49 @@ describe('selectApprovals', () => {
     const account = MultisigConfig.getAddress(config)
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: { ...config, version: 1n },
       transaction,
       type: 'transaction',
     })
     const childHash = MultisigConfig.getSignPayload({
       account: child,
-      config: { version: 1n },
+      config: { ...childConfig, version: 1n },
       payload: hash,
     })
 
-    await expect(
-      MultisigOperation.selectApprovals({
-        account,
-        approvals: [
-          SignatureEnvelope.serialize({
-            account: child,
-            config: MultisigConfig.from({ ...childConfig, version: 1n }),
-            signatures: [
-              SignatureEnvelope.deserialize(
-                signApproval(owners[1]!, childHash),
-              ),
-            ],
-            type: 'multisig',
-          }),
+    const selection = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [
+        SignatureEnvelope.serialize({
+          account: child,
+          config: MultisigConfig.from({ ...childConfig, version: 1n }),
+          signatures: [
+            SignatureEnvelope.deserialize(signApproval(owners[1]!, childHash)),
+          ],
+          type: 'multisig',
+        }),
+      ],
+      config,
+      hash,
+    })
+    expect(selection).toMatchInlineSnapshot(
+      {
+        approvals: [expect.any(String)],
+        selectedApprovals: [expect.any(String)],
+      },
+      `
+      {
+        "approvals": [
+          Any<String>,
         ],
-        config,
-        hash,
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0x7888d60e9cc26c8569d394fce435c248f1e49c3b requires a config resolver.]`,
+        "selectedApprovals": [
+          Any<String>,
+        ],
+        "signatureCount": 1,
+        "threshold": 1,
+        "weight": 1,
+      }
+    `,
     )
   })
 
@@ -489,7 +523,7 @@ describe('selectApprovals', () => {
     const account = MultisigConfig.getAddress(config)
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: { ...config, version: 1n },
       transaction,
       type: 'transaction',
     })
@@ -531,7 +565,6 @@ describe('selectApprovals', () => {
       ],
       config,
       hash,
-      resolveConfig: () => ({ config: childConfig, version: 0n }),
     })
     expect({
       signatureCount: selection.signatureCount,
@@ -553,7 +586,7 @@ describe('selectApprovals', () => {
     })
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 2n,
+      config: { ...config, version: 2n },
       transaction,
       type: 'transaction',
     })
@@ -595,18 +628,18 @@ describe('selectApprovals', () => {
     const account = MultisigConfig.getAddress(config)
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: { ...config, version: 1n },
       transaction,
       type: 'transaction',
     })
     const childHash = MultisigConfig.getSignPayload({
       account: child,
-      config: { version: 1n },
+      config: { ...childConfig, version: 1n },
       payload: hash,
     })
     const grandchildHash = MultisigConfig.getSignPayload({
       account: grandchild,
-      config: { version: 1n },
+      config: { ...grandchildConfig, version: 1n },
       payload: childHash,
     })
 
@@ -637,20 +670,6 @@ describe('selectApprovals', () => {
         ],
         config,
         hash,
-        resolveConfig: ({ account }) => {
-          if (Address.isEqual(account, child))
-            return {
-              config: MultisigConfig.from({ ...childConfig, version: 1n }),
-              version: 1n,
-            }
-          return {
-            config: MultisigConfig.from({
-              ...grandchildConfig,
-              version: 1n,
-            }),
-            version: 1n,
-          }
-        },
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[MultisigOperation.InvalidApprovalError: Invalid multisig approval: nested multisig owner 0xf529c8f6b2b4c72102af4cfe5eeb55b7d45dede2 is invalid.]`,
@@ -659,14 +678,12 @@ describe('selectApprovals', () => {
 })
 
 describe('serializeTransaction', () => {
-  test('initialized and bootstrap transactions', async () => {
+  test('current and initial transactions', async () => {
     const results = []
-    for (const init of [false, true]) {
-      const configVersion = init ? 0n : 1n
-      const applicableConfig = init ? config : initializedConfig
+    for (const applicableConfig of [currentConfig, config]) {
       const hash = MultisigOperation.getHash({
         account,
-        configVersion,
+        config: applicableConfig,
         transaction,
         type: 'transaction',
       })
@@ -683,10 +700,8 @@ describe('serializeTransaction', () => {
         account,
         approvals: selection.approvals,
         config: applicableConfig,
-        configVersion,
         createdAt: 1,
         hash,
-        init,
         signatureCount: selection.signatureCount,
         status: 'pending',
         threshold: selection.threshold,
@@ -701,7 +716,7 @@ describe('serializeTransaction', () => {
       const value = TxEnvelopeTempo.deserialize(serialized)
       results.push({
         account: value.signature?.account,
-        configVersion:
+        version:
           value.signature?.type === 'multisig'
             ? value.signature.config.version
             : undefined,
@@ -718,17 +733,17 @@ describe('serializeTransaction', () => {
       [
         {
           "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
-          "configVersion": 1n,
           "hash": "0x8309740edaf304284186f7bcfe4527745cd4eb48e7441795ebdd970798091f8f",
           "signatureCount": 2,
           "type": "0x76",
+          "version": 1n,
         },
         {
           "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
-          "configVersion": 0n,
           "hash": "0x636af84d8445d87cbcd33039d5a3a2274a5911036b1b7ceb740ac41e2f638611",
           "signatureCount": 2,
           "type": "0x76",
+          "version": 0n,
         },
       ]
     `)
@@ -756,7 +771,7 @@ describe('serializeTransaction', () => {
     for (const transaction of transactions) {
       const hash = MultisigOperation.getHash({
         account,
-        configVersion: 1n,
+        config: currentConfig,
         transaction,
         type: 'transaction',
       })
@@ -766,18 +781,16 @@ describe('serializeTransaction', () => {
           signApproval(owners[0]!, hash),
           signApproval(owners[1]!, hash),
         ],
-        config: initializedConfig,
+        config: currentConfig,
         hash,
       })
       const serialized = MultisigOperation.serializeTransaction(
         MultisigOperation.from({
           account,
           approvals: selection.approvals,
-          config: initializedConfig,
-          configVersion: 1n,
+          config: currentConfig,
           createdAt: 1,
           hash,
-          init: false,
           signatureCount: selection.signatureCount,
           status: 'pending',
           threshold: selection.threshold,
@@ -825,7 +838,7 @@ describe('serializeTransaction', () => {
   test('rejects an approval not retained by the operation', async () => {
     const hash = MultisigOperation.getHash({
       account,
-      configVersion: 1n,
+      config: currentConfig,
       transaction,
       type: 'transaction',
     })
@@ -834,17 +847,15 @@ describe('serializeTransaction', () => {
     const selection = await MultisigOperation.selectApprovals({
       account,
       approvals: [approval_1],
-      config: initializedConfig,
+      config: currentConfig,
       hash,
     })
     const operation = MultisigOperation.from({
       account,
       approvals: selection.approvals,
-      config: initializedConfig,
-      configVersion: 1n,
+      config: currentConfig,
       createdAt: 1,
       hash,
-      init: false,
       signatureCount: selection.signatureCount,
       status: 'pending',
       threshold: selection.threshold,
@@ -907,10 +918,8 @@ describe('from', () => {
             "threshold": 2,
             "version": 1n,
           },
-          "configVersion": 1n,
           "createdAt": 1,
           "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
-          "init": false,
           "signatureCount": 1,
           "status": "pending",
           "threshold": 2,
@@ -940,11 +949,9 @@ describe('from', () => {
             "threshold": 2,
             "version": 1n,
           },
-          "configVersion": 1n,
           "createdAt": 1,
           "expiresAt": 10,
           "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
-          "init": false,
           "signatureCount": 2,
           "status": "submitting",
           "submissionId": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -975,10 +982,8 @@ describe('from', () => {
             "threshold": 2,
             "version": 1n,
           },
-          "configVersion": 1n,
           "createdAt": 1,
           "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
-          "init": false,
           "signatureCount": 2,
           "status": "success",
           "threshold": 2,
@@ -1004,7 +1009,7 @@ describe('from', () => {
       ...transactionPending,
       hash: MultisigConfig.getSignPayload({
         account,
-        config: initializedConfig,
+        config: currentConfig,
         payload: TxEnvelopeTempo.getSignPayload(
           TxEnvelopeTempo.deserialize(transaction),
         ),
@@ -1038,10 +1043,8 @@ describe('from', () => {
           "threshold": 2,
           "version": 1n,
         },
-        "configVersion": 1n,
         "createdAt": 1,
         "hash": Any<String>,
-        "init": false,
         "signatureCount": 1,
         "status": "pending",
         "threshold": 2,
@@ -1067,7 +1070,7 @@ describe('from', () => {
       ...transactionPending,
       hash: MultisigConfig.getSignPayload({
         account,
-        config: initializedConfig,
+        config: currentConfig,
         payload: TxEnvelopeTempo.getSignPayload(
           TxEnvelopeTempo.deserialize(transaction),
         ),
@@ -1078,11 +1081,10 @@ describe('from', () => {
     expect(operation.transaction).toBe(transaction)
   })
 
-  test('bootstrap transaction', () => {
+  test('initial transaction', () => {
     const operation = MultisigOperation.from({
       ...transactionPending,
       config,
-      configVersion: 0n,
       hash: MultisigConfig.getSignPayload({
         account,
         config,
@@ -1090,7 +1092,6 @@ describe('from', () => {
           TxEnvelopeTempo.deserialize(transaction),
         ),
       }),
-      init: true,
     })
 
     expect(operation).toMatchInlineSnapshot(
@@ -1119,10 +1120,8 @@ describe('from', () => {
           "threshold": 2,
           "version": 0n,
         },
-        "configVersion": 0n,
         "createdAt": 1,
         "hash": Any<String>,
-        "init": true,
         "signatureCount": 1,
         "status": "pending",
         "threshold": 2,
@@ -1135,31 +1134,6 @@ describe('from', () => {
     )
   })
 
-  test('initialized transaction at config version zero', () => {
-    const operation = MultisigOperation.from({
-      ...transactionPending,
-      config,
-      configVersion: 0n,
-      hash: MultisigConfig.getSignPayload({
-        account,
-        config,
-        payload: TxEnvelopeTempo.getSignPayload(
-          TxEnvelopeTempo.deserialize(transaction),
-        ),
-      }),
-    })
-
-    expect({
-      configVersion: operation.configVersion,
-      init: operation.init,
-    }).toMatchInlineSnapshot(`
-      {
-        "configVersion": 0n,
-        "init": false,
-      }
-    `)
-  })
-
   test('key authorization states', () => {
     const pending = MultisigOperation.from(keyAuthorizationPending)
     const authorization = KeyAuthorization.deserialize(keyAuthorization)
@@ -1170,7 +1144,7 @@ describe('from', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
-            config: initializedConfig,
+            config: currentConfig,
             signatures: [
               SignatureEnvelope.deserialize(approval_1),
               SignatureEnvelope.deserialize(approval_2),
@@ -1206,10 +1180,8 @@ describe('from', () => {
             "threshold": 2,
             "version": 1n,
           },
-          "configVersion": 1n,
           "createdAt": 1,
           "hash": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
-          "init": false,
           "keyAuthorization": "0xf838f782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36e",
           "signatureCount": 1,
           "status": "pending",
@@ -1239,10 +1211,8 @@ describe('from', () => {
             "threshold": 2,
             "version": 1n,
           },
-          "configVersion": 1n,
           "createdAt": 1,
           "hash": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
-          "init": false,
           "keyAuthorization": "0xf901b3f782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36eb9017805f9017494f81b7763d3a6876195d780865bd783dbd97dd36ef852a000000000000000000000000000000000000000000000000000000000000000000102eed69407e1ed8ea0e9601e5546b0a03aed683df360140701d694288f0cd85005f34168f731a468aef268c2f9456f01f90108b88201000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000065ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d503200b88201000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000047cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997807775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d100",
           "signatureCount": 2,
           "status": "success",
@@ -1255,7 +1225,7 @@ describe('from', () => {
     `)
   })
 
-  test('bootstrap key authorization', () => {
+  test('initial key authorization', () => {
     const authorization = KeyAuthorization.deserialize(keyAuthorization)
     const keyAuthorization_ = KeyAuthorization.serialize(
       KeyAuthorization.from(authorization, {
@@ -1274,13 +1244,11 @@ describe('from', () => {
       ...keyAuthorizationPending,
       approvals: [approval_1, approval_2],
       config,
-      configVersion: 0n,
       hash: MultisigConfig.getSignPayload({
         account,
         config,
         payload: KeyAuthorization.getSignPayload(authorization),
       }),
-      init: true,
       keyAuthorization: keyAuthorization_,
       signatureCount: 2,
       status: 'success',
@@ -1314,10 +1282,8 @@ describe('from', () => {
           "threshold": 2,
           "version": 0n,
         },
-        "configVersion": 0n,
         "createdAt": 1,
         "hash": Any<String>,
-        "init": true,
         "keyAuthorization": Any<String>,
         "signatureCount": 2,
         "status": "success",
@@ -1361,10 +1327,8 @@ describe('RPC conversion', () => {
             "threshold": 2,
             "version": "0x1",
           },
-          "configVersion": "0x1",
           "createdAt": 1,
           "hash": "0xf6995eb69c12c03d3d13b357abf7cac22b4effe52fba8ff02e5aef26161f77a0",
-          "init": false,
           "keyAuthorization": "0xf838f782107980943333333333333333333333333333333333333333846b49d2008080808094f81b7763d3a6876195d780865bd783dbd97dd36e",
           "signatureCount": 1,
           "status": "pending",
@@ -1393,10 +1357,8 @@ describe('RPC conversion', () => {
             "threshold": 2,
             "version": "0x1",
           },
-          "configVersion": "0x1",
           "createdAt": 1,
           "hash": "0xcdbc24a8fb192f799c5d166b13a99fb29cbb15e71a5e730988d6f8b3c5959d02",
-          "init": false,
           "signatureCount": 1,
           "status": "pending",
           "threshold": 2,
@@ -1529,7 +1491,7 @@ describe('validation', () => {
         account: '0x0000000000000000000000000000000000000000',
         hash: MultisigConfig.getSignPayload({
           account: '0x0000000000000000000000000000000000000000',
-          config: initializedConfig,
+          config: currentConfig,
           payload: TxEnvelopeTempo.getSignPayload(
             TxEnvelopeTempo.deserialize(transaction),
           ),
@@ -1596,7 +1558,7 @@ describe('validation', () => {
       },
     },
     {
-      name: 'nested bootstrap owner approval',
+      name: 'nested non-owner approval',
       operation: {
         ...transactionPending,
         approvals: [
@@ -1609,35 +1571,48 @@ describe('validation', () => {
         ],
       },
     },
-    {
-      name: 'bootstrap with initialized version',
-      operation: { ...transactionPending, init: true },
-    },
   ])('rejects $name', ({ operation }) => {
     expect(() =>
       MultisigOperation.from(operation as MultisigOperation.Operation),
     ).toThrowError(MultisigOperation.InvalidOperationError)
   })
 
-  test('rejects mismatched config versions', () => {
+  test('rejects an initial config for another account', () => {
+    const config = MultisigConfig.from({
+      ...transactionPending.config,
+      salt: `0x${'ff'.repeat(32)}`,
+      version: 0n,
+    })
     expect(() =>
       MultisigOperation.from({
         ...transactionPending,
-        config: { ...initializedConfig, version: 2n },
+        config,
+        hash: MultisigConfig.getSignPayload({
+          account,
+          config,
+          payload: TxEnvelopeTempo.getSignPayload(
+            TxEnvelopeTempo.deserialize(transaction),
+          ),
+        }),
       }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[MultisigOperation.InvalidOperationError: Invalid multisig operation: config.version must equal configVersion.]`,
+      `
+      [MultisigOperation.InvalidOperationError: Invalid multisig operation.
+
+      Details: Invalid native multisig owner approval: initial multisig config does not derive account.]
+    `,
     )
   })
 
   test('rejects noncanonical RPC quantities', () => {
+    const operation = MultisigOperation.toRpc(transactionPending)
     expect(() =>
       MultisigOperation.fromRpc({
-        ...MultisigOperation.toRpc(transactionPending),
-        configVersion: '0x01',
+        ...operation,
+        config: { ...operation.config, version: '0x01' },
       }),
     ).toThrowError(
-      'Invalid multisig operation: configVersion must use canonical quantity encoding.',
+      'Invalid multisig operation: config.version must use canonical quantity encoding.',
     )
   })
 
@@ -1650,7 +1625,7 @@ describe('validation', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
-            config: initializedConfig,
+            config: currentConfig,
             signatures: [
               SignatureEnvelope.deserialize(approval_1),
               SignatureEnvelope.deserialize(approval_3),
@@ -1674,7 +1649,7 @@ describe('validation', () => {
     const signatures = [
       ...SignatureEnvelope.sortMultisigApprovals({
         account,
-        config: initializedConfig,
+        config: currentConfig,
         payload: KeyAuthorization.getSignPayload(authorization),
         signatures: [
           SignatureEnvelope.deserialize(approval_1),
@@ -1689,7 +1664,7 @@ describe('validation', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
-            config: initializedConfig,
+            config: currentConfig,
             signatures,
             type: 'multisig',
           },
@@ -1714,7 +1689,7 @@ describe('validation', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
-            config: initializedConfig,
+            config: currentConfig,
             signatures: [
               SignatureEnvelope.deserialize(approval_1),
               SignatureEnvelope.deserialize(approval_1),
@@ -1763,7 +1738,7 @@ describe('validation', () => {
     })
     const selected = SignatureEnvelope.sortMultisigApprovals({
       account,
-      config: initializedConfig,
+      config: currentConfig,
       payload: KeyAuthorization.getSignPayload(authorization),
       signatures: [selectedNested, SignatureEnvelope.deserialize(approval_2)],
     })
@@ -1774,7 +1749,7 @@ describe('validation', () => {
         KeyAuthorization.from(authorization, {
           signature: {
             account,
-            config: initializedConfig,
+            config: currentConfig,
             signatures: selected,
             type: 'multisig',
           },
@@ -1790,7 +1765,7 @@ describe('validation', () => {
     )
   })
 
-  test('accepts case-insensitive bootstrap configs', () => {
+  test('accepts case-insensitive initial configs', () => {
     const config = MultisigConfig.from({
       owners: [
         {
@@ -1831,14 +1806,12 @@ describe('validation', () => {
       account,
       approvals,
       config,
-      configVersion: 0n,
       createdAt: 1,
       hash: MultisigConfig.getSignPayload({
         account,
         config,
         payload: KeyAuthorization.getSignPayload(authorization),
       }),
-      init: true,
       keyAuthorization: KeyAuthorization.serialize(
         KeyAuthorization.from(authorization, {
           signature: {

--- a/src/tempo/MultisigOperation.ts
+++ b/src/tempo/MultisigOperation.ts
@@ -15,14 +15,10 @@ export type Base<quantity = bigint> = {
   approvals: readonly Hex.Hex[]
   /** Root configuration used to verify approvals. */
   config: MultisigConfig.Config<quantity>
-  /** Root configuration version. */
-  configVersion: quantity
   /** Unix creation time in milliseconds. */
   createdAt: number
   /** Deterministic multisig operation hash. */
   hash: Hex.Hex
-  /** Whether the operation initializes the root multisig account. */
-  init: boolean
   /** Number of approvals selected for quorum evaluation. */
   signatureCount: number
   /** Required root owner weight. */
@@ -73,9 +69,6 @@ export type KeyAuthorizationRpc = KeyAuthorizationOperation<Hex.Hex>
 /** JSON-RPC multisig operation. */
 export type Rpc = Operation<Hex.Hex>
 
-/** Maximum supported multisig configuration version. */
-const maxConfigVersion = 2n ** 64n - 1n
-
 /**
  * Derives the deterministic hash for a multisig operation.
  *
@@ -86,7 +79,7 @@ const maxConfigVersion = 2n ** 64n - 1n
  *
  * const hash = MultisigOperation.getHash({
  *   account,
- *   configVersion: 1n,
+ *   config,
  *   transaction,
  *   type: 'transaction',
  * })
@@ -96,7 +89,7 @@ const maxConfigVersion = 2n ** 64n - 1n
  * @returns The operation hash signed by each owner.
  */
 export function getHash(options: getHash.Options): Hex.Hex {
-  const { account, configVersion } = options
+  const { account, config } = options
   const payload =
     options.type === 'transaction'
       ? TxEnvelopeTempo.getSignPayload(
@@ -109,7 +102,7 @@ export function getHash(options: getHash.Options): Hex.Hex {
         )
   return MultisigConfig.getSignPayload({
     account,
-    config: { version: configVersion },
+    config,
     payload,
   })
 }
@@ -119,8 +112,8 @@ export declare namespace getHash {
   export type Options = {
     /** Root multisig account. */
     account: Address.Address
-    /** Root configuration version. */
-    configVersion: bigint
+    /** Complete root multisig configuration witness. */
+    config: MultisigConfig.Config
   } & (
     | {
         /** Canonical serialized key authorization. */
@@ -163,7 +156,6 @@ export declare namespace getHash {
  *   approvals,
  *   config,
  *   hash,
- *   resolveConfig,
  * })
  * ```
  *
@@ -173,18 +165,25 @@ export declare namespace getHash {
 export async function selectApprovals(
   options: selectApprovals.Options,
 ): Promise<selectApprovals.ReturnValue> {
-  const { account, approvals, hash, resolveConfig } = options
+  const { account, approvals, hash } = options
   if (!Address.validate(account) || Hex.toBigInt(account) === 0n)
     throw new InvalidApprovalError({ reason: 'account is invalid' })
   if (!Hash.validate(hash))
     throw new InvalidApprovalError({ reason: 'hash is invalid' })
+  const config = MultisigConfig.from(options.config)
+  if (
+    config.version === 0n &&
+    !Address.isEqual(MultisigConfig.getAddress(config), account)
+  )
+    throw new InvalidApprovalError({
+      reason: 'initial config does not derive the root multisig account',
+    })
   return selectApprovals_internal(
     {
       account,
       approvals,
-      config: MultisigConfig.from(options.config),
+      config,
       hash,
-      resolveConfig,
     },
     [account.toLowerCase()],
   )
@@ -201,27 +200,6 @@ export declare namespace selectApprovals {
     config: MultisigConfig.Config
     /** Deterministic operation hash approved by root owners. */
     hash: Hex.Hex
-    /** Resolves the current configuration of a nested multisig owner. */
-    resolveConfig?: ResolveConfig | undefined
-  }
-
-  /** Resolves an initialized nested multisig configuration. */
-  export type ResolveConfig = (
-    options: ResolveConfigOptions,
-  ) => ResolvedConfig | Promise<ResolvedConfig>
-
-  /** Nested multisig configuration lookup parameters. */
-  export type ResolveConfigOptions = {
-    /** Nested multisig account. */
-    account: Address.Address
-  }
-
-  /** Resolved nested multisig configuration. */
-  export type ResolvedConfig = {
-    /** Current nested multisig configuration. */
-    config: MultisigConfig.Config
-    /** Current nested multisig configuration version. */
-    version: bigint
   }
 
   /** Result of validating and selecting approvals. */
@@ -339,10 +317,6 @@ export function from<const operation extends Operation>(
 ): from.ReturnValue<operation> {
   try {
     const config = MultisigConfig.from(operation.config)
-    if (config.version !== operation.configVersion)
-      throw new InvalidOperationError({
-        reason: 'config.version must equal configVersion',
-      })
     if (
       typeof config.threshold !== 'number' ||
       config.owners.some((owner) => typeof owner.weight !== 'number')
@@ -392,22 +366,19 @@ export function fromRpc<const operation extends Rpc>(
   operation: operation,
 ): fromRpc.ReturnValue<operation> {
   try {
-    if (
-      typeof operation.configVersion !== 'string' ||
-      !Hex.validate(operation.configVersion)
-    )
+    const version = operation.config?.version
+    if (typeof version !== 'string' || !Hex.validate(version))
       throw new InvalidOperationError({
-        reason: 'configVersion must be a hexadecimal quantity',
+        reason: 'config.version must be a hexadecimal quantity',
       })
-    const configVersion = Hex.toBigInt(operation.configVersion)
-    if (Hex.fromNumber(configVersion) !== operation.configVersion)
+    const version_ = Hex.toBigInt(version)
+    if (Hex.fromNumber(version_) !== version)
       throw new InvalidOperationError({
-        reason: 'configVersion must use canonical quantity encoding',
+        reason: 'config.version must use canonical quantity encoding',
       })
     return from({
       ...operation,
       config: MultisigConfig.fromRpc(operation.config),
-      configVersion,
     } as Operation) as never
   } catch (cause) {
     if (cause instanceof InvalidOperationError) throw cause
@@ -447,7 +418,6 @@ export function toRpc<const operation extends Operation>(
   return {
     ...value,
     config: MultisigConfig.toRpc(value.config),
-    configVersion: Hex.fromNumber(value.configVersion),
   } as never
 }
 
@@ -459,7 +429,7 @@ export declare namespace toRpc {
       : KeyAuthorizationRpc
 
   /** Error type for `toRpc`. */
-  export type ErrorType = from.ErrorType | Hex.fromNumber.ErrorType
+  export type ErrorType = from.ErrorType | MultisigConfig.toRpc.ErrorType
 }
 
 /**
@@ -525,15 +495,17 @@ async function selectApprovals_internal(
         throw new InvalidApprovalError({
           reason: `nested multisig owner ${group.address} is invalid`,
         })
-      if (!options.resolveConfig)
+      const config = MultisigConfig.from(nested[0]!.config)
+      if (nested.some((signature) => !sameConfig(signature.config, config)))
         throw new InvalidApprovalError({
-          reason: `nested multisig owner ${group.address} requires a config resolver`,
+          reason: `nested multisig owner ${group.address} has conflicting config witnesses`,
         })
-      const resolved = await options.resolveConfig({ account: group.address })
-      const config = MultisigConfig.from(resolved.config)
-      if (config.version !== resolved.version)
+      if (
+        config.version === 0n &&
+        !Address.isEqual(MultisigConfig.getAddress(config), group.address)
+      )
         throw new InvalidApprovalError({
-          reason: `resolved config.version must equal version for nested multisig owner ${group.address}`,
+          reason: `initial config does not derive nested multisig owner ${group.address}`,
         })
       const selected = await selectApprovals_internal(
         {
@@ -549,7 +521,6 @@ async function selectApprovals_internal(
             config,
             payload: options.hash,
           }),
-          resolveConfig: options.resolveConfig,
         },
         [...path, group.address.toLowerCase()],
       )
@@ -691,16 +662,6 @@ function assertBase(operation: Operation, config: MultisigConfig.Config): void {
     throw new InvalidOperationError({ reason: 'account cannot be zero' })
   if (!Hash.validate(operation.hash))
     throw new InvalidOperationError({ reason: 'hash is invalid' })
-  if (typeof operation.init !== 'boolean')
-    throw new InvalidOperationError({ reason: 'init must be a boolean' })
-  if (
-    typeof operation.configVersion !== 'bigint' ||
-    operation.configVersion < 0n ||
-    operation.configVersion > maxConfigVersion
-  )
-    throw new InvalidOperationError({
-      reason: 'configVersion must be an unsigned 64-bit integer',
-    })
   assertInteger(operation.createdAt, 'createdAt')
   assertInteger(operation.updatedAt, 'updatedAt')
   if (operation.updatedAt < operation.createdAt)
@@ -780,19 +741,13 @@ function assertBase(operation: Operation, config: MultisigConfig.Config): void {
       reason:
         'weight is not reachable by signatureCount retained owner approvals',
     })
-  if (operation.init) {
-    if (operation.configVersion !== 0n)
-      throw new InvalidOperationError({
-        reason: 'bootstrap operations must use config version zero',
-      })
-    if (
-      MultisigConfig.getAddress(config).toLowerCase() !==
-      operation.account.toLowerCase()
-    )
-      throw new InvalidOperationError({
-        reason: 'bootstrap config does not derive the operation account',
-      })
-  }
+  if (
+    config.version === 0n &&
+    !Address.isEqual(MultisigConfig.getAddress(config), operation.account)
+  )
+    throw new InvalidOperationError({
+      reason: 'initial config does not derive the operation account',
+    })
 }
 
 /**

--- a/src/tempo/SignatureEnvelope.test-d.ts
+++ b/src/tempo/SignatureEnvelope.test-d.ts
@@ -37,11 +37,11 @@ test('toRpc preserves the signature type', () => {
 test('MultisigRpc carries one complete witness shape', () => {
   const rpc = {
     account: '0x1111111111111111111111111111111111111111',
-    config: MultisigConfig.toRpc(config),
+    config: { ...config, version: 0 },
     signatures: [signatureRpc],
   } as const satisfies SignatureEnvelope.MultisigRpc
 
-  expectTypeOf(rpc.config).toMatchTypeOf<MultisigConfig.Rpc>()
+  expectTypeOf(rpc.config).toMatchTypeOf<MultisigConfig.Config<number>>()
   expectTypeOf(rpc.signatures).toMatchTypeOf<
     readonly SignatureEnvelope.SignatureEnvelopeRpc[]
   >()
@@ -92,7 +92,7 @@ test('MultisigRpc rejects old witness shapes', () => {
 
   const serialized = {
     account: '0x1111111111111111111111111111111111111111',
-    config: MultisigConfig.toRpc(config),
+    config: { ...config, version: 0 },
     signatures: ['0x1234'],
   } as const
   // @ts-expect-error Owner approvals use structured RPC envelopes.
@@ -100,7 +100,7 @@ test('MultisigRpc rejects old witness shapes', () => {
 
   const tagged = {
     account: '0x1111111111111111111111111111111111111111',
-    config: MultisigConfig.toRpc(config),
+    config: { ...config, version: 0 },
     signatures: [signatureRpc],
     type: 'multisig',
   } as const

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -3035,7 +3035,7 @@ describe('multisig', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 1,
-            "version": "0x1",
+            "version": 1,
           },
           "signatures": [
             {
@@ -3057,7 +3057,7 @@ describe('multisig', () => {
             ],
             "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "threshold": 1,
-            "version": "0x0",
+            "version": 0,
           },
           "signatures": [
             {

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -245,7 +245,7 @@ export type MultisigRpc = {
   /** Native multisig account address. */
   account: Address.Address
   /** Complete applicable multisig configuration witness. */
-  config: MultisigConfig.Rpc
+  config: MultisigConfig.Config<number>
   /** Structured owner approvals. */
   signatures: readonly SignatureEnvelopeRpc[]
   /** Multisig RPC signatures are untagged. */
@@ -1229,7 +1229,7 @@ export function fromRpc(envelope: SignatureEnvelopeRpc): SignatureEnvelope {
     const multisig = envelope as MultisigRpc
     const result = {
       account: multisig.account,
-      config: MultisigConfig.fromRpc(multisig.config),
+      config: MultisigConfig.from(multisig.config),
       signatures: multisig.signatures.map((signature) => fromRpc(signature)),
       type: 'multisig',
     } satisfies Multisig
@@ -1245,7 +1245,7 @@ export declare namespace fromRpc {
     | assert.ErrorType
     | CoercionError
     | InvalidSerializedError
-    | MultisigConfig.fromRpc.ErrorType
+    | MultisigConfig.assert.ErrorType
     | Signature.fromRpc.ErrorType
     | Errors.GlobalErrorType
 }
@@ -1614,7 +1614,10 @@ export function toRpc<const envelope extends toRpc.Input>(
     assert(multisig)
     return {
       account: multisig.account,
-      config: MultisigConfig.toRpc(multisig.config),
+      config: {
+        ...multisig.config,
+        version: Hex.toNumber(Hex.fromNumber(multisig.config.version)),
+      },
       signatures: multisig.signatures.map((signature) => toRpc(signature)),
     } as never
   }
@@ -1643,7 +1646,8 @@ export declare namespace toRpc {
   type ErrorType =
     | assert.ErrorType
     | CoercionError
-    | MultisigConfig.toRpc.ErrorType
+    | Hex.fromNumber.ErrorType
+    | Hex.toNumber.ErrorType
     | Signature.toRpc.ErrorType
     | Errors.GlobalErrorType
 }


### PR DESCRIPTION
Migrates multisig operations and nested approval envelopes to carry complete configuration witnesses, removing redundant bootstrap and version fields and aligning with https://github.com/tempoxyz/tempo/pull/7242.
