### PR TITLE
fix: left-pad r/s in Signature.toHex

### DIFF
--- a/src/core/Signature.ts
+++ b/src/core/Signature.ts
@@ -704,8 +704,8 @@ export declare namespace fromRecoveredBytes {
 export function toHex(signature: Signature<boolean>): Hex.Hex {
   assert(signature)
 
-  const r = signature.r
-  const s = signature.s
+  const r = Hex.padLeft(signature.r, 32)
+  const s = Hex.padLeft(signature.s, 32)
 
   const signature_ = Hex.concat(
     r,
@@ -721,6 +721,8 @@ export function toHex(signature: Signature<boolean>): Hex.Hex {
 
 export declare namespace toHex {
   type ErrorType =
+    | assert.ErrorType
+    | Hex.padLeft.ErrorType
     | Hex.concat.ErrorType
     | Hex.fromNumber.ErrorType
     | Errors.GlobalErrorType

--- a/src/core/_test/Signature.test.ts
+++ b/src/core/_test/Signature.test.ts
@@ -488,6 +488,23 @@ describe('serialize', () => {
       `"0x6e100a352ec6ad1b70802290e18aeed190704973570f3b8ed42cb9808e2ea6bf4a90a229a244495b41890987806fcbd2d5d23fc0dbe5f5256c2613c039d76db8"`,
     )
   })
+
+  test('behavior: r/s shorter than 32 bytes are left-padded, not right-padded', () => {
+    const hex = Signature.toHex({
+      r: '0x01',
+      s: '0x02',
+      yParity: 0,
+    })
+    // `r` occupies the first 32 bytes and must be the big-endian integer `1`
+    // (left-padded), not `1` shifted into the top byte (right-padded).
+    expect(Hex.slice(hex, 0, 32)).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    )
+    expect(Hex.slice(hex, 32, 64)).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000002',
+    )
+    expect(Hex.size(hex)).toBe(65)
+  })
 })
 
 describe('toBytes', () => {


### PR DESCRIPTION
\`toHex\` concatenates \`r\`/\`s\` directly with \`Hex.concat\` without padding, unlike its sibling \`toCompactBytes\`/\`toRecoveredBytes\` (fixed in #435 for the exact same defect shape). \`Hex.concat\` does no length/byte-alignment validation — it's pure string concatenation — so a signature whose \`r\` or \`s\` is shorter than 32 bytes (leading zero byte stripped, which the \`Hex.Hex\` type permits and which a real signature has roughly a 1-in-256 chance of producing per component) silently serializes to a garbage, wrong-length byte string instead of the canonical 65-byte layout, rather than throwing or padding.

\`toBytes\` inherits the bug (and the fix) since it calls \`toHex\`.

```ts
import { Signature } from 'ox'

Signature.toHex({ r: '0x01', s: '0x02', yParity: 0 })
// before: '0x01021b'      (3 bytes — garbage)
// after:  '0x000...01' + '0x000...02' + '0x1b'  (65 bytes — correct)
```

\`assert()\` only range-checks \`r\`/\`s\` (0 <= value <= 2^256-1), it doesn't enforce a fixed byte length, so this is reachable through the fully public, documented \`toHex\`/\`toBytes\` API with any manually-constructed \`Signature\` object — no need to go through \`from()\` first.

Added a regression test mirroring the existing left-pad tests for \`toCompactBytes\`/\`toRecoveredBytes\`.

## testing

- Repro'd the pre-fix garbage output directly against \`main\` (\`0x01021b\`, 3 bytes) before applying the fix.
- \`vp test run src/core/_test/Signature.test.ts\` — 42/42 passing (incl. new test).
- \`tsc --noEmit\` clean.
- \`vp check --fix\` clean (pre-existing unrelated warnings only, in \`site/\`).