### PR TITLE
fix: Blobs.to truncates a payload at a 0x80 byte in a non-final blob

### DIFF
--- a/.changeset/fix-blobs-terminator-boundary.md
+++ b/.changeset/fix-blobs-terminator-boundary.md
@@ -2,4 +2,4 @@
 "ox": patch
 ---
 
-Fixed `Blobs.to` treating a `0x80` byte in a non-final blob as the terminator, silently truncating that blob and every subsequent blob. The terminator is only ever written into the last blob by `Blobs.from`, so decoding now only recognizes it there, matching viem's `fromBlobs`.
+Fixed `Blobs.to` truncating multi-blob payloads when a non-final blob contained a `0x80` byte.

--- a/.changeset/fix-blobs-terminator-boundary.md
+++ b/.changeset/fix-blobs-terminator-boundary.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `Blobs.to` treating a `0x80` byte in a non-final blob as the terminator, silently truncating that blob and every subsequent blob. The terminator is only ever written into the last blob by `Blobs.from`, so decoding now only recognizes it there, matching viem's `fromBlobs`.

--- a/src/core/Blobs.ts
+++ b/src/core/Blobs.ts
@@ -398,8 +398,10 @@ export function to<
   const data = Cursor.create(new Uint8Array(length))
   let active = true
 
