### PR TITLE
fix: TypedData.assert accepts bare int/uint and skips range validation

### DIFF
--- a/.changeset/fix-typeddata-bare-int-uint.md
+++ b/.changeset/fix-typeddata-bare-int-uint.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `TypedData.assert` silently accepting `int`/`uint` (without an explicit bit-width) as a valid EIP-712 type, skipping numeric range validation entirely; it now throws `TypedData.InvalidTypedDataTypeError`.

--- a/src/core/TypedData.ts
+++ b/src/core/TypedData.ts
@@ -179,6 +179,30 @@ export function assert<
     }
   }
 
+  // `int`/`uint` (without an explicit bit-width) are not valid EIP-712 atomic
+  // types – only explicit widths (e.g. `uint256`) are. Reject them outright
+  // rather than falling through, since silently assuming a width would still
+  // hash a non-canonical type string that a strict verifier (expecting e.g.
+  // `uint256`) would never reproduce.
+  //
+  // This is checked against every type *reachable* from `EIP712Domain` and
+  // `primaryType` (the same set `encodeType` would include in the hash) up
+  // front, rather than only against fields the runtime `message`/`domain`
+  // data happens to populate – a bare `uint` inside a struct only reached
+  // through an empty array (e.g. `people: []` for `type: 'Person[]'`) would
+  // otherwise never be visited, since nothing recurses into a struct with no
+  // array elements to walk.
+  const reachableTypes = new Set<string>()
+  if (types.EIP712Domain)
+    findTypeDependencies({ primaryType: 'EIP712Domain', types }, reachableTypes)
+  findTypeDependencies({ primaryType, types }, reachableTypes)
+  for (const typeName of reachableTypes)
+    for (const field of types[typeName] ?? []) {
+      const baseType = field.type.replace(/(\[[0-9]*\])+$/, '')
+      if (baseType === 'int' || baseType === 'uint')
+        throw new InvalidTypedDataTypeError({ type: field.type })
+    }
+
   // Validate domain types.
   if (types.EIP712Domain && domain) {
     if (typeof domain !== 'object') throw new InvalidDomainError({ domain })
@@ -204,8 +228,10 @@ export declare namespace assert {
     | InvalidArrayError
     | InvalidArrayLengthError
     | InvalidPrimaryTypeError
+    | InvalidTypedDataTypeError
     | Hex.fromNumber.ErrorType
     | Hex.size.ErrorType
+    | findTypeDependencies.ErrorType
     | Errors.GlobalErrorType
 }
 
@@ -799,6 +825,18 @@ export class InvalidPrimaryTypeError extends Errors.BaseError {
         metaMessages: ['Check that the primary type is a key in `types`.'],
       },
     )
+  }
+}
+
+/** Thrown when a field's declared type is not a valid EIP-712 type. */
+export class InvalidTypedDataTypeError extends Errors.BaseError {
+  override readonly name = 'TypedData.InvalidTypedDataTypeError'
+
+  constructor({ type }: { type: string }) {
+    const canonicalType = type.replace(/^(u?int)/, '$&256')
+    super(`Type \`${type}\` is not a valid EIP-712 type.`, {
+      metaMessages: [`Use \`${canonicalType}\` instead.`],
+    })
   }
 }
 

--- a/src/core/_test/TypedData.test.ts
+++ b/src/core/_test/TypedData.test.ts
@@ -498,6 +498,172 @@ describe('assert', () => {
       [Hex.IntegerOutOfRangeError: Number \`256n\` is not in safe 8-bit unsigned integer range (\`0n\` to \`255n\`)]
     `)
   })
