### PR TITLE
fix(Hex): signed odd-length decode RangeError, silent-zero negative encode without size

### DIFF
--- a/.changeset/fix-hex-signed-odd-length.md
+++ b/.changeset/fix-hex-signed-odd-length.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `Hex.toBigInt`/`Hex.toNumber` throwing a `RangeError` when decoding odd-length hex with `signed: true` (including `Hex`'s own `fromNumber` output), and `Hex.fromNumber` silently returning `0x0` for a negative `number` value with `signed: true` and no explicit `size`.

--- a/src/core/Hex.ts
+++ b/src/core/Hex.ts
@@ -281,7 +281,8 @@ export function fromNumber(
   // so it must be rejected here — matching how the `bigint` overload already
   // rejects a sizeless negative value (its `maxValue` stays `undefined`,
   // leaving `minValue` at `0`).
-  const minValue = size && typeof maxValue === 'bigint' && signed ? -maxValue - 1n : 0
+  const minValue =
+    size && typeof maxValue === 'bigint' && signed ? -maxValue - 1n : 0
 
   if ((maxValue && value_ > maxValue) || value_ < minValue) {
     const suffix = typeof value === 'bigint' ? 'n' : ''

--- a/src/core/Hex.ts
+++ b/src/core/Hex.ts
@@ -276,7 +276,12 @@ export function fromNumber(
     maxValue = BigInt(Number.MAX_SAFE_INTEGER)
   }
 
-  const minValue = typeof maxValue === 'bigint' && signed ? -maxValue - 1n : 0
+  // A negative `number` value without an explicit `size` has no defined
+  // two's-complement width to encode into (`size * 8` below would be `NaN`),
+  // so it must be rejected here — matching how the `bigint` overload already
+  // rejects a sizeless negative value (its `maxValue` stays `undefined`,
+  // leaving `minValue` at `0`).
+  const minValue = size && typeof maxValue === 'bigint' && signed ? -maxValue - 1n : 0
 
   if ((maxValue && value_ > maxValue) || value_ < minValue) {
     const suffix = typeof value === 'bigint' ? 'n' : ''
@@ -601,7 +606,10 @@ export function toBigInt(hex: Hex, options: toBigInt.Options = {}): bigint {
   const value = BigInt(hex)
   if (!signed) return value
 
-  const size = (hex.length - 2) / 2
+  // `Math.ceil` handles odd-length hex (e.g. `0x1a4`, ox's own `fromNumber`
+  // output for many values) — a plain `/ 2` yields a fractional byte count,
+  // which then throws when fed into `BigInt.asUintN`/shifted below.
+  const size = Math.ceil((hex.length - 2) / 2)
 
   const max_unsigned = (1n << (BigInt(size) * 8n)) - 1n
   const max_signed = max_unsigned >> 1n

--- a/src/core/_test/Hex.fuzz.ts
+++ b/src/core/_test/Hex.fuzz.ts
@@ -74,30 +74,33 @@ describe('Hex round-trip', () => {
       nibbles: fc.integer({ min: 0, max: 30 }).map((n) => n * 2 + 1), // odd values in [1, 61]
     },
     { numRuns },
-  )('toBigInt(oddLengthHex, { signed: true }) matches an independent two’s-complement decode', ({ nibbles }) => {
-    fc.assert(
-      fc.property(
-        fc.bigInt({
-          min: nibbles === 1 ? 0n : 16n ** BigInt(nibbles - 1),
-          max: 16n ** BigInt(nibbles) - 1n,
-        }),
-        (magnitude) => {
-          const hexDigits = magnitude.toString(16)
-          expect(hexDigits.length).toBe(nibbles) // sanity: guards the fuzz generator itself
-          const hex = `0x${hexDigits}` as Hex.Hex
+  )(
+    'toBigInt(oddLengthHex, { signed: true }) matches an independent two’s-complement decode',
+    ({ nibbles }) => {
+      fc.assert(
+        fc.property(
+          fc.bigInt({
+            min: nibbles === 1 ? 0n : 16n ** BigInt(nibbles - 1),
+            max: 16n ** BigInt(nibbles) - 1n,
+          }),
+          (magnitude) => {
+            const hexDigits = magnitude.toString(16)
+            expect(hexDigits.length).toBe(nibbles) // sanity: guards the fuzz generator itself
+            const hex = `0x${hexDigits}` as Hex.Hex
 
-          const byteWidth = Math.ceil(nibbles / 2)
-          const maxUnsigned = (1n << (BigInt(byteWidth) * 8n)) - 1n
-          const maxSigned = maxUnsigned >> 1n
-          const expected =
-            magnitude <= maxSigned ? magnitude : magnitude - maxUnsigned - 1n
+            const byteWidth = Math.ceil(nibbles / 2)
+            const maxUnsigned = (1n << (BigInt(byteWidth) * 8n)) - 1n
+            const maxSigned = maxUnsigned >> 1n
+            const expected =
+              magnitude <= maxSigned ? magnitude : magnitude - maxUnsigned - 1n
 
-          expect(Hex.toBigInt(hex, { signed: true })).toEqual(expected)
-        },
-      ),
-      { numRuns: 20 },
-    )
-  })
+            expect(Hex.toBigInt(hex, { signed: true })).toEqual(expected)
+          },
+        ),
+        { numRuns: 20 },
+      )
+    },
+  )
 
   test.prop(
     {

--- a/src/core/_test/Hex.fuzz.ts
+++ b/src/core/_test/Hex.fuzz.ts
@@ -54,6 +54,53 @@ describe('Hex round-trip', () => {
 
   test.prop(
     {
+      // Signed decode, fuzzed directly over odd-length hex strings rather
+      // than round-tripped through `fromNumber` — a round trip through
+      // `fromNumber` (unsigned-minimal-width encoding) is ambiguous
+      // whenever a positive value's own top bit lands on its own byte
+      // boundary (e.g. `2^47`), independent of and unrelated to hex-length
+      // parity, so it isn't a suitable oracle here.
+      //
+      // Generates a magnitude in `[16^(n-1), 16^n - 1]` (n = odd nibble
+      // count) so `magnitude.toString(16)` always renders as EXACTLY n
+      // digits — `toString(16)` doesn't zero-pad, so a magnitude below that
+      // floor would silently render shorter (and possibly even-length),
+      // defeating the odd-length case entirely. The expected value is
+      // computed by an independent two's-complement implementation against
+      // the hex string's own actual length (matching what the real
+      // implementation is meant to do), not assumed from `n` — a fractional
+      // `(hex.length - 2) / 2` byte-width computation previously threw a
+      // `RangeError` on every one of these odd-length inputs.
+      nibbles: fc.integer({ min: 0, max: 30 }).map((n) => n * 2 + 1), // odd values in [1, 61]
+    },
+    { numRuns },
+  )('toBigInt(oddLengthHex, { signed: true }) matches an independent two’s-complement decode', ({ nibbles }) => {
+    fc.assert(
+      fc.property(
+        fc.bigInt({
+          min: nibbles === 1 ? 0n : 16n ** BigInt(nibbles - 1),
+          max: 16n ** BigInt(nibbles) - 1n,
+        }),
+        (magnitude) => {
+          const hexDigits = magnitude.toString(16)
+          expect(hexDigits.length).toBe(nibbles) // sanity: guards the fuzz generator itself
+          const hex = `0x${hexDigits}` as Hex.Hex
+
+          const byteWidth = Math.ceil(nibbles / 2)
+          const maxUnsigned = (1n << (BigInt(byteWidth) * 8n)) - 1n
+          const maxSigned = maxUnsigned >> 1n
+          const expected =
+            magnitude <= maxSigned ? magnitude : magnitude - maxUnsigned - 1n
+
+          expect(Hex.toBigInt(hex, { signed: true })).toEqual(expected)
+        },
+      ),
+      { numRuns: 20 },
+    )
+  })
+
+  test.prop(
+    {
       value: fc.bigInt({ min: 0n, max: 2n ** 256n - 1n }),
     },
     { numRuns },

--- a/src/core/_test/Hex.test.ts
+++ b/src/core/_test/Hex.test.ts
@@ -205,6 +205,32 @@ describe('fromNumber', () => {
       '[Hex.IntegerOutOfRangeError: Number `-32769` is not in safe 16-bit signed integer range (`-32768` to `32767`)]',
     )
   })
+
+  test('behavior: signed, negative, no size throws instead of silently zeroing', () => {
+    // Without an explicit `size`, there is no defined two's-complement width
+    // to encode a negative value into. This must throw (matching the
+    // `bigint` overload's existing behavior for the same shape of input)
+    // rather than silently collapsing to `0x0`.
+    //
+    // The public type already requires `size` whenever `signed` is passed
+    // (see `fromNumber.Options`) — these calls deliberately bypass that at
+    // the type level to exercise the runtime guard directly, since nothing
+    // stops an untyped/JS caller from doing the same.
+    expect(() =>
+      // @ts-expect-error — intentionally omitting the required `size`.
+      Hex.fromNumber(-1, { signed: true }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Hex.IntegerOutOfRangeError: Number `-1` is not in safe signed integer range (`0` to `9007199254740991`)]',
+    )
+    expect(() =>
+      // @ts-expect-error — intentionally omitting the required `size`.
+      Hex.fromNumber(-1n, { signed: true }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      '[Hex.IntegerOutOfRangeError: Number `-1n` is not in safe signed integer range (above `0n`)]',
+    )
+    // Control: an explicit `size` still encodes correctly.
+    expect(Hex.fromNumber(-1, { signed: true, size: 1 })).toBe('0xff')
+  })
 })
 
 describe('fromString', () => {
@@ -403,6 +429,24 @@ describe('toBigInt', () => {
         },
       ),
     ).toBe(-12312312312312312412n)
+  })
+
+  test('behavior: signed, odd-length hex', () => {
+    // Odd-length hex (an odd number of nibbles) previously threw a
+    // `RangeError` in signed mode, since the byte-width computation
+    // (`(hex.length - 2) / 2`) produced a fraction. `Hex.fromNumber`'s own
+    // output is odd-length for roughly half of all values, so this needed
+    // to round-trip.
+    expect(Hex.toBigInt('0xf', { signed: true })).toBe(15n)
+    expect(Hex.toBigInt('0x1a4', { signed: true })).toBe(420n)
+    expect(Hex.toBigInt('0xfff', { signed: true })).toBe(4095n)
+    // An explicit `size` doesn't help on its own — it only drives a
+    // separate `assertSize` validation; the width used for the actual
+    // two's-complement decode is still derived unconditionally from
+    // `hex.length`, so this case threw on the old code too.
+    expect(Hex.toBigInt('0x1a4', { signed: true, size: 32 })).toBe(420n)
+    // Round-trip through ox's own encoder.
+    expect(Hex.toBigInt(Hex.fromNumber(420), { signed: true })).toBe(420n)
   })
 
   test('args: size', () => {


### PR DESCRIPTION
## What

Two related bugs in `Hex.toBigInt`/`Hex.toNumber`/`Hex.fromNumber`'s signed handling, both in `src/core/Hex.ts`:

**1. `toBigInt`/`toNumber` with `signed: true` throw `RangeError` on every odd-length hex**

```ts
const size = (hex.length - 2) / 2   // fractional for odd nibble counts
```

This width feeds into `BigInt.asUintN`/a `BigInt` shift below, which throws on a non-integer. `Hex.fromNumber`'s own output is odd-length for roughly half of all values (e.g. `Hex.fromNumber(420)` → `'0x1a4'`), so ox can't round-trip its own encoder's output in signed mode:

```
Hex.toBigInt(Hex.fromNumber(420), { signed: true })
// RangeError: The number 1.5 cannot be converted to a BigInt because it is not an integer
```

An explicit `size` option doesn't help — it only drives a separate `assertSize` validation; the width used for the actual decode is still computed unconditionally from `hex.length`.

**Provenance**: viem has the identical function and fixed this exact bug on 2026-09-01 (viem#4913, `Math.ceil((hex.length - 2) / 2)`). This file was last touched 2026-07-30 (an unrelated ABI-perf change) — the port never received the corresponding patch.

Fixed with `Math.ceil`, matching viem exactly.

**2. `fromNumber(negativeValue, { signed: true })` with no `size` silently returns `0x0`**

```ts
Hex.fromNumber(-1, { signed: true })
// '0x0'   <- should throw, not silently zero
```

For a `number` input with no `size`, `maxValue` defaults to `MAX_SAFE_INTEGER`, which widens `minValue` enough that a negative value passes the range check and reaches `BigInt.asUintN(size * 8, ...)` with `size` undefined (`NaN`). `BigInt.asUintN` coerces `NaN` to `0` via `ToIndex`, so `BigInt.asUintN(0, -1n)` evaluates to `0n` — silent, no error.

This is an internal inconsistency, not a one-off: the `bigint` overload of this *same function* already throws for the identical shape of input (`Hex.fromNumber(-1n, { signed: true })` → `IntegerOutOfRangeError`, since `maxValue` stays `undefined` for a bigint input, leaving `minValue` at `0`). And the sibling `Bytes.fromNumber(-1, { signed: true })` (no size) correctly returns `0xffff` rather than sharing this bug — so `Hex` and `Bytes`, the two encoders for the same concept, currently disagree on identical input, and `Hex.fromNumber`'s own two overloads disagree with each other.

Fixed by narrowing `minValue` to `0` when `size` is falsy, matching the `bigint` overload's existing (correct) behavior — negative values without a size now throw a clear `IntegerOutOfRangeError` instead of silently zeroing. An explicit `size` still encodes correctly (`Hex.fromNumber(-1, { signed: true, size: 1 })` → `'0xff'`, unchanged).

## Why the existing tests missed both

- All ~11 signed test vectors for `toBigInt` are even-length hex; none is odd.
- The property-based round-trip test (`Hex.fuzz.ts`) round-trips `toNumber(fromNumber(n))` but its own comment says "ox uses unsigned by default" and deliberately never adds a `signed: true` arm — meaning the fuzzer generates exactly the breaking odd-length inputs (via `fromNumber`) but never asks the question that would catch it.
- Nothing exercised `fromNumber` with a negative value and no `size`.

## Testing

Added:
- Direct odd-length signed-decode unit tests (`0xf`, `0x1a4`, `0xfff`, with and without an explicit `size`, plus a round-trip through `fromNumber`).
- A `fromNumber` unit test asserting the negative-no-size case now throws (both `number` and `bigint` overloads), with an explicit `size` control still working.
- A property test decoding random odd-length hex directly against an independently-computed two's-complement reference (not round-tripped through `fromNumber`, since that round trip has a separate, unrelated ambiguity when a positive value's own top bit lands on a byte boundary — noted in the test's comment so it isn't mistaken for covering that case too).

Verified genuine red-before/green-after by stashing just the source fix and confirming the new tests fail with the exact predicted symptoms (`RangeError`/silent `0x0`) against unfixed code, then pass after restoring the fix.

Full `src/core` test suite: 3352/3352 relevant tests pass (12 pre-existing failures are unrelated network-timeout tests hitting a fallback public RPC in this sandbox — `AbiConstructor`, `TransactionEnvelope*`, `RpcRequest`/`RpcResponse` "behavior: network" cases, none touching `Hex.ts`). `pnpm check:types` clean.

Ran Codex adversarially against the diff before opening this PR — it caught two real issues, both fixed: the negative-no-size test calls intentionally violate `fromNumber.Options`' type contract (which already requires `size` whenever `signed` is passed) and needed `@ts-expect-error`, and a test comment inaccurately claimed an explicit `size` bypasses the odd-length width computation (it doesn't — `size` only drives a separate `assertSize` check).

Changeset added.
