### PR TITLE
feat(tempo): serialize multisig key authorizations

### DIFF
--- a/.changeset/bright-keys-sign.md
+++ b/.changeset/bright-keys-sign.md
@@ -1,0 +1,16 @@
+---
+"ox": patch
+---
+
+Added `MultisigOperation.serializeKeyAuthorization` for attaching selected owner approvals to a key authorization.
+
+```ts
+const authorization = MultisigOperation.serializeKeyAuthorization(
+  keyAuthorization,
+  {
+    account,
+    approvals: selection.selectedApprovals,
+    config,
+  },
+)
+```

--- a/src/tempo/MultisigOperation.test-d.ts
+++ b/src/tempo/MultisigOperation.test-d.ts
@@ -11,6 +11,8 @@ declare const operation: MultisigOperation.Operation
 declare const operationRpc: MultisigOperation.Rpc
 declare const getHashOptions: MultisigOperation.getHash.Options
 declare const selectApprovalsOptions: MultisigOperation.selectApprovals.Options
+declare const serializedKeyAuthorization: Hex.Hex
+declare const serializeKeyAuthorizationOptions: MultisigOperation.serializeKeyAuthorization.Options
 declare const serializeTransactionOptions: MultisigOperation.serializeTransaction.Options
 
 test('preserves operation kinds during validation', () => {
@@ -62,6 +64,12 @@ test('operation helpers return narrow types', async () => {
   expectTypeOf(
     await MultisigOperation.selectApprovals(selectApprovalsOptions),
   ).toEqualTypeOf<MultisigOperation.selectApprovals.ReturnValue>()
+  expectTypeOf(
+    MultisigOperation.serializeKeyAuthorization(
+      serializedKeyAuthorization,
+      serializeKeyAuthorizationOptions,
+    ),
+  ).toEqualTypeOf<Hex.Hex>()
   expectTypeOf(
     MultisigOperation.serializeTransaction(
       transaction,

--- a/src/tempo/MultisigOperation.test.ts
+++ b/src/tempo/MultisigOperation.test.ts
@@ -680,6 +680,100 @@ describe('selectApprovals', () => {
   })
 })
 
+describe('serializeKeyAuthorization', () => {
+  test('current and initial authorizations', async () => {
+    const results = []
+    for (const applicableConfig of [currentConfig, config]) {
+      const hash = MultisigOperation.getHash({
+        account,
+        config: applicableConfig,
+        keyAuthorization,
+        type: 'keyAuthorization',
+      })
+      const selection = await MultisigOperation.selectApprovals({
+        account,
+        approvals: [
+          signApproval(owners[1]!, hash),
+          signApproval(owners[0]!, hash),
+        ],
+        config: applicableConfig,
+        hash,
+      })
+      const serialized = MultisigOperation.serializeKeyAuthorization(
+        keyAuthorization,
+        {
+          account,
+          approvals: selection.selectedApprovals,
+          config: applicableConfig,
+        },
+      )
+      const value = KeyAuthorization.deserialize(serialized)
+      results.push({
+        account:
+          value.signature?.type === 'multisig'
+            ? value.signature.account
+            : undefined,
+        hash: Hash.keccak256(serialized),
+        signatureCount:
+          value.signature?.type === 'multisig'
+            ? value.signature.signatures.length
+            : 0,
+        version:
+          value.signature?.type === 'multisig'
+            ? value.signature.config.version
+            : undefined,
+      })
+    }
+
+    expect(results).toMatchInlineSnapshot(`
+      [
+        {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "hash": "0x14b3a60f7c3120e3983b1f6e085ab5b234e71f58f0a4f39d19a5ff64b89a2afe",
+          "signatureCount": 2,
+          "version": 1n,
+        },
+        {
+          "account": "0xf81b7763d3a6876195d780865bd783dbd97dd36e",
+          "hash": "0xbfdc90810a0634f413e627bdefea88ae8c42ed41d6670a70fd1d7574aedda2a4",
+          "signatureCount": 2,
+          "version": 0n,
+        },
+      ]
+    `)
+  })
+
+  test('rejects a signed authorization', async () => {
+    const selection = await MultisigOperation.selectApprovals({
+      account,
+      approvals: [
+        signApproval(owners[0]!, keyAuthorizationHash),
+        signApproval(owners[1]!, keyAuthorizationHash),
+      ],
+      config: currentConfig,
+      hash: keyAuthorizationHash,
+    })
+    const signed = MultisigOperation.serializeKeyAuthorization(
+      keyAuthorization,
+      {
+        account,
+        approvals: selection.selectedApprovals,
+        config: currentConfig,
+      },
+    )
+
+    expect(() =>
+      MultisigOperation.serializeKeyAuthorization(signed, {
+        account,
+        approvals: selection.selectedApprovals,
+        config: currentConfig,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[MultisigOperation.InvalidOperationError: Invalid multisig operation: keyAuthorization must not contain a signature.]`,
+    )
+  })
+})
+
 describe('serializeTransaction', () => {
   test('current and initial transactions', async () => {
     const results = []

--- a/src/tempo/MultisigOperation.ts
+++ b/src/tempo/MultisigOperation.ts
@@ -227,6 +227,89 @@ export declare namespace selectApprovals {
 }
 
 /**
+ * Serializes a key authorization with selected multisig owner approvals.
+ *
+ * @example
+ * ```ts twoslash
+ * // @noErrors
+ * import { MultisigOperation } from 'ox/tempo'
+ *
+ * const authorization = MultisigOperation.serializeKeyAuthorization(
+ *   keyAuthorization,
+ *   {
+ *     account,
+ *     approvals: selection.selectedApprovals,
+ *     config,
+ *   },
+ * )
+ * ```
+ *
+ * @param keyAuthorization - Canonical serialized unsigned key authorization.
+ * @param options - Multisig account, config, and selected approvals.
+ * @returns The signed serialized key authorization.
+ */
+export function serializeKeyAuthorization(
+  keyAuthorization: Hex.Hex,
+  options: serializeKeyAuthorization.Options,
+): Hex.Hex {
+  const authorization = KeyAuthorization_.deserialize(keyAuthorization)
+  if (authorization.signature)
+    throw new InvalidOperationError({
+      reason: 'keyAuthorization must not contain a signature',
+    })
+  if (
+    KeyAuthorization_.serialize(authorization).toLowerCase() !==
+    keyAuthorization.toLowerCase()
+  )
+    throw new InvalidOperationError({
+      reason: 'keyAuthorization is not canonically serialized',
+    })
+  const config = MultisigConfig.from(options.config)
+  const signatures = SignatureEnvelope.sortMultisigApprovals({
+    account: options.account,
+    config,
+    payload: KeyAuthorization_.getSignPayload(authorization),
+    signatures: options.approvals.map((approval) =>
+      SignatureEnvelope.deserialize(approval),
+    ),
+  })
+  return KeyAuthorization_.serialize(
+    KeyAuthorization_.from(authorization, {
+      signature: SignatureEnvelope.from({
+        account: options.account,
+        config,
+        signatures,
+      }),
+    }),
+  )
+}
+
+export declare namespace serializeKeyAuthorization {
+  /** Options for `serializeKeyAuthorization`. */
+  export type Options = {
+    /** Root multisig account. */
+    account: Address.Address
+    /** Selected serialized owner approvals. */
+    approvals: readonly SignatureEnvelope.Serialized[]
+    /** Complete applicable root multisig config. */
+    config: MultisigConfig.Config
+  }
+
+  /** Error type for `serializeKeyAuthorization`. */
+  export type ErrorType =
+    | InvalidOperationError
+    | KeyAuthorization_.deserialize.ErrorType
+    | KeyAuthorization_.from.ErrorType
+    | KeyAuthorization_.getSignPayload.ErrorType
+    | KeyAuthorization_.serialize.ErrorType
+    | MultisigConfig.assert.ErrorType
+    | SignatureEnvelope.assert.ErrorType
+    | SignatureEnvelope.InvalidSerializedError
+    | SignatureEnvelope.sortMultisigApprovals.ErrorType
+    | Errors.GlobalErrorType
+}
+
+/**
  * Serializes a multisig transaction operation with selected owner approvals.
  *
  * @example


### PR DESCRIPTION
Adds `MultisigOperation.serializeKeyAuthorization` to attach a selected multisig quorum to canonical unsigned key authorizations. This gives offchain coordinators an Ox-owned finalization path.
