### PR TITLE
fix: left-pad r/s in Signature.toCompactBytes/toRecoveredBytes

### DIFF
--- a/.changeset/calm-signatures-pad.md
+++ b/.changeset/calm-signatures-pad.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed signature byte codecs to left-pad short scalars and reject invalid lengths and recovery values.

--- a/src/core/Signature.ts
+++ b/src/core/Signature.ts
@@ -564,13 +564,16 @@ export declare namespace toBytes {
  */
 export function toCompactBytes(signature: Signature<boolean>): Bytes.Bytes {
   const bytes = new Uint8Array(64)
-  bytes.set(Bytes.fromHex(signature.r, { size: 32 }), 0)
-  bytes.set(Bytes.fromHex(signature.s, { size: 32 }), 32)
+  bytes.set(Bytes.fromHex(Hex.padLeft(signature.r, 32)), 0)
+  bytes.set(Bytes.fromHex(Hex.padLeft(signature.s, 32)), 32)
   return bytes
 }
 
 export declare namespace toCompactBytes {
-  type ErrorType = Bytes.fromHex.ErrorType | Errors.GlobalErrorType
+  type ErrorType =
+    | Hex.padLeft.ErrorType
+    | Bytes.fromHex.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -591,6 +594,8 @@ export declare namespace toCompactBytes {
  * @returns The decoded {@link ox#Signature.Signature}.
  */
 export function fromCompactBytes(bytes: Bytes.Bytes): Signature<false> {
+  if (bytes.length !== 64)
+    throw new InvalidSerializedSizeError({ signature: bytes })
   return {
     r: Hex.fromBytes(bytes.subarray(0, 32)),
     s: Hex.fromBytes(bytes.subarray(32, 64)),
@@ -598,7 +603,10 @@ export function fromCompactBytes(bytes: Bytes.Bytes): Signature<false> {
 }
 
 export declare namespace fromCompactBytes {
-  type ErrorType = Hex.fromBytes.ErrorType | Errors.GlobalErrorType
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
+    | InvalidSerializedSizeError
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -623,13 +631,17 @@ export declare namespace fromCompactBytes {
 export function toRecoveredBytes(signature: Signature): Bytes.Bytes {
   const bytes = new Uint8Array(65)
   bytes[0] = signature.yParity
-  bytes.set(Bytes.fromHex(signature.r, { size: 32 }), 1)
-  bytes.set(Bytes.fromHex(signature.s, { size: 32 }), 33)
+  bytes.set(Bytes.fromHex(Hex.padLeft(signature.r, 32)), 1)
+  bytes.set(Bytes.fromHex(Hex.padLeft(signature.s, 32)), 33)
   return bytes
 }
 
 export declare namespace toRecoveredBytes {
-  type ErrorType = Bytes.fromNumber.ErrorType | Errors.GlobalErrorType
+  type ErrorType =
+    | Hex.padLeft.ErrorType
+    | Bytes.fromHex.ErrorType
+    | Bytes.fromNumber.ErrorType
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -650,15 +662,24 @@ export declare namespace toRecoveredBytes {
  * @returns The decoded {@link ox#Signature.Signature}.
  */
 export function fromRecoveredBytes(bytes: Bytes.Bytes): Signature {
+  if (bytes.length !== 65)
+    throw new InvalidSerializedSizeError({ signature: bytes })
+  const yParity = bytes[0]!
+  if (yParity !== 0 && yParity !== 1)
+    throw new InvalidYParityError({ value: yParity })
   return {
     r: Hex.fromBytes(bytes.subarray(1, 33)),
     s: Hex.fromBytes(bytes.subarray(33, 65)),
-    yParity: bytes[0]!,
+    yParity,
   }
 }
 
 export declare namespace fromRecoveredBytes {
-  type ErrorType = Hex.fromBytes.ErrorType | Errors.GlobalErrorType
+  type ErrorType =
+    | Hex.fromBytes.ErrorType
+    | InvalidSerializedSizeError
+    | InvalidYParityError
+    | Errors.GlobalErrorType
 }
 
 /**

--- a/src/core/Signature.ts
+++ b/src/core/Signature.ts
@@ -595,7 +595,7 @@ export declare namespace toCompactBytes {
  */
 export function fromCompactBytes(bytes: Bytes.Bytes): Signature<false> {
   if (bytes.length !== 64)
-    throw new InvalidSerializedSizeError({ signature: bytes })
+    throw new InvalidSerializedSizeError({ expectedSize: 64, signature: bytes })
   return {
     r: Hex.fromBytes(bytes.subarray(0, 32)),
     s: Hex.fromBytes(bytes.subarray(32, 64)),
@@ -629,6 +629,7 @@ export declare namespace fromCompactBytes {
  * @returns The 65-byte recovered representation.
  */
 export function toRecoveredBytes(signature: Signature): Bytes.Bytes {
+  assert(signature, { recovered: true })
   const bytes = new Uint8Array(65)
   bytes[0] = signature.yParity
   bytes.set(Bytes.fromHex(Hex.padLeft(signature.r, 32)), 1)
@@ -638,9 +639,9 @@ export function toRecoveredBytes(signature: Signature): Bytes.Bytes {
 
 export declare namespace toRecoveredBytes {
   type ErrorType =
+    | assert.ErrorType
     | Hex.padLeft.ErrorType
     | Bytes.fromHex.ErrorType
-    | Bytes.fromNumber.ErrorType
     | Errors.GlobalErrorType
 }
 
@@ -663,7 +664,7 @@ export declare namespace toRecoveredBytes {
  */
 export function fromRecoveredBytes(bytes: Bytes.Bytes): Signature {
   if (bytes.length !== 65)
-    throw new InvalidSerializedSizeError({ signature: bytes })
+    throw new InvalidSerializedSizeError({ expectedSize: 65, signature: bytes })
   const yParity = bytes[0]!
   if (yParity !== 0 && yParity !== 1)
     throw new InvalidYParityError({ value: yParity })
@@ -966,10 +967,18 @@ export declare namespace yParityToV {
 export class InvalidSerializedSizeError extends Errors.BaseError {
   override readonly name = 'Signature.InvalidSerializedSizeError'
 
-  constructor({ signature }: { signature: Hex.Hex | Bytes.Bytes }) {
+  constructor({
+    expectedSize,
+    signature,
+  }: {
+    expectedSize?: number | undefined
+    signature: Hex.Hex | Bytes.Bytes
+  }) {
     super(`Value \`${signature}\` is an invalid signature size.`, {
       metaMessages: [
-        'Expected: 64 bytes or 65 bytes.',
+        typeof expectedSize === 'number'
+          ? `Expected: ${expectedSize} bytes.`
+          : 'Expected: 64 bytes or 65 bytes.',
         `Received ${Hex.size(Hex.from(signature))} bytes.`,
       ],
     })

--- a/src/core/_test/Signature.test.ts
+++ b/src/core/_test/Signature.test.ts
@@ -642,12 +642,12 @@ describe('fromCompactBytes', () => {
   })
 
   test('behavior: throws on a byte length other than 64', () => {
-    expect(() => Signature.fromCompactBytes(new Uint8Array(20)))
+    expect(() => Signature.fromCompactBytes(new Uint8Array(65)))
       .toThrowErrorMatchingInlineSnapshot(`
-      [Signature.InvalidSerializedSizeError: Value \`0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\` is an invalid signature size.
+      [Signature.InvalidSerializedSizeError: Value \`0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\` is an invalid signature size.
 
-      Expected: 64 bytes or 65 bytes.
-      Received 20 bytes.]
+      Expected: 64 bytes.
+      Received 65 bytes.]
     `)
   })
 })
@@ -679,6 +679,18 @@ describe('toRecoveredBytes', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000002',
     )
   })
+
+  test('behavior: throws before coercing an out-of-range yParity', () => {
+    expect(() =>
+      Signature.toRecoveredBytes({
+        r: '0x01',
+        s: '0x02',
+        yParity: 256,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Signature.InvalidYParityError: Value \`256\` is an invalid y-parity value. Y-parity must be 0 or 1.]`,
+    )
+  })
 })
 
 describe('fromRecoveredBytes', () => {
@@ -706,9 +718,13 @@ describe('fromRecoveredBytes', () => {
   })
 
   test('behavior: throws on a byte length other than 65', () => {
-    expect(() => Signature.fromRecoveredBytes(new Uint8Array(64))).toThrowError(
-      'is an invalid signature size',
-    )
+    expect(() => Signature.fromRecoveredBytes(new Uint8Array(64)))
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Signature.InvalidSerializedSizeError: Value \`0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\` is an invalid signature size.
+
+      Expected: 65 bytes.
+      Received 64 bytes.]
+    `)
   })
 
   test('behavior: throws on an out-of-range yParity byte', () => {

--- a/src/core/_test/Signature.test.ts
+++ b/src/core/_test/Signature.test.ts
@@ -572,6 +572,156 @@ describe('toBytes', () => {
   })
 })
 
+describe('toCompactBytes', () => {
+  test('default', () => {
+    const bytes = Signature.toCompactBytes({
+      r: '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf',
+      s: '0x4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+      yParity: 1,
+    })
+    expect(bytes.length).toBe(64)
+    expect(Hex.fromBytes(bytes)).toBe(
+      '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+    )
+  })
+
+  test('behavior: r/s shorter than 32 bytes are left-padded, not right-padded', () => {
+    const bytes = Signature.toCompactBytes({
+      r: '0x01',
+      s: '0x02',
+      yParity: 0,
+    })
+    // `r` occupies the first 32 bytes and must be the big-endian integer `1`
+    // (left-padded), not `1` shifted into the top byte (right-padded).
+    expect(Hex.fromBytes(bytes.subarray(0, 32))).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    )
+    expect(Hex.fromBytes(bytes.subarray(32, 64))).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000002',
+    )
+  })
+
+  test('behavior: round-trips through recoverPublicKey for a signature whose r has a leading zero byte', async () => {
+    const { Secp256k1 } = await import('ox')
+    const payload = `0x${'11'.repeat(32)}` as const
+    const privateKey = Hex.fromNumber(4n * 123456789013n + 7n, { size: 32 })
+    const signature = Secp256k1.sign({ payload, privateKey })
+    // sanity: this fixture's `r` genuinely has a leading zero byte
+    expect(signature.r.startsWith('0x00')).toBe(true)
+    const expectedPublicKey = Secp256k1.recoverPublicKey({ payload, signature })
+
+    // simulate an external source (RPC/subgraph/DB) that stores `r` in
+    // minimal (non-zero-padded) form, as the `Hex.Hex` type permits
+    const minimalR = `0x${signature.r.slice(4)}` as const
+    const recoveredBytes = Signature.toRecoveredBytes({
+      r: minimalR,
+      s: signature.s,
+      yParity: signature.yParity,
+    })
+    const roundTripped = Signature.fromRecoveredBytes(recoveredBytes)
+    const recoveredPublicKey = Secp256k1.recoverPublicKey({
+      payload,
+      signature: roundTripped,
+    })
+    expect(recoveredPublicKey.x).toBe(expectedPublicKey.x)
+    expect(recoveredPublicKey.y).toBe(expectedPublicKey.y)
+  })
+})
+
+describe('fromCompactBytes', () => {
+  test('default', () => {
+    const signature = Signature.fromCompactBytes(
+      Bytes.fromHex(
+        '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+      ),
+    )
+    expect(signature).toStrictEqual({
+      r: '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf',
+      s: '0x4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+    })
+  })
+
+  test('behavior: throws on a byte length other than 64', () => {
+    expect(() => Signature.fromCompactBytes(new Uint8Array(20)))
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Signature.InvalidSerializedSizeError: Value \`0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\` is an invalid signature size.
+
+      Expected: 64 bytes or 65 bytes.
+      Received 20 bytes.]
+    `)
+  })
+})
+
+describe('toRecoveredBytes', () => {
+  test('default', () => {
+    const bytes = Signature.toRecoveredBytes({
+      r: '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf',
+      s: '0x4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+      yParity: 1,
+    })
+    expect(bytes.length).toBe(65)
+    expect(bytes[0]).toBe(1)
+    expect(Hex.fromBytes(bytes.subarray(1))).toBe(
+      '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+    )
+  })
+
+  test('behavior: r/s shorter than 32 bytes are left-padded, not right-padded', () => {
+    const bytes = Signature.toRecoveredBytes({
+      r: '0x01',
+      s: '0x02',
+      yParity: 0,
+    })
+    expect(Hex.fromBytes(bytes.subarray(1, 33))).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    )
+    expect(Hex.fromBytes(bytes.subarray(33, 65))).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000002',
+    )
+  })
+})
+
+describe('fromRecoveredBytes', () => {
+  test('default', () => {
+    const bytes = new Uint8Array(65)
+    bytes[0] = 1
+    bytes.set(
+      Bytes.fromHex(
+        '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf',
+      ),
+      1,
+    )
+    bytes.set(
+      Bytes.fromHex(
+        '0x4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+      ),
+      33,
+    )
+    const signature = Signature.fromRecoveredBytes(bytes)
+    expect(signature).toStrictEqual({
+      r: '0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf',
+      s: '0x4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8',
+      yParity: 1,
+    })
+  })
+
+  test('behavior: throws on a byte length other than 65', () => {
+    expect(() => Signature.fromRecoveredBytes(new Uint8Array(64))).toThrowError(
+      'is an invalid signature size',
+    )
+  })
+
+  test('behavior: throws on an out-of-range yParity byte', () => {
+    const bytes = new Uint8Array(65)
+    bytes[0] = 7
+    expect(() =>
+      Signature.fromRecoveredBytes(bytes),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Signature.InvalidYParityError: Value \`7\` is an invalid y-parity value. Y-parity must be 0 or 1.]`,
+    )
+  })
+})
+
 describe('toDerHex', () => {
   test('default', () => {
     const signature = Signature.from({


### PR DESCRIPTION
## tl;dr

`Signature.toCompactBytes` and `Signature.toRecoveredBytes` right-pad `r`/`s` to 32 bytes instead of left-padding. Since `r`/`s` are big-endian integers, right-padding a value shorter than 32 bytes changes its numeric value — for a hand-built `{ r, s, yParity }` literal (fully type-legal, no length constraint on `Hex.Hex`) whose `r` or `s` happens to have a leading zero byte, this makes `Secp256k1.recoverPublicKey` silently return the **wrong public key**, with no error, roughly 60% of the time it fires (the rest of the time it throws instead).

## Where

`src/core/Signature.ts:565-574` (`toCompactBytes`) and `:623-633` (`toRecoveredBytes`), both via `Bytes.fromHex(v, { size: 32 })`, which right-pads by construction (`src/core/Bytes.ts:223-232`, own comment: *"Right-pad the hex string before parsing"*).

The same file's own normalizer does this correctly: `Signature.from` (`:314-317`) left-pads via `Hex.padLeft` after `assert`.

## Reproduction

Over 3000 real secp256k1 signatures (varying the private key against a fixed payload), 10 had a leading-zero `r` byte (~1/256 expected rate). Of those 10, feeding each through `toRecoveredBytes` → `fromRecoveredBytes` → `recoverPublicKey` with `r` in **minimal (non-zero-padded) hex form** — the shape you'd get reading `r` back out of an RPC response, subgraph, or DB that stores minimal-form quantities — produced:

```
leading-zero-r signatures found: 10
  threw:               4
  silently wrong key:  6   <- no error, just a different address
  accidentally correct: 0
```

Concrete example:
```
correct pubkey.x: 0xd14ea6b0d28249f7404018b97aef6fab03642ba2b27e3b5214d996b48c4de730
full (left-padded) r:    0x00f7eb915663884a849bc182207d6090f97d48c3782ee520829a272d37344a39
minimal-form (trimmed) r:  0xf7eb915663884a849bc182207d6090f97d48c3782ee520829a272d37344a39

toRecoveredBytes(trimmed) r-half (CURRENT/buggy):
  0xf7eb915663884a849bc182207d6090f97d48c3782ee520829a272d37344a3900
                                                                  ^^ garbage byte shifted in

recoverPublicKey on that round-trip -> THREW "bad point: is not on curve" in this instance
(6/10 sampled cases instead silently returned a different, wrong pubkey.x)
```

## Scope — please read before assuming this is worse than it is

All entry points that construct a `Signature` through ox's own APIs (`Secp256k1.sign`, `Signature.from`, `Signature.fromHex`, etc.) already pad `r`/`s` to 32 bytes before returning, per the design invariant established in #247. **I confirmed this myself** — `Secp256k1.sign` returns pre-padded `r`/`s`, so this bug does not fire through the normal signing path. It fires specifically when a caller builds `{ r, s, yParity }` by hand from a source that stores `r`/`s` in minimal (non-zero-padded) hex — no downstream code doing exactly that was found in this repo or observed by me. So: **a real, silent, wrong-answer bug on a public, untested API — not "signature verification is broken" in general.**

## Fix

Left-pad instead of right-pad in both functions, matching `Signature.from`'s existing pattern:
```diff
-  bytes.set(Bytes.fromHex(signature.r, { size: 32 }), 0)
-  bytes.set(Bytes.fromHex(signature.s, { size: 32 }), 32)
+  bytes.set(Bytes.fromHex(Hex.padLeft(signature.r, 32)), 0)
+  bytes.set(Bytes.fromHex(Hex.padLeft(signature.s, 32)), 32)
```

**Bundled in the same patch** (same root cause class — these functions previously accepted malformed input silently): `fromCompactBytes`/`fromRecoveredBytes` used `Uint8Array#subarray`, which clamps instead of throwing — `fromCompactBytes(new Uint8Array(20))` previously returned a bogus signature instead of throwing, and `fromRecoveredBytes` never validated `yParity ∈ {0,1}`. Both now throw `Signature.InvalidSerializedSizeError` / `Signature.InvalidYParityError` (reusing the errors the sibling `fromHex` already throws for the same conditions).

**One honest side effect worth flagging**: oversized `r`/`s` (>32 bytes) now throws `Hex.SizeExceedsPaddingSizeError` via `Hex.padLeft` instead of the previous `Hex.SizeOverflowError` via `Bytes.fromHex`'s internal `assertSize`. Both are real, correctly-typed errors for the same underlying problem; no existing test asserted on the old error type for these two functions (there were zero prior tests for any of the four functions touched here — confirmed via the `exports` key-list test, which only listed their names). Happy to adjust if you'd prefer the old error type preserved.

## receipts

```
$ npx tsc -b
(clean, no output)

$ npx vp test src/core/_test/Signature.test.ts
 Test Files  1 passed (1)
      Tests  40 passed (40)

$ npx vp test src/core/_test/Signature.test.ts src/core/_test/Signature.fuzz.ts src/core/_test/Secp256k1.test.ts src/core/_test/P256.test.ts
 Test Files  3 passed (3)
      Tests  134 passed (134)

$ npx vp check --fix
Found 0 errors and 2 warnings in 783 files   # both pre-existing, unrelated (site/Landing.tsx)
```

Red-before/green-after confirmed directly: stashed the fix and re-ran `Signature.test.ts` — the 6 new tests exercising the bug (padding-direction assertions + the two malformed-input preconditions) failed against unfixed code with the exact wrong values shown above; the other 34 (including the two `default` round-trip tests that don't exercise the bug) still passed. Restored the fix, all 40 pass.

Codex adversarial review didn't return in 5 minutes — killed it and did a thorough self-review instead (that's how the error-type change above got caught and written up honestly rather than glossed over).

## risk

Low. `toCompactBytes`/`toRecoveredBytes`/`fromCompactBytes`/`fromRecoveredBytes` had no prior test coverage and no internal callers in this repo — the diff only changes the pad direction and adds input validation, both matching patterns already established elsewhere in the same file.
