### PR TITLE
fix: reject non-canonical RLP length encodings

### DIFF
--- a/.changeset/fix-rlp-noncanonical-length.md
+++ b/.changeset/fix-rlp-noncanonical-length.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed the RLP decoder silently accepting non-canonical alternate encodings (a single byte < 0x80 wrapped in an unnecessary length prefix, or a length using more length-bytes than the minimal required form), which allowed distinct byte strings to decode to the same value. Non-canonical encodings now throw `Rlp.NonCanonicalError`.

--- a/src/core/Rlp.ts
+++ b/src/core/Rlp.ts
@@ -118,6 +118,14 @@ export function decodeRlpCursor<to extends 'Hex' | 'Bytes' = 'Hex'>(
   if (prefix < 0xc0) {
     const length = readLength(cursor, prefix, 0x80)
     const bytes = cursor.readBytes(length)
+    // A single byte below `0x80` must be its own encoding (no length
+    // prefix); wrapping it in an explicit one-byte-length prefix is a
+    // non-canonical alternate encoding of the same value (Yellow Paper,
+    // Appendix B).
+    if (prefix >= 0x80 && length === 1 && bytes[0]! < 0x80)
+      throw new NonCanonicalError({
+        reason: `single byte \`0x${bytes[0]!.toString(16).padStart(2, '0')}\` is wrapped in an explicit length prefix instead of being encoded as itself`,
+      })
     return (
       to === 'Hex' ? Hex.fromBytes(bytes) : bytes
     ) as decodeRlpCursor.ReturnType<to>
@@ -152,10 +160,42 @@ export function readLength(
 ) {
   if (offset === 0x80 && prefix < 0x80) return 1
   if (prefix <= offset + 55) return prefix - offset
-  if (prefix === offset + 55 + 1) return cursor.readUint8()
-  if (prefix === offset + 55 + 2) return cursor.readUint16()
-  if (prefix === offset + 55 + 3) return cursor.readUint24()
-  if (prefix === offset + 55 + 4) return cursor.readUint32()
+  // Long-form lengths must use the minimal number of length-bytes: a value
+  // that fits in fewer bytes (or in the short form, i.e. <= 55) encoded via
+  // a longer form is a non-canonical alternate encoding of the same value
+  // (Yellow Paper, Appendix B).
+  if (prefix === offset + 55 + 1) {
+    const length = cursor.readUint8()
+    if (length <= 55)
+      throw new NonCanonicalError({
+        reason: `length \`${length}\` fits in the short form and must not use a one-byte length prefix`,
+      })
+    return length
+  }
+  if (prefix === offset + 55 + 2) {
+    const length = cursor.readUint16()
+    if (length <= 0xff)
+      throw new NonCanonicalError({
+        reason: `length \`${length}\` fits in fewer length-bytes and must not use a two-byte length prefix`,
+      })
+    return length
+  }
+  if (prefix === offset + 55 + 3) {
+    const length = cursor.readUint24()
+    if (length <= 0xffff)
+      throw new NonCanonicalError({
+        reason: `length \`${length}\` fits in fewer length-bytes and must not use a three-byte length prefix`,
+      })
+    return length
+  }
+  if (prefix === offset + 55 + 4) {
+    const length = cursor.readUint32()
+    if (length <= 0xffffff)
+      throw new NonCanonicalError({
+        reason: `length \`${length}\` fits in fewer length-bytes and must not use a four-byte length prefix`,
+      })
+    return length
+  }
   throw new Errors.BaseError('Invalid RLP prefix')
 }
 
@@ -871,5 +911,14 @@ export class TrailingBytesError extends Errors.BaseError {
         count === 1 ? 'byte remains' : 'bytes remain'
       }.`,
     )
+  }
+}
+
+/** Thrown when an RLP payload uses a non-canonical alternate encoding of a value. */
+export class NonCanonicalError extends Errors.BaseError {
+  override readonly name = 'Rlp.NonCanonicalError'
+
+  constructor({ reason }: { reason: string }) {
+    super(`RLP payload is not canonically encoded: ${reason}.`)
   }
 }

--- a/src/core/_test/Rlp.test.ts
+++ b/src/core/_test/Rlp.test.ts
@@ -17,6 +17,7 @@ test('exports', () => {
       "DepthLimitExceededError",
       "ListBoundaryExceededError",
       "TrailingBytesError",
+      "NonCanonicalError",
     ]
   `)
 })