-  for (const blob of blobs_) {
+  for (const [index, blob] of blobs_.entries()) {
     const cursor = Cursor.create(blob)
+    // Only the final blob contains a terminator; preceding blobs contain only data.
+    const isLastBlob = index === blobs_.length - 1
     while (active && cursor.position < blob.length) {
       // First byte will be a zero 0x00 byte – we can skip.
       cursor.incrementPosition(1)
@@ -411,7 +413,9 @@ export function to<
       for (let i = 0; i < consume; i++) {
         const byte = cursor.readByte()
         const isTerminator =
-          byte === 0x80 && !cursor.inspectBytes(cursor.remaining).includes(0x80)
+          isLastBlob &&
+          byte === 0x80 &&
+          !cursor.inspectBytes(cursor.remaining).includes(0x80)
         if (isTerminator) {
           active = false
           break

--- a/src/core/_test/Blobs.test.ts
+++ b/src/core/_test/Blobs.test.ts
@@ -415,6 +415,35 @@ describe('to', () => {
     const blobs = Blobs.from(data)
     expect(Blobs.to(blobs, 'Bytes')).toEqual(data)
   })
+
+  test('0x80 byte in a non-final blob is not mistaken for the terminator', () => {
+    // A payload large enough to span multiple blobs, containing a 0x80 byte
+    // well before the end. Only the terminator in the LAST blob should end
+    // decoding — a 0x80 byte in an earlier blob is just data.
+    const size = 200_000
+    const data = new Uint8Array(size).fill(0x41)
+    data[1_000] = 0x80
+    data[100_000] = 0x80
+
+    const blobs = Blobs.from(data)
+    expect(blobs.length).toBeGreaterThan(1)
+    expect(Blobs.to(blobs, 'Bytes')).toEqual(data)
+  })
+
+  test('all-0x80 data exactly filling the first blob leaves a terminator-only final blob', () => {
+    // Usable data bytes per blob: one 0x00 padding byte precedes every 31
+    // data bytes, `fieldElementsPerBlob` times. Filling exactly this many
+    // bytes leaves no room for a terminator in the first blob, so `from`
+    // must place it alone in a second, terminator-only blob. Every data
+    // byte here is 0x80 — covers all-0x80 payloads, a 0x80 at the very last
+    // position of a non-final blob, and a terminator-only last blob at once.
+    const size = 31 * Blobs.fieldElementsPerBlob
+    const data = new Uint8Array(size).fill(0x80)
+
+    const blobs = Blobs.from(data)
+    expect(blobs.length).toBe(2)
+    expect(Blobs.to(blobs, 'Bytes')).toEqual(data)
+  })
 })
 
 describe('toCommitments', () => {

--- a/src/core/_test/Blobs.test.ts
+++ b/src/core/_test/Blobs.test.ts
@@ -417,9 +417,7 @@ describe('to', () => {
   })
 
   test('0x80 byte in a non-final blob is not mistaken for the terminator', () => {
-    // A payload large enough to span multiple blobs, containing a 0x80 byte
-    // well before the end. Only the terminator in the LAST blob should end
-    // decoding — a 0x80 byte in an earlier blob is just data.
+    // This payload spans multiple blobs and places terminator-shaped data in the first blob.
     const size = 200_000
     const data = new Uint8Array(size).fill(0x41)
     data[1_000] = 0x80
@@ -431,12 +429,7 @@ describe('to', () => {
   })
 
   test('all-0x80 data exactly filling the first blob leaves a terminator-only final blob', () => {
-    // Usable data bytes per blob: one 0x00 padding byte precedes every 31
-    // data bytes, `fieldElementsPerBlob` times. Filling exactly this many
-    // bytes leaves no room for a terminator in the first blob, so `from`
-    // must place it alone in a second, terminator-only blob. Every data
-    // byte here is 0x80 — covers all-0x80 payloads, a 0x80 at the very last
-    // position of a non-final blob, and a terminator-only last blob at once.
+    // Exact first-blob capacity forces `Blobs.from` to place the terminator in a second blob.
     const size = 31 * Blobs.fieldElementsPerBlob
     const data = new Uint8Array(size).fill(0x80)
 


### PR DESCRIPTION
## What

`Blobs.to` silently truncates essentially every real multi-blob payload that contains a `0x80` byte before the very end.

## Bug

`src/core/Blobs.ts:401` and `:413-414` — the decoder's terminator check has no "is this the last blob" guard:

```ts
for (const blob of blobs_) {
  ...
  const isTerminator =
    byte === 0x80 && !cursor.inspectBytes(cursor.remaining).includes(0x80)
```

`cursor.remaining` is only the remainder of the *current* blob. `Blobs.from` only ever writes a real terminator byte into the **last** blob (`:313`, `blob.pushByte(0x80)` inside the `bytes.length < 31` branch that also sets `active = false`). So in any non-final blob, the last `0x80` byte naturally has nothing after it *within that blob*, `isTerminator` fires anyway, and decoding stops there — silently dropping that blob and every subsequent one, with no error.

For arbitrary binary data spanning multiple blobs (>126,976 bytes), the chance of containing at least one `0x80` byte in a non-final blob is close to 1 (roughly 1/256 per byte position, over ~127KB per blob). One wrong byte anywhere in blob 1 of a 2-blob payload can drop the entire second blob.

## Why ox specifically

`Blobs.to` is a near line-for-line port of viem's `fromBlobs`. Viem fixed the identical bug in their own copy on 2026-07-22 ([viem#4888](https://github.com/wevm/viem/pull/4888), commit `944a011e`, *"fix: preserve blob-boundary `0x80` bytes"*). `src/core/Blobs.ts` was last touched here on 2026-07-14 — before viem's fix landed — and hasn't been touched since, so the port never received the corresponding patch.

## Repro

```
clean 200,000-byte payload (2 blobs, no 0x80): round-trips correctly
same payload with ONE 0x80 byte at index 1,000 (well inside blob 1):
  decoded output length: 1,000   (expected: 200,000)
```

Verified `git diff --check` clean and confirmed by stashing the source fix and re-running the new tests: both fail with exactly the predicted truncation on unfixed code, pass after restoring the fix.

## Fix

Track whether the current blob is the last one and gate the terminator check on it, matching viem's already-fixed `fromBlobs` exactly:

```ts
for (const [index, blob] of blobs_.entries()) {
  const cursor = Cursor.create(blob)
  const isLastBlob = index === blobs_.length - 1
  ...
    const isTerminator =
      isLastBlob &&
      byte === 0x80 &&
      !cursor.inspectBytes(cursor.remaining).includes(0x80)
```

## Why the existing tests never caught this

- The only multi-blob round-trip test (`large`, using a 178,628-byte lorem-ipsum fixture) contains **zero** `0x80` bytes — pure ASCII text, so the buggy branch is structurally unreachable.
- The regression test for `0x80` handling (`https://github.com/wevm/viem/issues/1986`) is only **11 bytes** — a single blob, where "current blob" and "last blob" are the same thing, so the missing guard is invisible there too.

Neither existing fixture combines *multi-blob* and *contains 0x80*. The two new tests do:

1. A 200,000-byte payload (2 blobs) with `0x80` bytes inside the first blob — proven to fail pre-fix, pass post-fix.
2. A boundary case: exactly `31 * fieldElementsPerBlob` bytes, all `0x80` — forces the first blob completely full of data with no terminator room, so `from` emits a second, terminator-only blob. This single case covers all-`0x80` data, a `0x80` at the very last position of a non-final blob, and a terminator-only final blob at once (per Codex review feedback below).

## Verification

- All existing 24 tests in `Blobs.test.ts` remain byte-identical after the fix — confirmed by running the full suite before and after.
- New tests: `pnpm test src/core/_test/Blobs.test.ts` → 26/26 passing.
- `pnpm check` → 0 errors (2 pre-existing, unrelated warnings in `site/src/components/Landing.tsx`, confirmed present on unmodified `main` too).
- Ran Codex (`gpt-5.6-sol`) as an adversarial reviewer against the diff, synchronously. Verdict: no correctness blocker — it independently confirmed single-blob, empty-input, all-`0x80`, and exact-capacity cases are all handled correctly by the fix. It flagged two real gaps, both addressed before opening this PR: the test should cover an exact-capacity all-`0x80` boundary case (added, described above), and this repo's guidelines require a changeset for a public decoding-behavior change (added: `.changeset/fix-blobs-terminator-boundary.md`).

## Scope

Decode-side only. Producers (`Blobs.from`) are unaffected — this only changes how `Blobs.to` interprets bytes that were already produced correctly.
