### PR TITLE
fix: AbiFunction.decodeData drops args when a name overload has zero inputs

### DIFF
--- a/src/core/AbiFunction.ts
+++ b/src/core/AbiFunction.ts
@@ -199,12 +199,12 @@ export function decodeData(
   const { overloads } = abiFunction
 
   if (Hex.size(data) < 4) throw new AbiItem.InvalidSelectorSizeError({ data })
-  if (abiFunction.inputs?.length === 0) return undefined
 
   const item = overloads
     ? fromAbi([abiFunction, ...overloads], data as never)
     : abiFunction
 
+  if (item.inputs.length === 0) return undefined
   if (item.inputs.length > 0 && Hex.size(data) <= 4)
     throw new AbiParameters.DataSizeTooSmallError({
       data,

--- a/src/core/AbiItem.ts
+++ b/src/core/AbiItem.ts
@@ -314,14 +314,19 @@ export function fromAbi<
     } as never
 
   let matchedAbiItem: AbiItem | undefined
+  // Tracked separately from `matchedAbiItem`: when `args` isn't supplied, the
+  // first zero-input overload is a provisional pick, not a final resolution
+  // (e.g. `AbiFunction.decodeData` still needs the other overloads to
+  // disambiguate by selector). Returning early here would drop them.
+  let zeroArgAbiItem: AbiItem | undefined
   for (const abiItem of abiItems) {
     if (!('inputs' in abiItem)) continue
     if (!args || args.length === 0) {
-      if (!abiItem.inputs || abiItem.inputs.length === 0)
-        return {
-          ...abiItem,
-          ...(prepare ? { hash: getSignatureHash(abiItem) } : {}),
-        } as never
+      if (
+        !zeroArgAbiItem &&
+        (!abiItem.inputs || abiItem.inputs.length === 0)
+      )
+        zeroArgAbiItem = abiItem
       continue
     }
     if (!abiItem.inputs) continue
@@ -363,8 +368,9 @@ export function fromAbi<
 
   const abiItem = (() => {
     if (matchedAbiItem) return matchedAbiItem
-    const [abiItem, ...overloads] = abiItems
-    return { ...abiItem!, overloads }
+    const chosen = zeroArgAbiItem ?? abiItems[0]
+    const overloads = abiItems.filter((item) => item !== chosen)
+    return { ...chosen!, overloads }
   })()
 
   if (!abiItem) throw new NotFoundError({ name: name as string })

--- a/src/core/AbiItem.ts
+++ b/src/core/AbiItem.ts
@@ -322,10 +322,7 @@ export function fromAbi<
   for (const abiItem of abiItems) {
     if (!('inputs' in abiItem)) continue
     if (!args || args.length === 0) {
-      if (
-        !zeroArgAbiItem &&
-        (!abiItem.inputs || abiItem.inputs.length === 0)
-      )
+      if (!zeroArgAbiItem && (!abiItem.inputs || abiItem.inputs.length === 0))
         zeroArgAbiItem = abiItem
       continue
     }

--- a/src/core/_test/AbiError.test.ts
+++ b/src/core/_test/AbiError.test.ts
@@ -828,6 +828,17 @@ describe('fromAbi', () => {
       "hash": "0xbfb4ebcfff8f360b39de1de85df1edc256d63337b743120bf6e2e2144b973d38",
       "inputs": [],
       "name": "Foo",
+      "overloads": [
+        {
+          "inputs": [
+            {
+              "type": "uint256",
+            },
+          ],
+          "name": "Foo",
+          "type": "error",
+        },
+      ],
       "type": "error",
     }
   `)
@@ -841,6 +852,17 @@ describe('fromAbi', () => {
       "hash": "0xbfb4ebcfff8f360b39de1de85df1edc256d63337b743120bf6e2e2144b973d38",
       "inputs": [],
       "name": "Foo",
+      "overloads": [
+        {
+          "inputs": [
+            {
+              "type": "uint256",
+            },
+          ],
+          "name": "Foo",
+          "type": "error",
+        },
+      ],
       "type": "error",
     }
   `)
@@ -858,6 +880,26 @@ describe('fromAbi', () => {
       "hash": "0x34c73884fbbb790762253ae313e57da96c00670344647f0cb8d41ee92b9f1971",
       "inputs": [],
       "name": "Mint",
+      "overloads": [
+        {
+          "inputs": [
+            {
+              "type": "uint256",
+            },
+          ],
+          "name": "Mint",
+          "type": "error",
+        },
+        {
+          "inputs": [
+            {
+              "type": "string",
+            },
+          ],
+          "name": "Mint",
+          "type": "error",
+        },
+      ],
       "type": "error",
     }
   `)

--- a/src/core/_test/AbiEvent.test.ts
+++ b/src/core/_test/AbiEvent.test.ts
@@ -1743,6 +1743,17 @@ describe('fromAbi', () => {
       "hash": "0xbfb4ebcfff8f360b39de1de85df1edc256d63337b743120bf6e2e2144b973d38",
       "inputs": [],
       "name": "Foo",
+      "overloads": [
+        {
+          "inputs": [
+            {
+              "type": "uint256",
+            },
+          ],
+          "name": "Foo",
+          "type": "event",
+        },
+      ],
       "type": "event",
     }
   `)
@@ -1756,6 +1767,17 @@ describe('fromAbi', () => {
       "hash": "0xbfb4ebcfff8f360b39de1de85df1edc256d63337b743120bf6e2e2144b973d38",
       "inputs": [],
       "name": "Foo",
+      "overloads": [
+        {
+          "inputs": [
+            {
+              "type": "uint256",
+            },
+          ],
+          "name": "Foo",
+          "type": "event",
+        },
+      ],
       "type": "event",
     }
   `)
@@ -1773,6 +1795,26 @@ describe('fromAbi', () => {
       "hash": "0x34c73884fbbb790762253ae313e57da96c00670344647f0cb8d41ee92b9f1971",
       "inputs": [],
       "name": "Mint",
+      "overloads": [
+        {
+          "inputs": [
+            {
+              "type": "uint256",
+            },
+          ],
+          "name": "Mint",
+          "type": "event",
+        },
+        {
+          "inputs": [
+            {
+              "type": "string",
+            },
+          ],
+          "name": "Mint",
+          "type": "event",
+        },
+      ],
       "type": "event",
     }
   `)

--- a/src/core/_test/AbiFunction.test.ts
+++ b/src/core/_test/AbiFunction.test.ts
@@ -114,16 +114,14 @@ describe('decodeData', () => {
     const dataWithArgs = AbiFunction.encodeData(withArgs, [123n])
     // Resolving by name alone (no args) must still disambiguate the
     // zero-input overload from the one actually encoded in `data`.
-    expect(AbiFunction.decodeData(abi, 'deposit', dataWithArgs)).toEqual([
-      123n,
-    ])
+    expect(AbiFunction.decodeData(abi, 'deposit', dataWithArgs)).toEqual([123n])
     expect(AbiFunction.decodeData(abi, dataWithArgs)).toEqual([123n])
 
     const withoutArgs = AbiFunction.fromAbi(abi, 'deposit', { args: [] })
     const dataWithoutArgs = AbiFunction.encodeData(withoutArgs)
-    expect(
-      AbiFunction.decodeData(abi, 'deposit', dataWithoutArgs),
-    ).toEqual(undefined)
+    expect(AbiFunction.decodeData(abi, 'deposit', dataWithoutArgs)).toEqual(
+      undefined,
+    )
     expect(AbiFunction.decodeData(abi, dataWithoutArgs)).toEqual(undefined)
   })
 })

--- a/src/core/_test/AbiFunction.test.ts
+++ b/src/core/_test/AbiFunction.test.ts
@@ -91,6 +91,41 @@ describe('decodeData', () => {
       ),
     ).toEqual(['0xdeadbeef'])
   })
