### PR TITLE
fix(tempo): Tick.fromPrice silently accepts a negative price as its positive counterpart

### DIFF
--- a/src/tempo/Tick.test.ts
+++ b/src/tempo/Tick.test.ts
@@ -115,6 +115,26 @@ describe('fromPrice', () => {
     expect(Tick.fromPrice('  1.0  ')).toBe(0)
     expect(Tick.fromPrice(' 1.001 ')).toBe(100)
   })
+
+  test('never silently accepts a negative price as its positive counterpart', () => {
+    // Regression: `BigInt('-0')` is `0n`, so a fractional negative price
+    // (magnitude < 1) previously lost its sign entirely and was silently
+    // treated as the equivalent positive price, landing at the SAME
+    // in-bounds tick instead of correctly being rejected. No tick in
+    // [minTick, maxTick] ever round-trips to a negative or zero price
+    // (see `toPrice`, whose output range is always positive), so every
+    // negative price string must throw.
+    expect(() => Tick.fromPrice('-0.999')).toThrow(Tick.PriceOutOfBoundsError)
+    expect(() => Tick.fromPrice('-0.98')).toThrow(Tick.PriceOutOfBoundsError)
+    expect(() => Tick.fromPrice('-0.0005')).toThrow(Tick.PriceOutOfBoundsError)
+    expect(() => Tick.fromPrice('-1.0')).toThrow(Tick.PriceOutOfBoundsError)
+    expect(() => Tick.fromPrice('0')).toThrow(Tick.PriceOutOfBoundsError)
+    expect(() => Tick.fromPrice('-0')).toThrow(Tick.PriceOutOfBoundsError)
+
+    // Positive prices are unaffected.
+    expect(Tick.fromPrice('0.999')).toBe(-100)
+    expect(Tick.fromPrice('0.98')).toBe(-2000)
+  })
 })
 
 describe('round-trip conversions', () => {

--- a/src/tempo/Tick.ts
+++ b/src/tempo/Tick.ts
@@ -100,15 +100,21 @@ export function fromPrice(price: fromPrice.Price): fromPrice.ReturnType {
   if (!/^-?\d+(\.\d+)?$/.test(priceStr))
     throw new InvalidPriceFormatError({ price })
 
-  // Parse price using string manipulation to avoid float precision issues
-  const [w, d = '0'] = priceStr.split('.')
+  // Parse price using string manipulation to avoid float precision issues.
+  // Sign is tracked separately: `BigInt('-0')` is `0n`, so a negative
+  // fractional price (e.g. "-0.999") would otherwise lose its sign and
+  // silently collide with the equivalent positive price (e.g. "0.999").
+  const negative = priceStr.startsWith('-')
+  const unsigned = negative ? priceStr.slice(1) : priceStr
+  const [w, d = '0'] = unsigned.split('.')
   const whole = BigInt(w!)
 
   // Pad or truncate decimal to exactly 5 digits
   const decimal = BigInt(d.padEnd(5, '0').slice(0, 5))
 
   // Calculate price
-  const priceInt = whole * BigInt(priceScale) + decimal
+  let priceInt = whole * BigInt(priceScale) + decimal
+  if (negative) priceInt = -priceInt
 
   // Calculate tick
   const tick = Number(priceInt - BigInt(priceScale))


### PR DESCRIPTION
`Tick.fromPrice` silently accepted a negative fractional price (magnitude < 1) as if it were its positive counterpart, instead of rejecting it.

## Root cause

```ts
const [w, d = '0'] = priceStr.split('.')
const whole = BigInt(w!)
```

`BigInt('-0')` is `0n` — JavaScript BigInt has no negative zero. So for any price string whose whole-number part is `"0"` or `"-0"` (i.e. `|price| < 1`), the sign is discarded before the decimal component is even parsed, and the decimal component is always parsed unsigned. The negative and positive versions of the same fractional price collapse to the identical internal integer.

## Why this matters

`Tick.toPrice`'s output range is always positive — `price = priceScale + tick` with `tick ∈ [-2000, 2000]` and `priceScale = 100_000`, so real prices only ever fall in `[0.98, 1.02]` (this is a stablecoin-peg DEX, ±2% around 1.0). No valid tick ever round-trips to a negative or zero price. So a negative price string reaching `fromPrice` is *always* invalid input and should throw `PriceOutOfBoundsError` — but for `|price| < 1` it was instead silently accepted as a valid, in-bounds tick.

```
fromPrice('-0.999') -> -100   (WRONG: silently accepted, aliases onto fromPrice('0.999'))
fromPrice('0.999')  -> -100   (correct)
fromPrice('-0.98')  -> -2000  (WRONG: silently accepted, aliases onto fromPrice('0.98'))
fromPrice('0.98')   -> -2000  (correct)
```

For `|price| >= 1` the bug is invisible — a nonzero whole-number part (`BigInt('-1')` is genuinely `-1n`) already carries the correct sign, so those cases already threw `PriceOutOfBoundsError` as expected. The bug is confined to the `(-1, 0]` range.

## Fix

Track the negative sign separately from the `BigInt` parse of the whole-number part, and apply it to the final combined price integer — so the sign survives regardless of whether the whole-number part happens to be zero.

## Test

Existing coverage never exercised a negative price string at all — every `fromPrice` test case in the file uses a positive input. Added a regression test asserting every negative price (including the `-0`/`-0.0` edge cases) throws `PriceOutOfBoundsError`, and that positive prices are unaffected.

## Receipts

Genuine red-before/green-after (`git stash` on just the source fix, new test fails with the exact predicted collision, restored fix passes):

```
$ vp test run src/tempo/Tick.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

Full `src/tempo/` suite: 22/24 files pass (683/720 tests, 37 pre-existing skips); the 2 failing suites are `multisig.e2e.test.ts` and `e2e.test.ts`, both network-dependent (`ECONNRESET`, no connectivity in this sandbox) and unrelated to this change — confirmed via `git diff --stat` touching neither file.

`tsc --noEmit` clean, `vp check --fix` clean (0 errors; 2 pre-existing warnings in an unrelated `site/` file, confirmed untouched by this diff).

Codex adversarial review: attempted synchronously, stalled 5 minutes with no output — substituted a thorough self-review (checked sign-handling on `-0`/`-0.0`, large-magnitude negatives, positive-path non-regression, and confirmed no duplicate implementation of this parsing logic elsewhere in the repo).
