### PR TITLE
fix(tempo): KeyAuthorization encoder never enforced the TIP-1049 admin/account pairing

### DIFF
--- a/src/tempo/KeyAuthorization.test.ts
+++ b/src/tempo/KeyAuthorization.test.ts
@@ -2680,4 +2680,95 @@ describe('admin keys (TIP-1049)', () => {
     })
     expect(KeyAuthorization.hash(a)).not.toBe(KeyAuthorization.hash(b))
   })
+
+  // These compose the encoder and decoder on the exact same object, unlike
+  // the tests above, which only ever exercise one side (a `from()`-built
+  // paired fixture through `toTuple`, or a hand-written orphan tuple/RPC
+  // literal that never came out of the real encoder). An orphan built via
+  // `from()` and then encoded is what actually happened before this fix:
+  // `toTuple`/`toRpc` silently emitted `isAdmin: true` with no `account`
+  // on the wire, and `fromTuple`/`fromRpc` silently dropped it back off on
+  // decode -- so `hash()` before and after a round trip disagreed.
+  test('toTuple: throws on orphan isAdmin with no account', () => {
+    // Bypasses `from()` (which now also rejects this shape -- see below)
+    // to independently confirm `toTuple` itself enforces the invariant,
+    // exactly as it must for any caller that skips `from()` entirely --
+    // raw wire input reconstructed by hand, or a non-TypeScript caller.
+    const orphan = {
+      address,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    } as any
+    expect(() =>
+      KeyAuthorization.toTuple(orphan),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[KeyAuthorization.MissingAdminAccountError: \`isAdmin: true\` requires an \`account\` binding (TIP-1049); the admin grant must be scoped to an account.]`,
+    )
+  })
+
+  test('toRpc: throws on orphan isAdmin with no account', () => {
+    const orphan = {
+      address,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+      signature: SignatureEnvelope.from(signature_secp256k1),
+    } as any
+    expect(() =>
+      KeyAuthorization.toRpc(orphan),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[KeyAuthorization.MissingAdminAccountError: \`isAdmin: true\` requires an \`account\` binding (TIP-1049); the admin grant must be scoped to an account.]`,
+    )
+  })
+
+  test('from: throws on orphan isAdmin with no account', () => {
+    expect(() =>
+      KeyAuthorization.from({
+        address,
+        chainId: 1n,
+        isAdmin: true,
+        type: 'secp256k1',
+      } as any),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[KeyAuthorization.MissingAdminAccountError: \`isAdmin: true\` requires an \`account\` binding (TIP-1049); the admin grant must be scoped to an account.]`,
+    )
+  })
+
+  test('toTuple/fromTuple: composed round trip is stable for a legitimate admin pair', () => {
+    const authorization = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: true,
+      type: 'secp256k1',
+    })
+    const hashBefore = KeyAuthorization.hash(authorization)
+    const decoded = KeyAuthorization.fromTuple(
+      KeyAuthorization.toTuple(authorization),
+    )
+    expect(KeyAuthorization.hash(decoded)).toBe(hashBefore)
+  })
+
+  test('account-only (isAdmin: false) is unaffected by the admin-binding guard', () => {
+    // The reverse direction -- `account` set, `isAdmin: false` -- is a
+    // normal account-scoped, non-admin key. It round-trips stably; only an
+    // unscoped `isAdmin: true` is rejected. (The `OneOf` type requires both
+    // keys together on this branch -- `account` with `isAdmin` omitted
+    // entirely doesn't type-check, so `isAdmin: false` is the legal way to
+    // express "account-scoped, not admin".)
+    const authorization = KeyAuthorization.from({
+      address,
+      account,
+      chainId: 1n,
+      isAdmin: false,
+      type: 'secp256k1',
+    })
+    const hashBefore = KeyAuthorization.hash(authorization)
+    const decoded = KeyAuthorization.fromTuple(
+      KeyAuthorization.toTuple(authorization),
+    )
+    expect(decoded.isAdmin).toBe(false)
+    expect(KeyAuthorization.hash(decoded)).toBe(hashBefore)
+  })
 })

--- a/src/tempo/KeyAuthorization.ts
+++ b/src/tempo/KeyAuthorization.ts
@@ -443,6 +443,7 @@ export function from<
   }
   if (auth.witness !== undefined) assertWitness(auth.witness)
   if (auth.signature) assertSignature(auth.signature)