+
+  test('behavior: with overloads, resolved by name (one overload has zero inputs)', () => {
+    const abi = Abi.from([
+      {
+        inputs: [],
+        name: 'deposit',
+        outputs: [],
+        stateMutability: 'payable',
+        type: 'function',
+      },
+      {
+        inputs: [{ name: 'assets', type: 'uint256' }],
+        name: 'deposit',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ])
+
+    const withArgs = AbiFunction.fromAbi(abi, 'deposit', { args: [123n] })
+    const dataWithArgs = AbiFunction.encodeData(withArgs, [123n])
+    // Resolving by name alone (no args) must still disambiguate the
+    // zero-input overload from the one actually encoded in `data`.
+    expect(AbiFunction.decodeData(abi, 'deposit', dataWithArgs)).toEqual([
+      123n,
+    ])
+    expect(AbiFunction.decodeData(abi, dataWithArgs)).toEqual([123n])
+
+    const withoutArgs = AbiFunction.fromAbi(abi, 'deposit', { args: [] })
+    const dataWithoutArgs = AbiFunction.encodeData(withoutArgs)
+    expect(
+      AbiFunction.decodeData(abi, 'deposit', dataWithoutArgs),
+    ).toEqual(undefined)
+    expect(AbiFunction.decodeData(abi, dataWithoutArgs)).toEqual(undefined)
+  })
 })
 
 describe('decodeResult', () => {
@@ -838,6 +873,30 @@ describe('fromAbi', () => {
       "inputs": [],
       "name": "mint",
       "outputs": [],
+      "overloads": [
+        {
+          "inputs": [
+            {
+              "type": "uint256",
+            },
+          ],
+          "name": "mint",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+        },
+        {
+          "inputs": [
+            {
+              "type": "string",
+            },
+          ],
+          "name": "mint",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function",
+        },
+      ],
       "stateMutability": "nonpayable",
       "type": "function",
     }

--- a/src/core/_test/AbiItem.test.ts
+++ b/src/core/_test/AbiItem.test.ts
@@ -398,6 +398,19 @@ describe('fromAbi', () => {
         "inputs": [],
         "name": "foo",
         "outputs": [],
+        "overloads": [
+          {
+            "inputs": [
+              {
+                "type": "uint256",
+              },
+            ],
+            "name": "foo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function",
+          },
+        ],
         "stateMutability": "nonpayable",
         "type": "function",
       }
@@ -417,6 +430,19 @@ describe('fromAbi', () => {
         "inputs": [],
         "name": "foo",
         "outputs": [],
+        "overloads": [
+          {
+            "inputs": [
+              {
+                "type": "uint256",
+              },
+            ],
+            "name": "foo",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function",
+          },
+        ],
         "stateMutability": "nonpayable",
         "type": "function",
       }
@@ -524,6 +550,30 @@ describe('fromAbi', () => {
         "inputs": [],
         "name": "mint",
         "outputs": [],
+        "overloads": [
+          {
+            "inputs": [
+              {
+                "type": "uint256",
+              },
+            ],
+            "name": "mint",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function",
+          },
+          {
+            "inputs": [
+              {
+                "type": "string",
+              },
+            ],
+            "name": "mint",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function",
+          },
+        ],
         "stateMutability": "nonpayable",
         "type": "function",
       }


### PR DESCRIPTION
`AbiFunction.decodeData(abi, name, data)` resolves `name` through `AbiItem.fromAbi` *before* it knows the real 4-byte selector in `data`. When one overload of `name` takes zero inputs, `fromAbi` picked that overload eagerly (without `args`) and returned immediately, without ever attaching the other overloads. Back in `decodeData`, the zero-input check ran on that stale pick *before* the selector-based overload resolution had a chance to run — so if `data` was actually calldata for a different, non-zero-input overload of the same name, `decodeData` silently returned `undefined` instead of the real decoded arguments.

Repro (any ABI that combines a zero-arg overload with a real one under the same name, e.g. a WETH-style `deposit()` + `deposit(uint256)`):

```ts
const abi = [
  { type: 'function', name: 'deposit', inputs: [], outputs: [], stateMutability: 'payable' },
  { type: 'function', name: 'deposit', inputs: [{ name: 'assets', type: 'uint256' }], outputs: [], stateMutability: 'nonpayable' },
]

const data = AbiFunction.encodeData(AbiFunction.from(abi[1]), [123n])

AbiFunction.decodeData(abi, 'deposit', data) // => undefined (wrong, should be [123n])
AbiFunction.decodeData(abi, data)            // => [123n]    (selector-only path was unaffected)
```

## Fix

- `AbiItem.fromAbi`: the args-less multi-overload loop no longer eager-returns on the first zero-input match. It now tracks it as a provisional pick and still attaches the other overloads via `.overloads`, exactly like the existing "no zero-input match" fallback already does.
- `AbiFunction.decodeData`: the zero-input short-circuit now runs *after* `item` is resolved through the overload/selector match, instead of on the un-resolved `abiFunction`.

A true zero-arg call (no other overload matches the selector) still correctly decodes to `undefined`; args-based disambiguation (`fromAbi(abi, name, { args })`) is untouched.

## Test plan

- Added a regression test in `AbiFunction.test.ts` reproducing the exact scenario above.
- Updated 6 pre-existing inline snapshots (`AbiItem.test.ts`, `AbiFunction.test.ts`, `AbiEvent.test.ts`, `AbiError.test.ts`) that pinned the old shape (no `.overloads` field when a zero-input overload won) — they now show the correctly-populated `overloads` array.
- `npx tsc --noEmit` clean.
- Ran `AbiFunction.test.ts`, `AbiItem.test.ts`, `AbiError.test.ts`, `AbiEvent.test.ts` (plus the rest of the `core` project) via `vp test run` — 0 failures in any Abi-related file; the only failures present (`RpcRequest`/`RpcResponse`/`TransactionEnvelope` network tests) are pre-existing and unrelated to this diff (confirmed via `git diff main -- <those files>` showing zero changes).