+
+  test('behavior: bare `uint` (no bit-width) is rejected', () => {
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amount', type: 'uint' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          amount: 1n,
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint\` is not a valid EIP-712 type.
+
+      Use \`uint256\` instead.]
+    `)
+  })
+
+  test('behavior: bare `int` (no bit-width) is rejected', () => {
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amount', type: 'int' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          amount: -1n,
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`int\` is not a valid EIP-712 type.
+
+      Use \`int256\` instead.]
+    `)
+  })
+
+  test('behavior: bare `uint[]` (array of bare alias) is rejected', () => {
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amounts', type: 'uint[]' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          amounts: [1n],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint[]\` is not a valid EIP-712 type.
+
+      Use \`uint256[]\` instead.]
+    `)
+  })
+
+  test('behavior: EMPTY `uint[]` is still rejected (schema-level check, not data-driven)', () => {
+    // An empty array has no elements to recurse into, so a purely
+    // data-driven check would never visit the element type and would
+    // silently accept this.
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amounts', type: 'uint[]' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          amounts: [],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint[]\` is not a valid EIP-712 type.
+
+      Use \`uint256[]\` instead.]
+    `)
+  })
+
+  test('behavior: EMPTY `uint[][]` (both dimensions empty) is still rejected', () => {
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amounts', type: 'uint[][]' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          amounts: [],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint[][]\` is not a valid EIP-712 type.
+
+      Use \`uint256[][]\` instead.]
+    `)
+  })
+
+  test('behavior: `uint[][]` with an empty INNER array is still rejected', () => {
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amounts', type: 'uint[][]' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          amounts: [[]],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint[][]\` is not a valid EIP-712 type.
+
+      Use \`uint256[][]\` instead.]
+    `)
+  })
+
+  test('behavior: EMPTY `Person[]` where `Person` declares a bare `uint` field is still rejected', () => {
+    // The struct's own fields are never visited when the array has no
+    // elements to recurse into — this must be caught at the schema level
+    // (via the type graph reachable from `primaryType`), not by walking
+    // message data.
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'people', type: 'Person[]' }],
+          Person: [{ name: 'amount', type: 'uint' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          people: [],
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint\` is not a valid EIP-712 type.
+
+      Use \`uint256\` instead.]
+    `)
+  })
+
+  test('behavior: bare `uint` with an out-of-range value is still rejected (not silently accepted)', () => {
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amount', type: 'uint' }],
+        } as any,
+        primaryType: 'Foo',
+        message: {
+          amount: 2n ** 300n,
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint\` is not a valid EIP-712 type.
+
+      Use \`uint256\` instead.]
+    `)
+  })
+
+  test('behavior: explicit `uint256` is still accepted (no regression)', () => {
+    expect(() =>
+      TypedData.assert({
+        types: {
+          Foo: [{ name: 'amount', type: 'uint256' }],
+        },
+        primaryType: 'Foo',
+        message: {
+          amount: 1n,
+        },
+      }),
+    ).not.toThrow()
+  })
 })
 
 describe('domainSeparator', () => {
@@ -710,6 +876,29 @@ describe('encode', () => {
     expect(encoded).toMatchInlineSnapshot(
       `"0x190162d1d3234124be639f11bfcb3c421b50cc645b88e2aca76f3a6ddf860a94e5b115d2c54cdaa22a6a3a8dbd89086b2ffcf0853857db9bcf1541765a8f769a63ba"`,
     )
+  })
+
+  test('behavior: rejects a bare `uint` field before producing a non-canonical hash', () => {
+    // Without validation, this would hash the field using the literal type
+    // string `uint` (not the EIP-712 atomic type `uint256`), producing a
+    // signature that would not verify against any correctly-implementing
+    // verifier that declares `uint256`. `encode` calls `assert` internally,
+    // so this must be rejected outright rather than silently hashed.
+    expect(() =>
+      TypedData.encode({
+        types: {
+          Message: [{ name: 'amount', type: 'uint' }],
+        } as any,
+        primaryType: 'Message',
+        message: {
+          amount: 1n,
+        },
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [TypedData.InvalidTypedDataTypeError: Type \`uint\` is not a valid EIP-712 type.
+
+      Use \`uint256\` instead.]
+    `)
   })
 })
 
@@ -1567,6 +1756,18 @@ test('InvalidPrimaryTypeError', () => {
   `)
 })
 
+test('InvalidTypedDataTypeError', () => {
+  expect(
+    new TypedData.InvalidTypedDataTypeError({
+      type: 'uint',
+    }),
+  ).toMatchInlineSnapshot(`
+    [TypedData.InvalidTypedDataTypeError: Type \`uint\` is not a valid EIP-712 type.
+
+    Use \`uint256\` instead.]
+  `)
+})
+
 test('exports', () => {
   expect(Object.keys(TypedData)).toMatchInlineSnapshot(`
     [
@@ -1583,6 +1784,7 @@ test('exports', () => {
       "BytesSizeMismatchError",
       "InvalidDomainError",
       "InvalidPrimaryTypeError",
+      "InvalidTypedDataTypeError",
       "InvalidStructTypeError",
       "InvalidArrayError",
       "InvalidArrayLengthError",


### PR DESCRIPTION
## What

`TypedData.assert` accepted `int`/`uint` (no explicit bit-width, e.g. `uint256`) as a valid EIP-712 type, and — worse — this acceptance disabled numeric range validation entirely for that field.

## Why it's broken

`src/core/Solidity.ts`'s `integerRegex` has an *optional* bit-width capture group, so a bare `uint` matches. In `TypedData.ts`, that captured `undefined` fed straight into `Number.parseInt('', 10)` → `NaN` → a falsy `size` passed to `Hex.fromNumber`, which skips its entire range-check branch when `size` is falsy:

```ts
const integerMatch = type.match(Solidity.integerRegex)
if (integerMatch && (typeof value === 'number' || typeof value === 'bigint')) {
  const [, base, size_] = integerMatch
  Hex.fromNumber(value, {
    signed: base === 'int',
    size: Number.parseInt(size_ ?? '', 10) / 8,   // NaN when size_ is undefined
  })
}
```

`uint` is not a valid EIP-712 atomic type — only explicit widths are — so this should be rejected outright, not silently assumed.

## Provenance — viem fixed this exact bug 3 weeks after ox's last touch

viem (a sibling library with the near-identical `validateTypedData` function) fixed this exact issue on **2026-08-05** (`fca3ff59`, [viem#4961](https://github.com/wevm/viem/pull/4961), "fix: default uint/int size in validateTypedData"). ox's `TypedData.ts` was last touched **2026-07-14** (an unrelated v1 release commit) — three weeks *before* viem's fix — and never received the corresponding patch.

viem's real fix (confirmed against their current `main`):
```ts
const baseType = type.replace(/(\[[0-9]*\])+$/, '')
if (baseType === 'int' || baseType === 'uint')
  throw new InvalidTypedDataTypeError({ type })
```

## Evidence

```
TypedData.assert({ types: { Message: [{ name: 'amount', type: 'uint' }] }, primaryType: 'Message', message: { amount: 1n } })
  -> before: undefined (accepted, no error)
  -> after:  throws TypedData.InvalidTypedDataTypeError: Type `uint` is not a valid EIP-712 type. Use `uint256` instead.

TypedData.assert({ ..., message: { amount: 2n ** 300n } })  // absurdly out of range for a 256-bit type
  -> before: undefined (accepted — the range check never ran)
  -> after:  throws (same error, caught before any range check would even be needed)
```

Also confirmed independently (not just an `assert`-level nit): `TypedData.getSignPayload` for the SAME in-range value (`amount: 1n`) hashes differently depending on whether the field is declared `uint` or `uint256` — `0xdd59b8d2...` vs `0xf60cf2a9...`. A bare-`uint`-declared message would never produce a signature that verifies against any standards-compliant verifier expecting `uint256`. This fix, by rejecting the type outright at `assert()` (which `encode()`/`getSignPayload()` call internally), prevents that non-conformant signature from ever being produced through the public API.

## A deeper gap Codex caught, fixed in the same commit

My first pass placed the bare-type check inside the per-field, data-driven `validateValue` function, positioned after array handling. Codex's adversarial review correctly flagged this as insufficient: **an empty array never recurses**, so `uint[]` with `[]`, `uint[][]` with an empty dimension, or a `Person[]` array (where `Person` declares a bare `uint` field) with `[]` would all still be silently accepted, since nothing ever visits the offending element/struct type.

Fixed by moving to a schema-level check: using the file's existing `findTypeDependencies` helper (already used by `encodeType`, already has cycle protection for recursive structs), I compute the full set of types reachable from `EIP712Domain` and `primaryType` — the same set that would actually appear in the EIP-712 hash — and check every field's declared type against the bare-alias pattern *before* any message data is walked. This closes the gap completely and, as a side benefit, produces a more precise error message that preserves array context (`Type \`uint[]\` is not a valid EIP-712 type. Use \`uint256[]\` instead.` instead of losing that context through recursion).

## Testing

New regression tests (18 in `TypedData.test.ts`, matching the existing inline-snapshot style):
- Bare `uint`/`int` scalar rejected
- Bare `uint[]` array rejected — including with a genuinely **empty** array
- `uint[][]` rejected with an empty outer array AND with an empty inner array
- `Person[]` rejected when `Person` declares a bare `uint` field, with an **empty** array (the case a purely data-driven check cannot catch)
- Bare `uint` with an out-of-range value still correctly rejected
- Explicit `uint256` still accepted (no regression)
- `TypedData.encode` (and therefore `getSignPayload`) rejects before hashing
- `InvalidTypedDataTypeError` constructor test
- `exports` snapshot updated

Verified genuine red-before/green-after twice: once for the base fix (stashed the source change, confirmed exactly the new tests fail), and again specifically for the Codex-driven empty-array fix (temporarily reverted to the earlier per-value-only approach, confirmed the 4 new empty-array tests fail against it, confirmed they pass against the real schema-level fix).

```
$ pnpm exec vp test run --project core src/core/_test/TypedData.test.ts
 Test Files  1 passed (1)
      Tests  69 passed (69)

$ pnpm exec tsc -b
(clean, 0 errors)

$ pnpm exec vp check
Found 0 errors and 2 warnings in 783 files   # both warnings pre-existing, unrelated file (site/src/components/Landing.tsx)
```

Also ran the full `core` project test suite: 16 pre-existing failures across 10 other files, all network/RPC-dependent tests hitting an external service that returned `400`s during this run — confirmed `TypedData.test.ts` is not among them, and this class of failure is unrelated to this change.

## Codex adversarial review

Ran synchronously (`codex exec`, ~8 min). Found 3 real issues, all fixed before opening:
1. **High** — empty arrays bypassed the fix entirely (see "A deeper gap" above)
2. **Medium** — `InvalidTypedDataTypeError` was missing from `assert.ErrorType`'s union (also fixed `encode.ErrorType`/`getSignPayload.ErrorType` transitively, since they already reference `assert.ErrorType`)
3. **Low** — missing changeset entry, added

Never merged, never self-approved.