+  assertAdminBinding(auth.isAdmin, auth.account)
   const resolved = {
     ...auth,
     ...(auth.scopes
@@ -947,6 +948,7 @@ export function toRpc(authorization: toRpc.Input): Rpc {
   } = authorization
   assertSignature(signature)
   if (witness !== undefined) assertWitness(witness)
+  assertAdminBinding(isAdmin, account)
 
   // Group flat scopes by address into nested allowedCalls wire format
   const allowedCalls = (() => {
@@ -1046,6 +1048,7 @@ export function toTuple<const authorization extends KeyAuthorization>(
     account,
   } = authorization
   if (witness !== undefined) assertWitness(witness)
+  assertAdminBinding(isAdmin, account)
   const signature = (() => {
     if (!authorization.signature) return undefined
     assertSignature(authorization.signature)
@@ -1195,6 +1198,24 @@ function isAbsent(value: unknown): boolean {
   return value === undefined || value === '0x'
 }
 
+// TIP-1049: an admin marker with no `account` binding is unscoped and has no
+// well-defined meaning on-chain (the admin grant is defined relative to the
+// bound account). Only this direction is rejected — `account` alone (no
+// `isAdmin`) is a normal account-scoped, non-admin key and round-trips fine
+// (`isAdmin` defaults to `false`), so it is intentionally left permitted.
+// Wire-decoded shapes (`fromTuple`/`fromRpc`) are NOT checked here: a
+// wire-carried orphan marker is deliberately tolerated for forward-compat
+// and normalized (the orphan field is dropped) rather than rejected — this
+// assertion only guards the encode boundary, so ox itself can never
+// *produce* wire bytes that fail to round-trip.
+function assertAdminBinding(
+  isAdmin: boolean | null | undefined,
+  account: Address.Address | null | undefined,
+): void {
+  if (isAdmin && (account === undefined || account === null))
+    throw new MissingAdminAccountError()
+}
+
 /** Thrown when a `witness` field is not exactly 32 bytes. */
 export class InvalidWitnessSizeError extends Error {
   override readonly name = 'KeyAuthorization.InvalidWitnessSizeError'
@@ -1211,6 +1232,20 @@ export class InvalidAdminMarkerError extends Error {
   constructor(marker: Hex.Hex) {
     super(
       `Admin marker \`${marker}\` is invalid; expected \`0x01\` (TIP-1049).`,
+    )
+  }
+}
+
+/**
+ * Thrown when `isAdmin: true` is set with no `account` binding (TIP-1049).
+ * An admin grant is only meaningful scoped to an account; an unscoped
+ * marker cannot be represented stably on the wire.
+ */
+export class MissingAdminAccountError extends Error {
+  override readonly name = 'KeyAuthorization.MissingAdminAccountError'
+  constructor() {
+    super(
+      '`isAdmin: true` requires an `account` binding (TIP-1049); the admin grant must be scoped to an account.',
     )
   }
 }


### PR DESCRIPTION
## what

`KeyAuthorization.toTuple`/`toRpc` never enforced the TIP-1049 invariant that `account` and `isAdmin` are paired (documented right above the type: "either both are specified or neither"). A caller bypassing the `OneOf` type — raw wire input, a non-TypeScript caller, or any `as any` — could construct `isAdmin: true` with no `account`, and the encoder would happily put it on the wire.

`fromTuple`/`fromRpc` already tolerate this shape on decode and silently drop the orphan `isAdmin` marker. That's intentional, not a bug — a deleted comment still visible in git history says so explicitly:

```
// TIP-1049 admin fields are paired: only emit both when both are present on
// the wire. Wire shapes carrying only one are tolerated for forward-compat
// but the orphan field is dropped (since the public API requires both).
```

So decode is left untouched. The actual gap is one-sided: **ox itself should never produce wire bytes it wouldn't accept as valid input.** A decode → re-encode round trip on an orphan-shaped authorization silently drops `isAdmin`, which changes `hash()`/`getSignPayload()` before vs after — since `hash()` is exactly `keccak256(rlp(toTuple(auth)))`.

## repro (before this fix)

```ts
const orphan = { address, chainId: 4217n, type: 'secp256k1', isAdmin: true } // as any — no `account`

hash(orphan)                              // 0x5c2d5693...
const decoded = fromTuple(toTuple(orphan))
decoded.isAdmin                           // undefined -- dropped
hash(decoded)                             // 0xc4fdaab1...  -- DIFFERENT
```

## fix

Adds `assertAdminBinding()`, called from `from()`, `toTuple()`, and `toRpc()`. It throws `MissingAdminAccountError` **only** for the unstable direction — `isAdmin: true` with no `account`. The reverse (`account` set, `isAdmin: false` or omitted) is a normal account-scoped non-admin key, already round-trips stably today, and stays permitted:

```
isAdmin: true,  account: undefined  -> throws (this fix)
isAdmin: true,  account: 0x...      -> fine, unaffected
isAdmin: false, account: 0x...      -> fine, unaffected
isAdmin: undefined, account: 0x...  -> fine, unaffected (isAdmin defaults false)
```

Verified every real (non-doc-comment) call site that serializes a `KeyAuthorization` goes through `toRpc`/`toTuple` — `Transaction.ts:366`, `TransactionRequest.ts:263`, `TxEnvelopeTempo.ts:730` — so this closes the gap at every reachable production path, not just the module's own entry points.

## why the existing tests didn't catch it

The `admin keys (TIP-1049)` describe block has 12 tests, but every one of them tests only one side in isolation:
- Every **encoder** fixture passes `isAdmin` and `account` together (`from({ ..., isAdmin: true, account })`).
- The decoder's orphan-shape tests (`fromTuple: drops orphan isAdmin without account`, `fromRpc: drops orphan isAdmin without account`) build the orphan tuple/RPC object as a hand-written literal — never from the real encoder's own output.

So the two sides were pinned independently and never composed: nothing ran `toTuple(x)` → `fromTuple(...)` on an object the encoder itself produced from an orphan input. The new tests do exactly that composition, plus direct `toTuple`/`toRpc`/`from` rejection tests, plus a control confirming a legitimate paired shape and an `isAdmin: false` account-only shape both still round-trip stably.

## severity, honestly

- The **encoder-originated** path is TS-blocked under normal usage (`tsc --strict` rejects the orphan shape via `OneOf`) — reachable only via `as any`, a union-collapsing spread, or a non-TypeScript caller.
- No real node was observed emitting this shape in production.
- This is a signing-payload-correctness fix on a pre-release surface (`src/tempo/**`), not a demonstrated live incident — shipping it now closes a real gap before it can bite anyone once this ships and gets more traffic.

## receipts

```
$ pnpm test src/tempo/KeyAuthorization.test.ts
 Test Files  1 passed (1)
      Tests  103 passed (103)

$ pnpm exec tsc -b        # the actual check:types command
(clean, no output)

$ pnpm check               # vp check --fix
Found 0 errors and 2 warnings in 783 files   # both warnings pre-existing, unrelated (site/src/components/Landing.tsx)
```

Genuine red-before/green-after: stashed just `src/tempo/KeyAuthorization.ts` (kept the new tests), reran — exactly the 3 new "throws" tests failed with `snapshot function didn't throw` / the actual round-trip instability, all 100 others passed. Restored the fix, all 103 pass.

Full `src/tempo/` suite (`pnpm test src/tempo/`): 687 passed, 37 skipped — the 2 failing files (`e2e.test.ts`, `multisig.e2e.test.ts`) fail identically on unmodified `main` too (an `afterAll` trying to `fetch` a stop endpoint on a localnet node that isn't running in this sandbox — `ECONNRESET`, not a code regression). Confirmed by stashing and re-running against clean `main`.

## review note

Ran Codex adversarially against this diff. It made real partial progress before I had to stop it — most usefully, it caught that my test file didn't type-check under the actual `tsc -b`/`check:types` command CI runs (I'd initially only run `tsc --noEmit` against the main `tsconfig.json`, which excludes test files; `test/tsconfig.json` is stricter and correctly rejected my first draft of the account-only test, which omitted `isAdmin` — the `OneOf` type requires both keys together on that branch, so `isAdmin: false` is the only type-legal way to express "account-scoped, not admin"). Fixed and reverified against the real `tsc -b`. It didn't reach a final verdict before I stopped it, so I finished the remaining checks myself (the call-site sweep above).
