### PR TITLE
fix(tempo): keychain signature version defaults to v2 (revert stale v1 default, fix doc comment instead)

### DIFF
--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -797,12 +797,12 @@ describe('deserialize', () => {
       )
     })
 
-    test('behavior: version defaults to v1 (matching the documented @default) when omitted', () => {
-      // Regression: `serialize` previously selected the v2 type id whenever
-      // `version` was anything other than the literal string 'v1' -- which
-      // includes `undefined` (version omitted). `Keychain['version']` is
-      // documented `@default 'v1'`, so an omitted version must serialize
-      // identically to an explicit 'v1', not silently fall through to v2.
+    test('behavior: version defaults to v2 (matching the documented @default) when omitted', () => {
+      // `Keychain['version']` is documented `@default 'v2'` -- an omitted
+      // version must serialize identically to an explicit 'v2', not fall
+      // through to the legacy v1 type id. (The live Tempo network rejects
+      // v1 keychain signatures outright: "legacy V1 keychain signature is
+      // no longer accepted, use V2" -- confirmed against tempo CI.)
       const withoutVersion = SignatureEnvelope.from({
         userAddress: signature_keychain_secp256k1.userAddress,
         inner: SignatureEnvelope.from(signature_secp256k1),
@@ -821,16 +821,16 @@ describe('deserialize', () => {
       const serializedWithoutVersion =
         SignatureEnvelope.serialize(withoutVersion)
       expect(serializedWithoutVersion).toBe(
-        SignatureEnvelope.serialize(explicitV1),
-      )
-      expect(serializedWithoutVersion).not.toBe(
         SignatureEnvelope.serialize(explicitV2),
       )
+      expect(serializedWithoutVersion).not.toBe(
+        SignatureEnvelope.serialize(explicitV1),
+      )
 
-      // The deserialized round trip must report 'v1', not 'v2'.
+      // The deserialized round trip must report 'v2', not 'v1'.
       expect(
         SignatureEnvelope.deserialize(serializedWithoutVersion),
-      ).toMatchObject({ version: 'v1' })
+      ).toMatchObject({ version: 'v2' })
     })
   })
 })

--- a/src/tempo/SignatureEnvelope.test.ts
+++ b/src/tempo/SignatureEnvelope.test.ts
@@ -796,6 +796,42 @@ describe('deserialize', () => {
         `[Hex.SliceOffsetOutOfBoundsError: Slice starting at offset \`20\` is out-of-bounds (size: \`10\`).]`,
       )
     })
+
+    test('behavior: version defaults to v1 (matching the documented @default) when omitted', () => {
+      // Regression: `serialize` previously selected the v2 type id whenever
+      // `version` was anything other than the literal string 'v1' -- which
+      // includes `undefined` (version omitted). `Keychain['version']` is
+      // documented `@default 'v1'`, so an omitted version must serialize
+      // identically to an explicit 'v1', not silently fall through to v2.
+      const withoutVersion = SignatureEnvelope.from({
+        userAddress: signature_keychain_secp256k1.userAddress,
+        inner: SignatureEnvelope.from(signature_secp256k1),
+      })
+      const explicitV1 = SignatureEnvelope.from({
+        userAddress: signature_keychain_secp256k1.userAddress,
+        inner: SignatureEnvelope.from(signature_secp256k1),
+        version: 'v1',
+      })
+      const explicitV2 = SignatureEnvelope.from({
+        userAddress: signature_keychain_secp256k1.userAddress,
+        inner: SignatureEnvelope.from(signature_secp256k1),
+        version: 'v2',
+      })
+
+      const serializedWithoutVersion =
+        SignatureEnvelope.serialize(withoutVersion)
+      expect(serializedWithoutVersion).toBe(
+        SignatureEnvelope.serialize(explicitV1),
+      )
+      expect(serializedWithoutVersion).not.toBe(
+        SignatureEnvelope.serialize(explicitV2),
+      )
+
+      // The deserialized round trip must report 'v1', not 'v2'.
+      expect(
+        SignatureEnvelope.deserialize(serializedWithoutVersion),
+      ).toMatchObject({ version: 'v1' })
+    })
   })
 })
 

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -153,7 +153,7 @@ export type Keychain<numberType = number> = {
   /** The access key address (recovered address of the access key signer). */
   keyId?: Address.Address | undefined
   type: 'keychain'
-  /** Keychain signature version. @default 'v1' */
+  /** Keychain signature version. @default 'v2' */
   version?: KeychainVersion | undefined
 }
 
