### PR TITLE
fix: reject non-canonical trailing bits in Base32.toBytes

### DIFF
--- a/.changeset/fix-base32-noncanonical-padding.md
+++ b/.changeset/fix-base32-noncanonical-padding.md
@@ -1,0 +1,5 @@
+---
+"ox": patch
+---
+
+Fixed `Base32.toBytes`/`toHex` silently accepting non-canonical trailing bits, which allowed distinct input strings to decode to the same value. Non-canonical padding now throws `Base32.InvalidPaddingError`.

--- a/src/core/Base32.ts
+++ b/src/core/Base32.ts
@@ -5,6 +5,7 @@ import {
   alphabet,
   alphabetMap,
   convertBits,
+  InvalidPaddingError as SharedInvalidPaddingError,
 } from './internal/codec/bech32-base32.js'
 
 /**
@@ -62,7 +63,7 @@ export declare namespace fromHex {
  * ```ts twoslash
  * import { Base32 } from 'ox'
  *
- * const value = Base32.toBytes('qqsa0')
+ * const value = Base32.toBytes('qrlsq')
  * ```
  *
  * @param value - The Base32 encoded string.
@@ -78,24 +79,24 @@ export function toBytes(value: string): Bytes.Bytes {
     values[i] = v
   }
 
-  let bits = 0
-  let acc = 0
-  // Worst-case: every 5 bits maps to up to 1 byte; preallocate.
-  const bytes = new Uint8Array((len * 5) >> 3)
-  let n = 0
-  for (let i = 0; i < len; i++) {
-    acc = (acc << 5) | values[i]!
-    bits += 5
-    if (bits >= 8) {
-      bits -= 8
-      bytes[n++] = (acc >>> bits) & 0xff
-    }
+  // `pad: false` enforces that leftover bits below a byte boundary are zero
+  // (canonical form); a non-zero remainder means the string re-encodes to a
+  // different Base32 string than it decoded from, so it is rejected here
+  // rather than silently accepted.
+  try {
+    return Uint8Array.from(convertBits(values, 5, 8, false))
+  } catch (error) {
+    if (error instanceof SharedInvalidPaddingError)
+      throw new InvalidPaddingError()
+    throw error
   }
-  return bytes.subarray(0, n)
 }
 
 export declare namespace toBytes {
-  type ErrorType = InvalidCharacterError | Errors.GlobalErrorType
+  type ErrorType =
+    | InvalidCharacterError
+    | InvalidPaddingError
+    | Errors.GlobalErrorType
 }
 
 /**
@@ -105,7 +106,7 @@ export declare namespace toBytes {
  * ```ts twoslash
  * import { Base32 } from 'ox'
  *
- * const value = Base32.toHex('qqsa0')
+ * const value = Base32.toHex('qrlsq')
  * ```
  *
  * @param value - The Base32 encoded string.

--- a/src/core/_test/Base32.test.ts
+++ b/src/core/_test/Base32.test.ts
@@ -44,6 +44,27 @@ describe('toBytes', () => {
       `[Base32.InvalidCharacterError: Invalid bech32 base32 character: "b".]`,
     )
   })
+
+  test('error: non-zero trailing bits', () => {
+    // `qrlsq` is the canonical encoding of [0x00, 0xff, 0x00]; flipping the
+    // final symbol only touches bits below the byte boundary. A canonical
+    // decoder must reject this rather than silently decode to the same
+    // bytes as `qrlsq` -- two distinct strings must not collide to one value.
+    const canonical = Base32.fromBytes(new Uint8Array([0x00, 0xff, 0x00]))
+    expect(canonical).toEqual('qrlsq')
+    expect(() => Base32.toBytes('qrlsp')).toThrowErrorMatchingInlineSnapshot(
+      `[Base32.InvalidPaddingError: Non-canonical trailing bits in Base32 input.]`,
+    )
+  })
+
+  test('accepts canonical zero-padded trailing bits', () => {
+    expect(Base32.toBytes('qq')).toEqual(new Uint8Array([0x00]))
+    for (let n = 1; n <= 8; n++) {
+      const bytes = new Uint8Array(n).map((_, i) => (i * 37 + 11) & 0xff)
+      const encoded = Base32.fromBytes(bytes)
+      expect(Base32.toBytes(encoded)).toEqual(bytes)
+    }
+  })
 })
 
 describe('toHex', () => {


### PR DESCRIPTION
## What

`Base32.toBytes` (`src/core/Base32.ts`) reimplemented the 5-bit-to-8-bit bit repacking by hand instead of reusing the shared `convertBits` helper, and never validated that the leftover bits below the final byte boundary were zero (canonical padding per BIP-173). Two distinct Base32 strings differing only in those trailing bits decoded to the identical byte value, and decoding then re-encoding a non-canonical string produced a different string than the input.

This is the exact class of bug BIP-173 canonical-padding validation exists to prevent — and this codebase's own `Bech32m.decode` already guards against it correctly, via the same `convertBits` helper with `pad: false`.

```
qrlsq -> decodes to [0x00, 0xff, 0x00]  (canonical encoding of that value)
qrlsp -> decodes to [0x00, 0xff, 0x00]  (same bytes, different string, pre-fix)
```

`Base32.InvalidPaddingError` was already declared in the file but never thrown anywhere.

## Fix

Routes `toBytes` through `convertBits(values, 5, 8, false)` — the same call shape `Bech32m.decode` already uses — so the canonical-padding check is shared with `Bech32m`'s, and throws the existing, previously-dead `InvalidPaddingError` class.

Also fixes two docstring examples that referenced `'qqsa0'`, which is itself non-canonical and now correctly throws under the fix — replaced with the genuinely canonical `'qrlsq'`.

## Testing

- New unit tests: non-canonical trailing-bit rejection, and a round-trip test across `fromBytes`/`toBytes` for 1-8 byte inputs (covering every possible leftover-bit alignment: 0/1/2/3/4 bits).
- `npx vp test src/core/_test/Base32.test.ts` — 10/10 pass.
- `npx tsc --noEmit` — clean.
- Codex adversarial review (independent pass) confirmed `convertBits(values, 5, 8, false)` is byte-identical to the old hand-rolled loop for every valid (canonical) input — exhaustively checked every sequence through 4 symbols (65,793 accepted cases, zero mismatches) plus round-trips through 256-byte inputs. No decoder correctness issues found. It also flagged that this repo uses changesets for public behavior changes — added one.

closes nothing — filed independently, no corresponding issue was open (dupe-checked before starting).
