### PR TITLE
fix: reject out-of-bounds length fields in erc8021 Attribution.fromData

### DIFF
--- a/src/erc8021/Attribution.ts
+++ b/src/erc8021/Attribution.ts
@@ -354,6 +354,11 @@ function decodeCodesTail(
 
   const codesEnd = codesLengthStart
   const codesStart = codesEnd - codesLength
+  // `codesStart` is an offset counted back from the end of `data`. `Hex.slice`
+  // doesn't bounds-check a negative start, so a `codesLength` byte that lies
+  // about how much data precedes it would otherwise silently clamp to the
+  // start of `data` instead of being rejected.
+  if (Hex.size(data) + codesStart < 0) return undefined
   const codesHex = Hex.slice(data, codesStart, codesEnd)
   const codesString = Hex.toString(codesHex)
   const codes = codesString.length > 0 ? codesString.split(',') : []
@@ -472,16 +477,18 @@ function schema2ToDataSuffix(attribution: AttributionSchemaId2): Hex.Hex {
 
 function schema2FromData(data: Hex.Hex): AttributionSchemaId2 | undefined {
   // cborLength is 2 bytes before schema ID
-  const cborLengthHex = Hex.slice(
-    data,
-    -ercSuffixSize - 1 - 2,
-    -ercSuffixSize - 1,
-  )
+  const cborLengthStart = -ercSuffixSize - 1 - 2
+  const cborLengthEnd = -ercSuffixSize - 1
+  if (Hex.size(data) + cborLengthStart < 0) return undefined
+  const cborLengthHex = Hex.slice(data, cborLengthStart, cborLengthEnd)
   const cborLength = Hex.toNumber(cborLengthHex)
 
-  // Extract CBOR data
-  const cborStart = -ercSuffixSize - 1 - 2 - cborLength
-  const cborEnd = -ercSuffixSize - 1 - 2
+  // Extract CBOR data. As with `decodeCodesTail`, `cborStart` must be
+  // bounds-checked since `Hex.slice` doesn't reject a negative start that
+  // runs past the beginning of `data`.
+  const cborStart = cborLengthStart - cborLength
+  if (Hex.size(data) + cborStart < 0) return undefined
+  const cborEnd = cborLengthStart
   const cborHex = Hex.slice(data, cborStart, cborEnd)
 
   // Decode CBOR

--- a/src/erc8021/_test/Attribution.test.ts
+++ b/src/erc8021/_test/Attribution.test.ts
@@ -442,6 +442,30 @@ describe('fromData', () => {
 
       expect(result).toBeUndefined()
     })
+
+    test('codesLength claims more bytes than are available', () => {
+      // codesLength (0xff = 255) + schemaId (0x00) + ERC suffix, with no
+      // actual codes data preceding the length byte. Old code silently
+      // clamped the out-of-bounds slice to an empty read and returned
+      // `{ codes: [], id: 0 }` instead of rejecting the malformed input.
+      const input = '0xff0080218021802180218021802180218021'
+
+      const result = Attribution.fromData(input)
+
+      expect(result).toBeUndefined()
+    })
+
+    test('codesLength overruns into unrelated leading bytes', () => {
+      // codesLength (0x0a = 10) claims 10 bytes of codes, but only 4 bytes
+      // (`deadbeef`) precede it. Old code silently truncated the read to
+      // those 4 unrelated bytes and returned a bogus decoded "code" instead
+      // of rejecting the malformed input.
+      const input = '0xdeadbeef0a0080218021802180218021802180218021'
+
+      const result = Attribution.fromData(input)
+
+      expect(result).toBeUndefined()
+    })
   })
 })
 
@@ -768,5 +792,19 @@ describe('schema 2 (CBOR-encoded)', () => {
         expect(parsed).toEqual(attribution)
       },
     )
+
+    test('cborLength claims more bytes than are available (returns undefined, does not throw)', () => {
+      // schemaId (0x02) + ERC suffix, with no room for a 2-byte cborLength
+      // field before it (total size is the schema-0/1 minimum of 18 bytes,
+      // one short of what schema 2 needs). Old code let the out-of-bounds
+      // slice clamp silently, mis-read the length field, and then threw an
+      // uncaught cursor error out of `Cbor.decode` instead of gracefully
+      // returning `undefined` for malformed input.
+      const input = '0x000280218021802180218021802180218021'
+
+      const result = Attribution.fromData(input)
+
+      expect(result).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
`Attribution.fromData` decodes wire-controlled length bytes (a 1-byte codes length for schema 0/1, a 2-byte CBOR length for schema 2) and slices backwards from them with a negative start offset. `Hex.slice` doesn't bounds-check a negative start (only positive-start overruns are checked), so a length field that lies about how much data actually precedes it silently clamps instead of failing.

Concretely, for schema 0/1 (`decodeCodesTail`):
- `codesLength` larger than the available prefix returns a wrong-but-plausible parsed result, e.g. `{ codes: [], id: 0 }`, for input that should be rejected as malformed.
- A `codesLength` that overruns into unrelated leading bytes silently ingests them as a bogus attribution code instead of failing.

For schema 2 (`schema2FromData`), the same shape currently surfaces as an *uncaught* cursor error thrown out of `Cbor.decode`, rather than the documented `undefined` return for invalid input.

`registryFromData` in the same file already guards this exact shape with an explicit `Hex.size(data) < totalRegistrySize` check — `decodeCodesTail` and `schema2FromData` were missing the equivalent bound check. This PR adds it to both, mirroring the existing pattern, so all three parsers agree on rejecting malformed/truncated attribution data instead of two of them silently mis-parsing or crashing.

## repro (before the fix)

```
malformed1 (codesLength=0xff, no codes data at all) -> {"codes":[],"id":0}
malformed2 (codesLength=0x0a overrunning into "deadbeef" prefix) -> {"codes":["ޭ��"],"id":0}
malformed3 (schema 2, structure one byte short of the minimum) -> throws "Position `0` is out of bounds"
```

After the fix, all three return `undefined` as documented.

Added regression tests covering all three cases (`src/erc8021/_test/Attribution.test.ts`); full existing suite for the module still passes (63/63).