@@ -984,14 +984,14 @@ export function from<const value extends from.Value>(
     ...(type === 'p256' ? { prehash: (value as P256).prehash } : {}),
     ...(type === 'keychain'
       ? {
-          // `Keychain['version']` is documented `@default 'v1'`.
+          // `Keychain['version']` is documented `@default 'v2'`.
           ...(!(
             typeof value === 'object' &&
             value !== null &&
             'version' in value &&
             value.version
           )
-            ? { version: 'v1' }
+            ? { version: 'v2' }
             : {}),
           ...(!(typeof value === 'object' && 'keyId' in value && value.keyId)
             ? (() => {
@@ -1360,12 +1360,12 @@ export function serialize(
 
   if (type === 'keychain') {
     const keychain = envelope as Keychain
-    // `version` defaults to 'v1' (see `Keychain['version']`'s doc comment),
-    // so only an explicit 'v2' should select the v2 type id.
+    // `version` defaults to 'v2' (see `Keychain['version']`'s doc comment),
+    // so only an explicit 'v1' should select the legacy v1 type id.
     const keychainTypeId =
-      keychain.version === 'v2'
-        ? serializedKeychainV2Type
-        : serializedKeychainType
+      keychain.version === 'v1'
+        ? serializedKeychainType
+        : serializedKeychainV2Type
     return Hex.concat(
       keychainTypeId,
       keychain.userAddress,

--- a/src/tempo/SignatureEnvelope.ts
+++ b/src/tempo/SignatureEnvelope.ts
@@ -984,13 +984,14 @@ export function from<const value extends from.Value>(
     ...(type === 'p256' ? { prehash: (value as P256).prehash } : {}),
     ...(type === 'keychain'
       ? {
+          // `Keychain['version']` is documented `@default 'v1'`.
           ...(!(
             typeof value === 'object' &&
             value !== null &&
             'version' in value &&
             value.version
           )
-            ? { version: 'v2' }
+            ? { version: 'v1' }
             : {}),
           ...(!(typeof value === 'object' && 'keyId' in value && value.keyId)
             ? (() => {
@@ -1359,10 +1360,12 @@ export function serialize(
 
   if (type === 'keychain') {
     const keychain = envelope as Keychain
+    // `version` defaults to 'v1' (see `Keychain['version']`'s doc comment),
+    // so only an explicit 'v2' should select the v2 type id.
     const keychainTypeId =
-      keychain.version === 'v1'
-        ? serializedKeychainType
-        : serializedKeychainV2Type
+      keychain.version === 'v2'
+        ? serializedKeychainV2Type
+        : serializedKeychainType
     return Hex.concat(
       keychainTypeId,
       keychain.userAddress,


### PR DESCRIPTION
## Correction (2026-09-02)

This PR previously changed the default to `'v1'` (see below for that reasoning). That was backwards and broke both `Test Runtime (tempo multisig)` and `Test Runtime (tempo, env: localnet, tag: edge)` — the live Tempo network these CI jobs run against already rejects v1 keychain signatures:

```
RpcRequestError: RPC Request failed.
Details: legacy V1 keychain signature is no longer accepted, use V2 (type 0x04)
```

Verified via GitHub's check-runs API that this branch's parent commit (`ef203862`, PR #438, upstream `main` at the time) has both tempo checks passing, and is the direct parent of this branch's only prior commit — i.e. this PR was exactly one commit ahead of a known-green `main`, and that commit is what broke both checks.

So the doc comment (`@default 'v1'`) was the stale side, not the runtime. This PR now:
- Reverts the functional default in `from()` and `serialize()` back to `'v2'` — confirmed via `git diff` to be byte-identical to the known-good parent commit's version of this file.
- Fixes the doc comment to read `@default 'v2'` instead, matching what the live network actually requires (and what the runtime always did prior to this PR).
- Updates the regression test to assert the correct (v2-default) direction: an omitted `version` serializes identically to an explicit `'v2'`, differently from `'v1'`, and round-trips reporting `'v2'`.

**Receipts**: `vp test src/tempo/SignatureEnvelope.test.ts` — 206/206 passing. `tsc --noEmit` clean. Both tempo CI checks now pass on this branch (previously failing). Codex adversarial review was started but didn't return a verdict within ~8 minutes and was killed (own tracked PID only, no impact on siblings); self-reviewed instead — the diff against the known-good parent commit, which shows zero functional delta, is the strongest available evidence.

---

## Original PR description (superseded reasoning, kept for context)

`Keychain['version']` is documented `@default 'v1'`, but omitting `version` actually resolved to `'v2'` at two separate sites.

### Root cause

Both introduced in the same commit that added v2 keychain support (`4a79ac54`, #178), alongside the doc comment itself:

**1. `from()`'s normalization step** explicitly filled in `version: 'v2'` when the field was absent.

**2. `serialize()`'s type-id selection** had the ternary condition inverted from what "default to v1" requires — anything other than the literal string `'v1'` (including `undefined`) fell through to v2.

### Why the doc was assumed to be right (turned out wrong)

The original reasoning: the v2-keychain feature isn't in any published `ox` tag, so there was assumed to be zero backward-compatibility risk in changing the runtime default to `'v1'` to match the doc. That assumption didn't account for the live Tempo network's own behavior, which the CI receipts above now correct for.