### PR TITLE
feat(tempo): add multisig config RPC method

### DIFF
--- a/.changeset/calm-configs-return.md
+++ b/.changeset/calm-configs-return.md
@@ -1,0 +1,5 @@
+---
+'ox': patch
+---
+
+Added `multisig_getConfig` to the Tempo RPC schemas.

--- a/src/tempo/RpcSchemaTempo.test-d.ts
+++ b/src/tempo/RpcSchemaTempo.test-d.ts
@@ -1,19 +1,36 @@
 import type { Provider } from 'ox'
 import type {
   KeyAuthorization,
+  MultisigConfig,
   MultisigOperation,
   RpcSchemaTempo,
 } from 'ox/tempo'
 import { expectTypeOf, test } from 'vp/test'
+import type * as Address from '../core/Address.js'
 import type * as Hex from '../core/Hex.js'
 
 declare const provider: Provider.Provider<{ schema: RpcSchemaTempo.Multisig }>
+declare const address: Address.Address
 declare const hash: Hex.Hex
 declare const keyAuthorization: KeyAuthorization.Rpc
 declare const serializedTransaction: Hex.Hex
 declare const signature: Hex.Hex
 
 test('multisig provider methods', () => {
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ keyAuthorization }],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+
+  expectTypeOf(
+    provider.request({
+      method: 'multisig_approveKeyAuthorization',
+      params: [{ hash, signature }],
+    }),
+  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+
   expectTypeOf(
     provider.request({
       method: 'multisig_approveRawTransaction',
@@ -35,17 +52,10 @@ test('multisig provider methods', () => {
 
   expectTypeOf(
     provider.request({
-      method: 'multisig_approveKeyAuthorization',
-      params: [{ keyAuthorization }],
+      method: 'multisig_getConfig',
+      params: [{ address }],
     }),
-  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
-
-  expectTypeOf(
-    provider.request({
-      method: 'multisig_approveKeyAuthorization',
-      params: [{ hash, signature }],
-    }),
-  ).resolves.toEqualTypeOf<MultisigOperation.KeyAuthorizationRpc>()
+  ).resolves.toEqualTypeOf<MultisigConfig.Rpc | null>()
 
   expectTypeOf(
     provider.request({

--- a/src/tempo/RpcSchemaTempo.ts
+++ b/src/tempo/RpcSchemaTempo.ts
@@ -1,3 +1,4 @@
+import type * as Address from '../core/Address.js'
 import type * as Block from '../core/Block.js'
 import type * as BlockOverrides from '../core/BlockOverrides.js'
 import type * as Hex from '../core/Hex.js'
@@ -5,6 +6,7 @@ import type * as Log from '../core/Log.js'
 import type * as RpcSchema from '../core/RpcSchema.js'
 import type * as StateOverrides from '../core/StateOverrides.js'
 import type * as KeyAuthorization from './KeyAuthorization.js'
+import type * as MultisigConfig from './MultisigConfig.js'
 import type * as MultisigOperation from './MultisigOperation.js'
 import type * as TransactionRequest from './TransactionRequest.js'
 
@@ -60,6 +62,16 @@ export type Tempo = RpcSchema.From<{
 export type Multisig = RpcSchema.From<
   | {
       Request: {
+        method: 'multisig_approveKeyAuthorization'
+        params: [
+          | { keyAuthorization: KeyAuthorization.Rpc }
+          | { hash: Hex.Hex; signature: Hex.Hex },
+        ]
+      }
+      ReturnType: MultisigOperation.KeyAuthorizationRpc
+    }
+  | {
+      Request: {
         method: 'multisig_approveRawTransaction'
         params: [serializedTransaction: Hex.Hex]
       }
@@ -74,13 +86,10 @@ export type Multisig = RpcSchema.From<
     }
   | {
       Request: {
-        method: 'multisig_approveKeyAuthorization'
-        params: [
-          | { keyAuthorization: KeyAuthorization.Rpc }
-          | { hash: Hex.Hex; signature: Hex.Hex },
-        ]
+        method: 'multisig_getConfig'
+        params: [{ address: Address.Address }]
       }
-      ReturnType: MultisigOperation.KeyAuthorizationRpc
+      ReturnType: MultisigConfig.Rpc | null
     }
   | {
       Request: {

--- a/src/zod/tempo/RpcSchemaTempo.ts
+++ b/src/zod/tempo/RpcSchemaTempo.ts
@@ -1,4 +1,5 @@
 /* eslint-disable jsdoc-js/require-jsdoc, jsdoc-js/require-description, jsdoc-js/require-example */
+import * as z_Address from '../Address.js'
 import * as z_Block from '../Block.js'
 import * as z_BlockOverrides from '../BlockOverrides.js'
 import * as z_Hex from '../Hex.js'
@@ -7,6 +8,7 @@ import * as z_StateOverrides from '../StateOverrides.js'
 import { from } from '../internal/rpcSchemas/from.js'
 import * as z from 'zod/mini'
 import * as z_KeyAuthorization from './KeyAuthorization.js'
+import * as z_MultisigConfig from './MultisigConfig.js'
 import * as z_MultisigOperation from './MultisigOperation.js'
 import * as z_TransactionRequest from './TransactionRequest.js'
 
@@ -88,6 +90,18 @@ export const tempo_simulateV1 = from({
 /** JSON-RPC method schemas for the `tempo_` namespace. */
 export const Tempo = { tempo_simulateV1 }
 
+/** Schema for the `multisig_approveKeyAuthorization` JSON-RPC method. */
+export const multisig_approveKeyAuthorization = from({
+  method: 'multisig_approveKeyAuthorization',
+  params: z.tuple([
+    z.union([
+      z.object({ keyAuthorization: z_KeyAuthorization.Rpc }),
+      z.object({ hash: z_Hex.Hex, signature: z_Hex.Hex }),
+    ]),
+  ]),
+  returns: z_MultisigOperation.KeyAuthorizationOperation,
+})
+
 /** Schema for the `multisig_approveRawTransaction` JSON-RPC method. */
 export const multisig_approveRawTransaction = from({
   method: 'multisig_approveRawTransaction',
@@ -102,16 +116,11 @@ export const multisig_approveRawTransactionSync = from({
   returns: z_MultisigOperation.TransactionOperation,
 })
 
-/** Schema for the `multisig_approveKeyAuthorization` JSON-RPC method. */
-export const multisig_approveKeyAuthorization = from({
-  method: 'multisig_approveKeyAuthorization',
-  params: z.tuple([
-    z.union([
-      z.object({ keyAuthorization: z_KeyAuthorization.Rpc }),
-      z.object({ hash: z_Hex.Hex, signature: z_Hex.Hex }),
-    ]),
-  ]),
-  returns: z_MultisigOperation.KeyAuthorizationOperation,
+/** Schema for the `multisig_getConfig` JSON-RPC method. */
+export const multisig_getConfig = from({
+  method: 'multisig_getConfig',
+  params: z.tuple([z.object({ address: z_Address.Address })]),
+  returns: z.nullable(z_MultisigConfig.Rpc),
 })
 
 /** Schema for the `multisig_getOperation` JSON-RPC method. */
@@ -126,5 +135,6 @@ export const Multisig = {
   multisig_approveKeyAuthorization,
   multisig_approveRawTransaction,
   multisig_approveRawTransactionSync,
+  multisig_getConfig,
   multisig_getOperation,
 }

--- a/src/zod/tempo/_test/RpcSchemaTempo.test-d.ts
+++ b/src/zod/tempo/_test/RpcSchemaTempo.test-d.ts
@@ -1,3 +1,5 @@
+import type * as core_Address from '../../../core/Address.js'
+import type * as core_MultisigConfig from '../../../tempo/MultisigConfig.js'
 import type * as core_MultisigOperation from '../../../tempo/MultisigOperation.js'
 import type * as z from 'zod/mini'
 import { expectTypeOf, test } from 'vp/test'
@@ -24,17 +26,29 @@ test('Tempo namespace exposes tempo_simulateV1', () => {
 
 test('multisig methods have the expected method names', () => {
   expectTypeOf<
+    typeof z_RpcSchemaTempo.multisig_approveKeyAuthorization.method
+  >().toEqualTypeOf<'multisig_approveKeyAuthorization'>()
+  expectTypeOf<
     typeof z_RpcSchemaTempo.multisig_approveRawTransaction.method
   >().toEqualTypeOf<'multisig_approveRawTransaction'>()
   expectTypeOf<
     typeof z_RpcSchemaTempo.multisig_approveRawTransactionSync.method
   >().toEqualTypeOf<'multisig_approveRawTransactionSync'>()
   expectTypeOf<
-    typeof z_RpcSchemaTempo.multisig_approveKeyAuthorization.method
-  >().toEqualTypeOf<'multisig_approveKeyAuthorization'>()
+    typeof z_RpcSchemaTempo.multisig_getConfig.method
+  >().toEqualTypeOf<'multisig_getConfig'>()
   expectTypeOf<
     typeof z_RpcSchemaTempo.multisig_getOperation.method
   >().toEqualTypeOf<'multisig_getOperation'>()
+})
+
+test('multisig_getConfig has the expected request and return types', () => {
+  expectTypeOf<
+    z.input<typeof z_RpcSchemaTempo.multisig_getConfig.params>
+  >().toEqualTypeOf<[{ address: core_Address.Address }]>()
+  expectTypeOf<
+    z.output<typeof z_RpcSchemaTempo.multisig_getConfig.returns>
+  >().toEqualTypeOf<core_MultisigConfig.Rpc | null>()
 })
 
 test('multisig return schemas decode RPC operations', () => {
@@ -47,6 +61,9 @@ test('multisig return schemas decode RPC operations', () => {
 })
 
 test('Multisig namespace exposes multisig methods', () => {
+  expectTypeOf<
+    typeof z_RpcSchemaTempo.Multisig.multisig_getConfig
+  >().toEqualTypeOf<typeof z_RpcSchemaTempo.multisig_getConfig>()
   expectTypeOf<
     typeof z_RpcSchemaTempo.Multisig.multisig_getOperation
   >().toEqualTypeOf<typeof z_RpcSchemaTempo.multisig_getOperation>()

--- a/src/zod/tempo/_test/RpcSchemaTempo.test.ts
+++ b/src/zod/tempo/_test/RpcSchemaTempo.test.ts
@@ -56,6 +56,16 @@ describe('tempo_simulateV1', () => {
 })
 
 describe('multisig methods', () => {
+  test('decodes key authorization approval params', () => {
+    expect(
+      z_RpcSchema.decodeParams(
+        z_RpcSchemaTempo.Multisig,
+        'multisig_approveKeyAuthorization',
+        [{ hash: '0x01', signature: '0x02' }],
+      ),
+    ).toEqual([{ hash: '0x01', signature: '0x02' }])
+  })
+
   test('decodes raw transaction params', () => {
     expect(
       z_RpcSchema.decodeParams(
@@ -66,14 +76,46 @@ describe('multisig methods', () => {
     ).toEqual(['0x76', 30_000])
   })
 
-  test('decodes key authorization approval params', () => {
+  test('decodes config params', () => {
     expect(
       z_RpcSchema.decodeParams(
         z_RpcSchemaTempo.Multisig,
-        'multisig_approveKeyAuthorization',
-        [{ hash: '0x01', signature: '0x02' }],
+        'multisig_getConfig',
+        [{ address: '0xcafebabecafebabecafebabecafebabecafebabe' }],
       ),
-    ).toEqual([{ hash: '0x01', signature: '0x02' }])
+    ).toEqual([{ address: '0xcafebabecafebabecafebabecafebabecafebabe' }])
+  })
+
+  test('decodes config result', () => {
+    const config = {
+      owners: [
+        {
+          owner: '0x1111111111111111111111111111111111111111',
+          weight: 1,
+        },
+      ],
+      salt: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      threshold: 1,
+      version: '0x0',
+    } as const
+
+    expect(
+      z_RpcSchema.decodeReturns(
+        z_RpcSchemaTempo.Multisig,
+        'multisig_getConfig',
+        config,
+      ),
+    ).toEqual(config)
+  })
+
+  test('accepts a missing config result', () => {
+    expect(
+      z_RpcSchema.decodeReturns(
+        z_RpcSchemaTempo.Multisig,
+        'multisig_getConfig',
+        null,
+      ),
+    ).toBeNull()
   })
 
   test('accepts a missing operation result', () => {


### PR DESCRIPTION
Adds `multisig_getConfig` to the Tempo TypeScript and Zod RPC schemas, returning `MultisigConfig.Rpc` for an account address or `null` when no configuration exists.
