### PR TITLE
feat(tempo): add multisig config RPC schema

### DIFF
--- a/.changeset/nice-keys-listen.md
+++ b/.changeset/nice-keys-listen.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Added multisig configuration lookup to the Tempo RPC schema.

--- a/src/tempo/RpcSchemaTempo.test-d.ts
+++ b/src/tempo/RpcSchemaTempo.test-d.ts
@@ -1,17 +1,20 @@
 import type { Provider } from 'ox'
 import type {
   KeyAuthorization,
+  MultisigConfig,
   MultisigOperation,
   MultisigWitness,
   RpcSchemaTempo,
 } from 'ox/tempo'
 import { expectTypeOf, test } from 'vitest'
+import type * as Address from '../core/Address.js'
 import type * as Hex from '../core/Hex.js'
 
 declare const provider: Provider.Provider<{ schema: RpcSchemaTempo.Multisig }>
 declare const tempoProvider: Provider.Provider<{
   schema: RpcSchemaTempo.Tempo
 }>
+declare const address: Address.Address
 declare const hash: Hex.Hex
 declare const keyAuthorization: KeyAuthorization.Rpc
 declare const multisigWitness: MultisigWitness.Rpc
@@ -51,6 +54,13 @@ test('multisig provider methods', () => {
       params: [{ hash, signature }],
     }),
   ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_getConfig',
+      params: [{ address }],
+    }),
+  ).resolves.toEqualTypeOf<MultisigConfig.Rpc | null>()
 
   expectTypeOf(
     provider.request({

--- a/src/tempo/RpcSchemaTempo.ts
+++ b/src/tempo/RpcSchemaTempo.ts
@@ -1,3 +1,4 @@
+import type * as Address from '../core/Address.js'
 import type * as Block from '../core/Block.js'
 import type * as BlockOverrides from '../core/BlockOverrides.js'
 import type * as Hex from '../core/Hex.js'
@@ -5,6 +6,7 @@ import type * as Log from '../core/Log.js'
 import type * as RpcSchema from '../core/RpcSchema.js'
 import type * as StateOverrides from '../core/StateOverrides.js'
 import type * as KeyAuthorization from './KeyAuthorization.js'
+import type * as MultisigConfig from './MultisigConfig.js'
 import type * as MultisigOperation from './MultisigOperation.js'
 import type * as TransactionRequest from './TransactionRequest.js'
 
@@ -81,6 +83,13 @@ export type Multisig = RpcSchema.From<
         ]
       }
       ReturnType: MultisigOperation.KeyAuthorizationRpc
+    }
+  | {
+      Request: {
+        method: 'multisig_getConfig'
+        params: [{ address: Address.Address }]
+      }
+      ReturnType: MultisigConfig.Rpc | null
     }
   | {
       Request: {


### PR DESCRIPTION
Adds `multisig_getConfig` to the Tempo multisig RPC schema, accepting an account address and returning `MultisigConfig.Rpc | null`.

Defines the contract proposed in https://github.com/tempoxyz/tempo/pull/7285.
