### PR TITLE
fix: AbiEvent.decode mis-indexes args when an indexed input isn't a declaration-order prefix

### DIFF
--- a/.changeset/calm-events-order.md
+++ b/.changeset/calm-events-order.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `AbiEvent.decode` argument ordering for interleaved indexed event inputs.

--- a/src/core/AbiEvent.ts
+++ b/src/core/AbiEvent.ts
@@ -496,12 +496,15 @@ export function decode(
   // don't have to call `inputs.indexOf(...)` per non-indexed entry below
   // (which is O(n^2) on event width).
   const indexedInputs: abitype.AbiEventParameter[] = []
+  const indexedOriginalIndex: number[] = []
   const nonIndexedInputs: abitype.AbiEventParameter[] = []
   const nonIndexedOriginalIndex: number[] = []
   for (let i = 0; i < inputs.length; i++) {
     const input = inputs[i]!
-    if ('indexed' in input && input.indexed) indexedInputs.push(input)
-    else {
+    if ('indexed' in input && input.indexed) {
+      indexedInputs.push(input)
+      indexedOriginalIndex.push(i)
+    } else {
       nonIndexedInputs.push(input)
       nonIndexedOriginalIndex.push(i)
     }
@@ -510,13 +513,14 @@ export function decode(
   // Decode topics (indexed args).
   for (let i = 0; i < indexedInputs.length; i++) {
     const param = indexedInputs[i]!
+    const index = indexedOriginalIndex[i]!
     const topic = argTopics[i]
     if (!topic)
       throw new TopicsMismatchError({
         abiEvent,
         param: param as abitype.AbiParameter & { indexed: boolean },
       })
-    args[isUnnamed ? i : param.name || i] = (() => {
+    args[isUnnamed ? index : param.name || index] = (() => {
       const t = param.type
       if (
         t === 'string' ||
@@ -545,12 +549,10 @@ export function decode(
           options,
         )
         if (decodedData) {
-          if (isUnnamed) args = [...args, ...decodedData]
-          else {
-            for (let i = 0; i < nonIndexedInputs.length; i++) {
-              const index = nonIndexedOriginalIndex[i]!
-              args[nonIndexedInputs[i]!.name! || index] = decodedData[i]
-            }
+          for (let i = 0; i < nonIndexedInputs.length; i++) {
+            const index = nonIndexedOriginalIndex[i]!
+            args[isUnnamed ? index : nonIndexedInputs[i]!.name || index] =
+              decodedData[i]
           }
         }
       } catch (err) {

--- a/src/core/_test/AbiEvent.test.ts
+++ b/src/core/_test/AbiEvent.test.ts
@@ -330,6 +330,51 @@ describe('decode', () => {
   `)
   })
 
+  test('behavior: unnamed, non-indexed input before indexed input (array mode)', () => {
+    // Declaration order (uint256, bool indexed) differs from indexed-subset
+    // order (bool is the only indexed input). Args must still come back in
+    // declaration order, not indexed-subset order.
+    const foo = AbiEvent.from('event Foo(uint256, bool indexed)')
+    const decoded = AbiEvent.decode(foo, {
+      data: '0x0000000000000000000000000000000000000000000000000000000000000111',
+      topics: [
+        '0x79c52e97493a8f32348c3cf1ebfe4a8dfaeb083ca12cddd87b5d9f7c00d3ccaa',
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      ],
+    })
+    expect(decoded).toMatchInlineSnapshot(`
+      [
+        273n,
+        true,
+      ]
+    `)
+  })
+
+  test('behavior: named + unnamed, indexed input interleaved with non-indexed (mixed mode)', () => {
+    // `a` (indexed) and the trailing unnamed `address` (indexed) are not a
+    // contiguous prefix of declaration order — a non-indexed `bool` sits
+    // between them. All three values must be present and at the correct
+    // declaration-order keys; none may be silently dropped or overwritten.
+    const foo = AbiEvent.from(
+      'event Foo(uint256 indexed a, bool, address indexed)',
+    )
+    const decoded = AbiEvent.decode(foo, {
+      data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      topics: [
+        '0xbf5963a29fe665781e91d832989689110056ee09e32656ea57265dbb1084006e',
+        '0x0000000000000000000000000000000000000000000000000000000000000aaa',
+        '0x00000000000000000000000000cccccccccccccccccccccccccccccccccccccc',
+      ],
+    })
+    expect(decoded).toMatchInlineSnapshot(`
+      {
+        "1": true,
+        "2": "0x00CCCCCCccCcCccCCcccCCcccCcCcCccCcCcCCcc",
+        "a": 2730n,
+      }
+    `)
+  })
+
   test('error: topics mismatch, named', () => {
     const transfer = AbiEvent.from(
       'event Transfer(address indexed from, address to, uint256 indexed value)',


### PR DESCRIPTION
`AbiEvent.decode` mis-indexes args whenever a non-indexed input appears before an indexed one in an event's declaration order — the indexed-topic loop keyed writes off the loop index *within the indexed subset*, not the input's original declaration index.

## The bug

`src/core/AbiEvent.ts`. The partition loop already tracked original declaration index for the non-indexed side (`nonIndexedOriginalIndex`), for exactly the reason this bug exists — but had no equivalent for the indexed side:

```ts
for (let i = 0; i < indexedInputs.length; i++) {
  const param = indexedInputs[i]!
  args[isUnnamed ? i : param.name || i] = (...)   // `i` is the indexed-SUBSET index
```

For a canonical event where indexed inputs are a declaration-order prefix (ERC-20 `Transfer`, `Approval`, etc.) the indexed-subset index and the declaration index are identical, so this was invisible. It breaks the moment they diverge.

## Repro (real, run against the published behavior before this fix)

```
event Foo(uint256, bool indexed)
  ox    : [true, 273n]        <- wrong order
  viem  : [273n, true]
  ethers: 273n true

event Foo(uint256 indexed a, bool, address indexed)
  ox    : { "1": true, "a": 2730n }                                    <- indexed address is GONE
  viem  : [2730n, true, "0x00CCCCCCccCcCccCCcccCCcccCcCcCccCcCcCCcc"]
  ethers: 2730n true 0x00CCCC...   a=2730n

event Transfer(address indexed from, address indexed to, uint256 value)  (canonical, sanity control)
  ox    : { from: "0x...", to: "0x...", value: 1000n }                 <- correct, unaffected
```

The second case is the dangerous one: three inputs decoded to two values, silently. Mechanism: `indexedInputs = [a (decl. 0), address (decl. 2)]`; the loop's `i=1` write for `address` collides with the non-indexed loop's write for `bool` (decl. index 1) — the address is overwritten with no error raised.

## Fix

Added `indexedOriginalIndex`, mirroring `nonIndexedOriginalIndex`, and keyed both the indexed-topic writes and the non-indexed array-mode fill by declaration index — matching what the non-indexed *named*-mode branch already did, and what viem's `decodeEventLog` (`utils/abi/decodeEventLog.js`) does.

## Tests

Two new cases in `src/core/_test/AbiEvent.test.ts` reproducing both failure modes above (array-mode reordering, mixed-mode silent drop). Verified genuine red-before/green-after by stashing just the source fix and rerunning: both new tests fail on unfixed code — the silent-drop case shows the `"2"` key (the address) entirely absent from the received snapshot — while all 67 pre-existing tests (including the canonical-prefix cases and the anonymous-event case) still pass unaffected.

```
# unfixed:  2 failed | 67 passed (69)
# fixed:    69 passed (69)
```

Also ran the two direct consumer test files (`AbiItem.test.ts`, `Log.test.ts`): 95/95 passing. `pnpm check:types` (`tsc -b`) and `pnpm check` (`vp check --fix`) both clean — 0 errors (2 pre-existing unrelated warnings in the docs site, untouched by this diff).

## Scope

Real-world exposure is unquantified — canonical ERC-20/721 events decode correctly today and are unaffected by this bug or this fix. It only fires for non-canonical/hand-written ABIs where a non-indexed param isn't after all the indexed ones. Framing this as a correctness bug with unmeasured frequency, not "everyone's Transfer decoding is broken" (it isn't).

## Related, out of scope

While checking this file for the same bug pattern elsewhere, I found `AbiEvent.encode`'s object-mode indexed-arg lookup (`indexedInputs.map((x, i) => args[x.name ?? i])`, around line 1237) has the *same* subset-index-vs-declaration-index confusion — for an unnamed/mixed event, it reads a caller's args object by indexed-subset index rather than declaration index. I confirmed this is real with a standalone repro: `AbiEvent.encode` on `event Foo(uint256, bool indexed, address indexed)` given `{1: true, 2: '0x1234...'}` (the natural shape, matching what `decode`'s own fixed output now produces) throws trying to encode the `bool` value as an `address`, because it read the wrong key. Leaving this out of this PR since it's a separate function with its own test surface and deserves its own focused fix — happy to open a follow-up if useful.

Confirmed unclaimed before starting: no open or closed issues/PRs on `AbiEvent decode unnamed`, `decodeEventLog unnamed`, `AbiEvent unnamed indexed`, `unnamed`, or `indexed` touch this. Only other open PRs on this repo are unrelated (#433 changesets bot, and two of my own in different files: #434, #435).