@@ -545,5 +546,55 @@ describe('list boundary', () => {
     expect(() => Rlp.toHex('0xc182aabbff')).toThrowErrorMatchingInlineSnapshot(
       `[Rlp.ListBoundaryExceededError: RLP list items consumed \`3\` bytes but the list declared a length of \`1\`.]`,
     )
+  })
+})
+
+describe('non-canonical encoding', () => {
+  // RLP is a bijection: every value has exactly one valid encoding (Yellow
+  // Paper, Appendix B). A decoder that accepts alternate encodings of the
+  // same value breaks that bijection and enables hash/identity malleability.
+  test('single byte < 0x80 wrapped in a length-1 prefix', () => {
+    expect(() => Rlp.toHex('0x8100')).toThrowErrorMatchingInlineSnapshot(
+      `[Rlp.NonCanonicalError: RLP payload is not canonically encoded: single byte \`0x00\` is wrapped in an explicit length prefix instead of being encoded as itself.]`,
+    )
+    expect(() => Rlp.toHex('0x817f')).toThrowErrorMatchingInlineSnapshot(
+      `[Rlp.NonCanonicalError: RLP payload is not canonically encoded: single byte \`0x7f\` is wrapped in an explicit length prefix instead of being encoded as itself.]`,
+    )
+  })
+
+  test('single byte >= 0x80 correctly requires a length-1 prefix', () => {
+    expect(Rlp.toHex('0x8180')).toEqual('0x80')
+    expect(Rlp.toHex('0x8185')).toEqual('0x85')
+  })
+
+  test('long-form length that fits the short form', () => {
+    // `0xb8` = long-form 1-byte-length string prefix; `0x00` declares length 0,
+    // which must instead be encoded directly as the short-form `0x80`.
+    expect(() => Rlp.toHex('0xb800')).toThrowErrorMatchingInlineSnapshot(
+      `[Rlp.NonCanonicalError: RLP payload is not canonically encoded: length \`0\` fits in the short form and must not use a one-byte length prefix.]`,
+    )
+    // declares length 1 (`0x41`), which fits the short form (`0x41` directly).
+    expect(() => Rlp.toHex('0xb80141')).toThrowErrorMatchingInlineSnapshot(
+      `[Rlp.NonCanonicalError: RLP payload is not canonically encoded: length \`1\` fits in the short form and must not use a one-byte length prefix.]`,
+    )
+    // list variant: `0xf8` = long-form 1-byte-length list prefix, length 2.
+    expect(() => Rlp.toHex('0xf8020102')).toThrowErrorMatchingInlineSnapshot(
+      `[Rlp.NonCanonicalError: RLP payload is not canonically encoded: length \`2\` fits in the short form and must not use a one-byte length prefix.]`,
+    )
+  })
+
+  test('long-form length with a leading zero length-byte', () => {
+    // `0xb9` = long-form 2-byte-length string prefix; `0x0001` (leading zero)
+    // declares length 1, which fits in a single length-byte.
+    expect(() => Rlp.toHex('0xb9000141')).toThrowErrorMatchingInlineSnapshot(
+      `[Rlp.NonCanonicalError: RLP payload is not canonically encoded: length \`1\` fits in fewer length-bytes and must not use a two-byte length prefix.]`,
+    )
+  })
+
+  test('long-form lengths at exact byte-count boundaries still decode', () => {
+    const bytes56 = `0x${'ab'.repeat(56)}` as const
+    expect(Rlp.toHex(Rlp.fromHex(bytes56))).toEqual(bytes56)
+    const bytes256 = `0x${'cd'.repeat(256)}` as const
+    expect(Rlp.toHex(Rlp.fromHex(bytes256))).toEqual(bytes256)
   })
 })

--- a/src/tempo/MultisigSimulation.test.ts
+++ b/src/tempo/MultisigSimulation.test.ts
@@ -163,7 +163,7 @@ describe('fromRpc', () => {
     expect(() =>
       MultisigSimulation.fromRpc({ ...rpc, config: noncanonical }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `[MultisigSimulation.InvalidSimulationError: Invalid multisig simulation: invalid config encoding.]`,
+      `[Rlp.NonCanonicalError: RLP payload is not canonically encoded: single byte \`0x00\` is wrapped in an explicit length prefix instead of being encoded as itself.]`,
     )
   })
 })


### PR DESCRIPTION
## What

RLP is defined as a bijection per the Yellow Paper (Appendix B): every value has exactly one canonical encoding. The decoder in `src/core/Rlp.ts` accepted non-canonical alternate encodings of the same value:

1. **A single byte < `0x80` wrapped in an explicit length-1 prefix** — e.g. `0x8100` decodes to the same value as the canonical `0x00`.
2. **A long-form length that fits the short form, or uses more length-bytes than the minimal required** — e.g. `0xb800` (long-form length-0 string, should be `0x80`), `0xb80141` (long-form length-1 wrapping `0x41`, should just be `0x41`), `0xb9000141` (2-byte long-form length with a leading zero byte, should use the 1-byte long form).

Accepting these means two different byte strings decode to the same value, and re-encoding a decoded non-canonical input produces different bytes than the original input — hash/identity malleability for anything that hashes or compares raw RLP bytes assuming a 1:1 mapping to decoded values (e.g. transaction hashing).

```
0x8100 -> decodes to 0x00 (canonical: 0x00, no prefix)
0x817f -> decodes to 0x7f (canonical: 0x7f, no prefix)
0xb800 -> decodes to 0x   (canonical: 0x80)
0xb9000141 -> decodes to 0x41 (canonical: 0x41)
0xf8020102 -> decodes to ["0x01","0x02"] (canonical: 0xc20102)
```

## Fix

Adds `Rlp.NonCanonicalError` and validates both cases in `readLength` / `decodeRlpCursor`.

## Testing

- New unit tests for all 6 non-canonical cases above, plus the 55/56 and 255/256 byte-count boundaries (valid long-form lengths must still decode).
- `npx vp test src/core/_test/Rlp.test.ts` — 37/37 pass.
- `bun test vectors/src/rlp.vectors.test.ts` — all 14,640 official RLP test vectors still pass (no false-positive rejections of valid encodings).
- Codex adversarial review (independent pass, re-verified the boundary thresholds and the false-positive/false-negative surface, ran the full vector suite itself) found no fault with the fix. It flagged one separate, pre-existing behavior unrelated to this diff: `Rlp.toHex('0x')` (a genuinely empty wire payload) decodes to the same empty value as the canonical `Rlp.toHex('0x80')`. That's a distinct question (is a zero-byte payload a valid RLP item at all?) from the alternate-encoding bug this PR fixes, and isn't touched here — happy to open a separate issue for it if useful.

closes nothing — filed independently, no corresponding issue was open (dupe-checked before starting).
